### PR TITLE
Generic DbContextResolver

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -9,34 +9,52 @@ function Get-Version-Suffix-From-Tag
   return $final
 }
 
+function CheckLastExitCode {
+    param ([int[]]$SuccessCodes = @(0), [scriptblock]$CleanupScript=$null)
+
+    if ($SuccessCodes -notcontains $LastExitCode) {
+        $msg = "EXE RETURNED EXIT CODE $LastExitCode"
+        throw $msg
+    }
+}
+
 $revision = @{ $true = $env:APPVEYOR_BUILD_NUMBER; $false = 1 }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
 $revision = "{0:D4}" -f [convert]::ToInt32($revision, 10)
 
 dotnet restore
 
 dotnet test ./test/UnitTests/UnitTests.csproj
+CheckLastExitCode
+
 dotnet test ./test/JsonApiDotNetCoreExampleTests/JsonApiDotNetCoreExampleTests.csproj
+CheckLastExitCode
+
 dotnet test ./test/NoEntityFrameworkTests/NoEntityFrameworkTests.csproj
+CheckLastExitCode
 
 dotnet build .\src\JsonApiDotNetCore -c Release
+CheckLastExitCode
 
-echo "APPVEYOR_REPO_TAG: $env:APPVEYOR_REPO_TAG"
+Write-Output "APPVEYOR_REPO_TAG: $env:APPVEYOR_REPO_TAG"
 
 If($env:APPVEYOR_REPO_TAG -eq $true) {
     $revision = Get-Version-Suffix-From-Tag
-    echo "VERSION-SUFFIX: $revision"
+    Write-Output "VERSION-SUFFIX: $revision"
 
     IF ([string]::IsNullOrWhitespace($revision)){
-        echo "RUNNING dotnet pack .\src\JsonApiDotNetCore -c Release -o .\artifacts"
+        Write-Output "RUNNING dotnet pack .\src\JsonApiDotNetCore -c Release -o .\artifacts"
         dotnet pack .\src\JsonApiDotNetCore -c Release -o .\artifacts
+        CheckLastExitCode
     }
     Else {
-        echo "RUNNING dotnet pack .\src\JsonApiDotNetCore -c Release -o .\artifacts --version-suffix=$revision"
+        Write-Output "RUNNING dotnet pack .\src\JsonApiDotNetCore -c Release -o .\artifacts --version-suffix=$revision"
         dotnet pack .\src\JsonApiDotNetCore -c Release -o .\artifacts --version-suffix=$revision 
+        CheckLastExitCode
     }
 }
 Else { 
-    echo "VERSION-SUFFIX: alpha1-$revision"
-    echo "RUNNING dotnet pack .\src\JsonApiDotNetCore -c Release -o .\artifacts --version-suffix=alpha1-$revision"
+    Write-Output "VERSION-SUFFIX: alpha1-$revision"
+    Write-Output "RUNNING dotnet pack .\src\JsonApiDotNetCore -c Release -o .\artifacts --version-suffix=alpha1-$revision"
     dotnet pack .\src\JsonApiDotNetCore -c Release -o .\artifacts --version-suffix=alpha1-$revision 
+    CheckLastExitCode
 }

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <MoqVersion>4.7.10</MoqVersion>
-    <xUnitVersion>2.2.0</xUnitVersion>
+    <xUnitVersion>2.3.1</xUnitVersion>
     <BogusVersion>8.0.1-beta-1</BogusVersion>
   </PropertyGroup>
 </Project>

--- a/src/JsonApiDotNetCore/Data/DbContextResolver.cs
+++ b/src/JsonApiDotNetCore/Data/DbContextResolver.cs
@@ -1,14 +1,14 @@
-using System;
 using JsonApiDotNetCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 
 namespace JsonApiDotNetCore.Data
 {
-    public class DbContextResolver : IDbContextResolver
+    public class DbContextResolver<TContext>  : IDbContextResolver
+        where TContext : DbContext
     {
-        private readonly DbContext _context;
+        private readonly TContext _context;
 
-        public DbContextResolver(DbContext context)
+        public DbContextResolver(TContext context)
         {
             _context = context;
         }

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -20,8 +20,9 @@ namespace JsonApiDotNetCore.Data
     {
         public DefaultEntityRepository(
             ILoggerFactory loggerFactory,
-            IJsonApiContext jsonApiContext)
-        : base(loggerFactory, jsonApiContext)
+            IJsonApiContext jsonApiContext,
+            IDbContextResolver contextResolver)
+        : base(loggerFactory, jsonApiContext, contextResolver)
         { }
     }
 
@@ -50,9 +51,9 @@ namespace JsonApiDotNetCore.Data
 
         public DefaultEntityRepository(
             ILoggerFactory loggerFactory,
-            IJsonApiContext jsonApiContext)
+            IJsonApiContext jsonApiContext,
+            IDbContextResolver contextResolver)
         {
-            var contextResolver = jsonApiContext.GetDbContextResolver();
             _context = contextResolver.GetContext();
             _dbSet = contextResolver.GetDbSet<TEntity>();
             _jsonApiContext = jsonApiContext;

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -36,19 +36,6 @@ namespace JsonApiDotNetCore.Data
         private readonly IJsonApiContext _jsonApiContext;
         private readonly IGenericProcessorFactory _genericProcessorFactory;
 
-        [Obsolete("DbContext is no longer directly injected into the ctor. Use JsonApiContext.GetDbContextResolver() instead")]
-        public DefaultEntityRepository(
-            DbContext context,
-            ILoggerFactory loggerFactory,
-            IJsonApiContext jsonApiContext)
-        {
-            _context = context;
-            _dbSet = context.GetDbSet<TEntity>();
-            _jsonApiContext = jsonApiContext;
-            _logger = loggerFactory.CreateLogger<DefaultEntityRepository<TEntity, TId>>();
-            _genericProcessorFactory = _jsonApiContext.GenericProcessorFactory;
-        }
-
         public DefaultEntityRepository(
             ILoggerFactory loggerFactory,
             IJsonApiContext jsonApiContext,

--- a/src/JsonApiDotNetCore/Extensions/IServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IServiceCollectionExtensions.cs
@@ -77,7 +77,8 @@ namespace JsonApiDotNetCore.Extensions
             if (jsonApiOptions.ContextGraph == null)
                 jsonApiOptions.BuildContextGraph<TContext>(null);
 
-            services.AddScoped(typeof(DbContext), typeof(TContext));
+            services.AddScoped<IDbContextResolver, DbContextResolver<TContext>>();
+
             AddJsonApiInternals(services, jsonApiOptions);
         }
 
@@ -91,7 +92,6 @@ namespace JsonApiDotNetCore.Extensions
                 services.AddSingleton<DbContextOptions>(new DbContextOptionsBuilder().Options);
             }
 
-            services.AddScoped<IDbContextResolver, DbContextResolver>();
             services.AddScoped(typeof(IEntityRepository<>), typeof(DefaultEntityRepository<>));
             services.AddScoped(typeof(IEntityRepository<,>), typeof(DefaultEntityRepository<,>));
             services.AddScoped(typeof(IResourceService<>), typeof(EntityResourceService<>));

--- a/src/JsonApiDotNetCore/Internal/Generics/GenericProcessor.cs
+++ b/src/JsonApiDotNetCore/Internal/Generics/GenericProcessor.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using JsonApiDotNetCore.Data;
 using JsonApiDotNetCore.Extensions;
 using JsonApiDotNetCore.Models;
 using Microsoft.EntityFrameworkCore;
@@ -10,9 +11,9 @@ namespace JsonApiDotNetCore.Internal.Generics
     public class GenericProcessor<T> : IGenericProcessor where T : class, IIdentifiable
     {
         private readonly DbContext _context;
-        public GenericProcessor(DbContext context)
+        public GenericProcessor(IDbContextResolver contextResolver)
         {
-            _context = context;
+            _context = contextResolver.GetContext();
         }
 
         public async Task UpdateRelationshipsAsync(object parent, RelationshipAttribute relationship, IEnumerable<string> relationshipIds)

--- a/src/JsonApiDotNetCore/Internal/Generics/GenericProcessorFactory.cs
+++ b/src/JsonApiDotNetCore/Internal/Generics/GenericProcessorFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using JsonApiDotNetCore.Data;
 using Microsoft.EntityFrameworkCore;
 
 namespace JsonApiDotNetCore.Internal.Generics
@@ -8,10 +9,11 @@ namespace JsonApiDotNetCore.Internal.Generics
         private readonly DbContext _dbContext;
         private readonly IServiceProvider _serviceProvider;
 
-        public GenericProcessorFactory(DbContext dbContext, 
+        public GenericProcessorFactory(
+            IDbContextResolver dbContextResolver, 
             IServiceProvider serviceProvider)
         {
-            _dbContext = dbContext;
+            _dbContext = dbContextResolver.GetContext();
             _serviceProvider = serviceProvider;
         }
 

--- a/src/JsonApiDotNetCore/Internal/Generics/GenericProcessorFactory.cs
+++ b/src/JsonApiDotNetCore/Internal/Generics/GenericProcessorFactory.cs
@@ -1,19 +1,13 @@
 using System;
-using JsonApiDotNetCore.Data;
-using Microsoft.EntityFrameworkCore;
 
 namespace JsonApiDotNetCore.Internal.Generics
 {
     public class GenericProcessorFactory : IGenericProcessorFactory
     {
-        private readonly DbContext _dbContext;
         private readonly IServiceProvider _serviceProvider;
 
-        public GenericProcessorFactory(
-            IDbContextResolver dbContextResolver, 
-            IServiceProvider serviceProvider)
+        public GenericProcessorFactory(IServiceProvider serviceProvider)
         {
-            _dbContext = dbContextResolver.GetContext();
             _serviceProvider = serviceProvider;
         }
 

--- a/src/JsonApiDotNetCore/Services/IJsonApiContext.cs
+++ b/src/JsonApiDotNetCore/Services/IJsonApiContext.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using JsonApiDotNetCore.Builders;
 using JsonApiDotNetCore.Configuration;
-using JsonApiDotNetCore.Data;
 using JsonApiDotNetCore.Internal;
 using JsonApiDotNetCore.Internal.Generics;
 using JsonApiDotNetCore.Internal.Query;
@@ -29,6 +27,5 @@ namespace JsonApiDotNetCore.Services
         Dictionary<RelationshipAttribute, object> RelationshipsToUpdate { get; set; }
         Type ControllerType { get; set; }
         TAttribute GetControllerAttribute<TAttribute>() where TAttribute : Attribute;
-        IDbContextResolver GetDbContextResolver();
     }
 }

--- a/src/JsonApiDotNetCore/Services/JsonApiContext.cs
+++ b/src/JsonApiDotNetCore/Services/JsonApiContext.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using JsonApiDotNetCore.Builders;
 using JsonApiDotNetCore.Configuration;
-using JsonApiDotNetCore.Data;
 using JsonApiDotNetCore.Internal;
 using JsonApiDotNetCore.Internal.Generics;
 using JsonApiDotNetCore.Internal.Query;
@@ -15,12 +14,10 @@ namespace JsonApiDotNetCore.Services
     public class JsonApiContext : IJsonApiContext
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly IDbContextResolver _contextResolver;
         private readonly IQueryParser _queryParser;
         private readonly IControllerContext _controllerContext;
 
         public JsonApiContext(
-            IDbContextResolver contextResolver,
             IContextGraph contextGraph,
             IHttpContextAccessor httpContextAccessor,
             JsonApiOptions options,
@@ -29,7 +26,6 @@ namespace JsonApiDotNetCore.Services
             IQueryParser queryParser,
             IControllerContext controllerContext)
         {
-            _contextResolver = contextResolver;
             ContextGraph = contextGraph;
             _httpContextAccessor = httpContextAccessor;
             Options = options;
@@ -80,8 +76,6 @@ namespace JsonApiDotNetCore.Services
             IsRelationshipPath = path[path.Length - 2] == "relationships";
             return this;
         }
-
-        public IDbContextResolver GetDbContextResolver() => _contextResolver;
 
         private PageManager GetPageManager()
         {

--- a/test/JsonApiDotNetCoreExampleTests/Helpers/Repositories/AuthorizedTodoItemsRepository.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Helpers/Repositories/AuthorizedTodoItemsRepository.cs
@@ -16,8 +16,9 @@ namespace JsonApiDotNetCoreExampleTests.Repositories
         public AuthorizedTodoItemsRepository(
             ILoggerFactory loggerFactory,
             IJsonApiContext jsonApiContext,
+            IDbContextResolver contextResolver,
             IAuthorizationService authService)
-        : base(loggerFactory, jsonApiContext)
+        : base(loggerFactory, jsonApiContext, contextResolver)
         {
             _logger = loggerFactory.CreateLogger<AuthorizedTodoItemsRepository>();
             _authService = authService;

--- a/test/JsonApiDotNetCoreExampleTests/JsonApiDotNetCoreExampleTests.csproj
+++ b/test/JsonApiDotNetCoreExampleTests/JsonApiDotNetCoreExampleTests.csproj
@@ -30,5 +30,9 @@
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>
-
+  
+  <ItemGroup>
+    <DotNetCliToolReference Include="dotnet-xunit" Version="$(XUnitVersion)" />
+    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="1.0.0" />
+  </ItemGroup>
 </Project>

--- a/test/JsonApiDotNetCoreExampleTests/Unit/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Unit/Extensions/IServiceCollectionExtensionsTests.cs
@@ -1,19 +1,19 @@
-using Xunit;
 using JsonApiDotNetCore.Builders;
-using Microsoft.Extensions.DependencyInjection;
-using JsonApiDotNetCore.Extensions;
 using JsonApiDotNetCore.Configuration;
-using Microsoft.EntityFrameworkCore;
 using JsonApiDotNetCore.Data;
+using JsonApiDotNetCore.Extensions;
+using JsonApiDotNetCore.Formatters;
 using JsonApiDotNetCore.Internal;
-using Microsoft.AspNetCore.Http;
+using JsonApiDotNetCore.Internal.Generics;
+using JsonApiDotNetCore.Serialization;
 using JsonApiDotNetCore.Services;
 using JsonApiDotNetCoreExample.Data;
-using Microsoft.Extensions.Caching.Memory;
 using JsonApiDotNetCoreExample.Models;
-using JsonApiDotNetCore.Serialization;
-using JsonApiDotNetCore.Formatters;
-using JsonApiDotNetCore.Internal.Generics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
 
 namespace JsonApiDotNetCoreExampleTests.Unit.Extensions
 {
@@ -36,7 +36,7 @@ namespace JsonApiDotNetCoreExampleTests.Unit.Extensions
             var provider = services.BuildServiceProvider();
 
             // assert
-            Assert.NotNull(provider.GetService<DbContext>());
+            Assert.NotNull(provider.GetService<IDbContextResolver>());
             Assert.NotNull(provider.GetService(typeof(IEntityRepository<TodoItem>)));
             Assert.NotNull(provider.GetService<JsonApiOptions>());
             Assert.NotNull(provider.GetService<IContextGraph>());

--- a/test/UnitTests/Data/DefaultEntityRepository_Tests.cs
+++ b/test/UnitTests/Data/DefaultEntityRepository_Tests.cs
@@ -89,13 +89,10 @@ namespace UnitTests.Data
                 .Setup(m => m.RelationshipsToUpdate)
                 .Returns(_relationshipsToUpdate);
 
-            _jsonApiContextMock
-                .Setup(m => m.GetDbContextResolver())
-                .Returns(_contextResolverMock.Object);
-
             return new DefaultEntityRepository<TodoItem>(
                 _loggFactoryMock.Object,
-                _jsonApiContextMock.Object);
+                _jsonApiContextMock.Object,
+                _contextResolverMock.Object);
         }
     }
 }


### PR DESCRIPTION
Closes #208 

`DefaultEntityRepository` should accept `IDbContextResolver` as ctor parameter instead of `JsonApiContext`. The context should not depend on a DbContext since it is not mandatory.