### PR TITLE
Use AsNoTracking with readonly queries

### DIFF
--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -48,34 +48,52 @@ namespace JsonApiDotNetCore.Data
             _genericProcessorFactory = _jsonApiContext.GenericProcessorFactory;
         }
 
-        public virtual IQueryable<TEntity> Get()
+        /// <summary>
+        /// Get resource by id. This method will be removed in the next major release
+        /// and replaced by the following signature: Get(bool isReadonly = false)
+        /// </summary>
+        public virtual IQueryable<TEntity> Get() => Get(isReadonly: false);
+
+        public virtual IQueryable<TEntity> Get(bool isReadonly = false)
         {
             if (_jsonApiContext.QuerySet?.Fields != null && _jsonApiContext.QuerySet.Fields.Any())
                 return _dbSet.Select(_jsonApiContext.QuerySet?.Fields);
+
+            if(isReadonly)
+                return _dbSet.AsNoTracking();
 
             return _dbSet;
         }
 
         public virtual IQueryable<TEntity> Filter(IQueryable<TEntity> entities, FilterQuery filterQuery)
-        {
-            return entities.Filter(_jsonApiContext, filterQuery);
-        }
+            => entities.Filter(_jsonApiContext, filterQuery);
 
         public virtual IQueryable<TEntity> Sort(IQueryable<TEntity> entities, List<SortQuery> sortQueries)
-        {
-            return entities.Sort(sortQueries);
-        }
+            => entities.Sort(sortQueries);
 
-        public virtual async Task<TEntity> GetAsync(TId id)
-        {
-            return await Get().SingleOrDefaultAsync(e => e.Id.Equals(id));
-        }
+        /// <summary>
+        /// Get resource by id. This method will be removed in the next major release
+        /// and replaced by the following signature: GetAsync(TId id, bool isReadonly = false)
+        /// </summary>
+        public virtual async Task<TEntity> GetAsync(TId id) 
+            => await Get().SingleOrDefaultAsync(e => e.Id.Equals(id));
 
+        public virtual async Task<TEntity> GetAsync(TId id, bool isReadonly = false)
+            => await Get(isReadonly).SingleOrDefaultAsync(e => e.Id.Equals(id));
+
+        /// <summary>
+        /// Get resource by id with relationship sideloaded. 
+        /// This method will be removed in the next major release and replaced by 
+        /// the following signature: GetAndIncludeAsync(TId id, string relationshipName, bool isReadonly)
+        /// </summary>
         public virtual async Task<TEntity> GetAndIncludeAsync(TId id, string relationshipName)
+            => await GetAndIncludeAsync(id, relationshipName, isReadonly: false);
+
+        public virtual async Task<TEntity> GetAndIncludeAsync(TId id, string relationshipName, bool isReadonly)
         {
             _logger.LogDebug($"[JADN] GetAndIncludeAsync({id}, {relationshipName})");
 
-            var result = await Get()
+            var result = await Get(isReadonly)
                 .Include(relationshipName)
                 .SingleOrDefaultAsync(e => e.Id.Equals(id));
 

--- a/src/JsonApiDotNetCore/Data/IEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/IEntityRepository.cs
@@ -1,7 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using JsonApiDotNetCore.Internal.Query;
 using JsonApiDotNetCore.Models;
 
 namespace JsonApiDotNetCore.Data

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Extensibility/RepositoryOverrideTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Extensibility/RepositoryOverrideTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -25,11 +26,12 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Extensibility
         }
 
         [Fact]
-        public async Task Total_Record_Count_Included()
+        public async Task Can_Override_Repository()
         {
             // arrange
             var builder = new WebHostBuilder()
                 .UseStartup<AuthorizedStartup>();
+
             var server = new TestServer(builder);
             var client = server.CreateClient();
             var context = (AppDbContext)server.Host.Services.GetService(typeof(AppDbContext));
@@ -43,8 +45,10 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Extensibility
             context.TodoItems.Add(ownedTodoItem);
             context.TodoItems.Add(unOwnedTodoItem);
             context.SaveChanges(); 
+            
+            const int expectedCount = 1;
 
-            var authService =  (IAuthorizationService)server.Host.Services.GetService(typeof(IAuthorizationService));        
+            var authService =  (IAuthorizationService)server.Host.Services.GetService(typeof(IAuthorizationService));
             authService.CurrentUserId = person.Id;
 
             var httpMethod = new HttpMethod("GET");
@@ -59,6 +63,8 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Extensibility
             
             // assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(expectedCount, deserializedBody.Count);
+
             foreach(var item in deserializedBody)
                 Assert.Equal(person.Id, item.OwnerId);
         }

--- a/test/JsonApiDotNetCoreExampleTests/Helpers/Repositories/AuthorizedTodoItemsRepository.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Helpers/Repositories/AuthorizedTodoItemsRepository.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using JsonApiDotNetCore.Data;
 using JsonApiDotNetCore.Services;
-using JsonApiDotNetCoreExample.Data;
 using JsonApiDotNetCoreExample.Models;
 using JsonApiDotNetCoreExampleTests.Services;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
Closes #221

This is on hold until I can evaluate the scope of the breaking changes. Not only are there API implications but also impacts on possible extensibility scenarios. By setting the query as `NoTracking`, acceptance tests using the same context may be impacted.

Need to put together documentation on these breaking changes and how users should handle acceptance testing that uses the same DbContext instance.

**Update**

I think the best way to move forward is to allow a global options flag to be set in `Startup` that will enable `AsNoTracking`. It will need to default to `false` to avoid breaking changes and will allow tests to enable tracking for all queries.

There may also be impact to #238 