### PR TITLE
Feat/#226: Add DocumentBuilderOptions allowing omission of null attributes

### DIFF
--- a/JsonApiDotnetCore.sln
+++ b/JsonApiDotnetCore.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.10
+VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JsonApiDotNetCore", "src\JsonApiDotNetCore\JsonApiDotNetCore.csproj", "{C0EC9E70-EB2E-436F-9D94-FA16FA774123}"
 EndProject
@@ -30,7 +30,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReportsExample", "src\Examp
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{076E1AE4-FD25-4684-B826-CAAE37FEA0AA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks", "benchmarks\Benchmarks.csproj", "{1F604666-BB0F-413E-922D-9D37C6073285}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks", "benchmarks\Benchmarks.csproj", "{1F604666-BB0F-413E-922D-9D37C6073285}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -110,22 +110,22 @@ Global
 		{FBFB0B0B-EA86-4B41-AB2A-E0249F70C86D}.Debug|x86.Build.0 = Debug|Any CPU
 		{FBFB0B0B-EA86-4B41-AB2A-E0249F70C86D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FBFB0B0B-EA86-4B41-AB2A-E0249F70C86D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FBFB0B0B-EA86-4B41-AB2A-E0249F70C86D}.Release|x64.ActiveCfg = Release|x64
-		{FBFB0B0B-EA86-4B41-AB2A-E0249F70C86D}.Release|x64.Build.0 = Release|x64
-		{FBFB0B0B-EA86-4B41-AB2A-E0249F70C86D}.Release|x86.ActiveCfg = Release|x86
-		{FBFB0B0B-EA86-4B41-AB2A-E0249F70C86D}.Release|x86.Build.0 = Release|x86
+		{FBFB0B0B-EA86-4B41-AB2A-E0249F70C86D}.Release|x64.ActiveCfg = Release|Any CPU
+		{FBFB0B0B-EA86-4B41-AB2A-E0249F70C86D}.Release|x64.Build.0 = Release|Any CPU
+		{FBFB0B0B-EA86-4B41-AB2A-E0249F70C86D}.Release|x86.ActiveCfg = Release|Any CPU
+		{FBFB0B0B-EA86-4B41-AB2A-E0249F70C86D}.Release|x86.Build.0 = Release|Any CPU
 		{1F604666-BB0F-413E-922D-9D37C6073285}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1F604666-BB0F-413E-922D-9D37C6073285}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1F604666-BB0F-413E-922D-9D37C6073285}.Debug|x64.ActiveCfg = Debug|x64
-		{1F604666-BB0F-413E-922D-9D37C6073285}.Debug|x64.Build.0 = Debug|x64
-		{1F604666-BB0F-413E-922D-9D37C6073285}.Debug|x86.ActiveCfg = Debug|x86
-		{1F604666-BB0F-413E-922D-9D37C6073285}.Debug|x86.Build.0 = Debug|x86
+		{1F604666-BB0F-413E-922D-9D37C6073285}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1F604666-BB0F-413E-922D-9D37C6073285}.Debug|x64.Build.0 = Debug|Any CPU
+		{1F604666-BB0F-413E-922D-9D37C6073285}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1F604666-BB0F-413E-922D-9D37C6073285}.Debug|x86.Build.0 = Debug|Any CPU
 		{1F604666-BB0F-413E-922D-9D37C6073285}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1F604666-BB0F-413E-922D-9D37C6073285}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1F604666-BB0F-413E-922D-9D37C6073285}.Release|x64.ActiveCfg = Release|x64
-		{1F604666-BB0F-413E-922D-9D37C6073285}.Release|x64.Build.0 = Release|x64
-		{1F604666-BB0F-413E-922D-9D37C6073285}.Release|x86.ActiveCfg = Release|x86
-		{1F604666-BB0F-413E-922D-9D37C6073285}.Release|x86.Build.0 = Release|x86
+		{1F604666-BB0F-413E-922D-9D37C6073285}.Release|x64.ActiveCfg = Release|Any CPU
+		{1F604666-BB0F-413E-922D-9D37C6073285}.Release|x64.Build.0 = Release|Any CPU
+		{1F604666-BB0F-413E-922D-9D37C6073285}.Release|x86.ActiveCfg = Release|Any CPU
+		{1F604666-BB0F-413E-922D-9D37C6073285}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/JsonApiDotNetCore/Builders/DocumentBuilderOptions.cs
+++ b/src/JsonApiDotNetCore/Builders/DocumentBuilderOptions.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace JsonApiDotNetCore.Builders
+{
+    public struct DocumentBuilderOptions 
+    {
+        public DocumentBuilderOptions(bool omitNullValuedAttributes = false)
+        {
+            this.OmitNullValuedAttributes = omitNullValuedAttributes;
+        }
+
+        public bool OmitNullValuedAttributes { get; private set; }
+    }
+}

--- a/src/JsonApiDotNetCore/Builders/DocumentBuilderOptionsProvider.cs
+++ b/src/JsonApiDotNetCore/Builders/DocumentBuilderOptionsProvider.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using JsonApiDotNetCore.Services;
+using Microsoft.AspNetCore.Http;
+
+namespace JsonApiDotNetCore.Builders
+{
+    public class DocumentBuilderOptionsProvider : IDocumentBuilderOptionsProvider
+    {
+        private readonly IJsonApiContext _jsonApiContext;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public DocumentBuilderOptionsProvider(IJsonApiContext jsonApiContext, IHttpContextAccessor httpContextAccessor)
+        {
+            _jsonApiContext = jsonApiContext;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public DocumentBuilderOptions GetDocumentBuilderOptions()
+        {
+            var nullAttributeResponseBehaviorConfig = this._jsonApiContext.Options.NullAttributeResponseBehavior;
+            if (nullAttributeResponseBehaviorConfig.AllowClientOverride && _httpContextAccessor.HttpContext.Request.Query.TryGetValue("omitNullValuedAttributes", out var omitNullValuedAttributesQs))
+            {
+                if (bool.TryParse(omitNullValuedAttributesQs, out var omitNullValuedAttributes))
+                {
+                    return new DocumentBuilderOptions(omitNullValuedAttributes);                                
+                }
+            }
+            return new DocumentBuilderOptions(this._jsonApiContext.Options.NullAttributeResponseBehavior.OmitNullValuedAttributes);
+        }
+    }
+}

--- a/src/JsonApiDotNetCore/Builders/IDocumentBuilderOptionsProvider.cs
+++ b/src/JsonApiDotNetCore/Builders/IDocumentBuilderOptionsProvider.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace JsonApiDotNetCore.Builders
+{
+    public interface IDocumentBuilderOptionsProvider
+    {
+        DocumentBuilderOptions GetDocumentBuilderOptions(); 
+    }
+}

--- a/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
@@ -17,6 +17,7 @@ namespace JsonApiDotNetCore.Configuration
         public IContextGraph ContextGraph { get; set; }
         public bool RelativeLinks { get; set; }
         public bool AllowCustomQueryParameters { get; set; }
+        public NullAttributeResponseBehavior NullAttributeResponseBehavior { get; set; }
 
         [Obsolete("JsonContract resolver can now be set on SerializerSettings.")]
         public IContractResolver JsonContractResolver
@@ -29,6 +30,7 @@ namespace JsonApiDotNetCore.Configuration
             NullValueHandling = NullValueHandling.Ignore,
             ContractResolver = new DasherizedResolver()
         };
+
         internal IContextGraphBuilder ContextGraphBuilder { get; } = new ContextGraphBuilder();
 
         public void BuildContextGraph<TContext>(Action<IContextGraphBuilder> builder) where TContext : DbContext
@@ -49,4 +51,6 @@ namespace JsonApiDotNetCore.Configuration
             ContextGraph = ContextGraphBuilder.Build();
         }
     }
+
+    
 }

--- a/src/JsonApiDotNetCore/Configuration/NullAttributeResponseBehavior.cs
+++ b/src/JsonApiDotNetCore/Configuration/NullAttributeResponseBehavior.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace JsonApiDotNetCore.Configuration
+{
+    public struct NullAttributeResponseBehavior
+    {
+        public NullAttributeResponseBehavior(bool omitNullValuedAttributes = false, bool allowClientOverride = false)
+        {
+            OmitNullValuedAttributes = omitNullValuedAttributes;
+            AllowClientOverride = allowClientOverride;
+        }
+
+        public bool OmitNullValuedAttributes { get; }
+        public bool AllowClientOverride { get; }
+        // ...
+    }
+}

--- a/src/JsonApiDotNetCore/Extensions/IServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IServiceCollectionExtensions.cs
@@ -112,6 +112,7 @@ namespace JsonApiDotNetCore.Extensions
             services.AddScoped<IQueryAccessor, QueryAccessor>();
             services.AddScoped<IQueryParser, QueryParser>();
             services.AddScoped<IControllerContext, Services.ControllerContext>();
+            services.AddScoped<IDocumentBuilderOptionsProvider, DocumentBuilderOptionsProvider>();
         }
 
         public static void SerializeAsJsonApi(this MvcOptions options, JsonApiOptions jsonApiOptions)

--- a/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
@@ -29,6 +29,7 @@ namespace JsonApiDotNetCore.Serialization
             try
             {
                 var document = JsonConvert.DeserializeObject<Document>(requestBody);
+                _jsonApiContext.DocumentMeta = document.Meta;
                 var entity = DocumentToObject(document.Data);
                 return entity;
             }

--- a/src/JsonApiDotNetCore/Services/IJsonApiContext.cs
+++ b/src/JsonApiDotNetCore/Services/IJsonApiContext.cs
@@ -26,6 +26,8 @@ namespace JsonApiDotNetCore.Services
         Dictionary<AttrAttribute, object> AttributesToUpdate { get; set; }
         Dictionary<RelationshipAttribute, object> RelationshipsToUpdate { get; set; }
         Type ControllerType { get; set; }
+        Dictionary<string, object> DocumentMeta { get; set; }
+
         TAttribute GetControllerAttribute<TAttribute>() where TAttribute : Attribute;
     }
 }

--- a/src/JsonApiDotNetCore/Services/JsonApiContext.cs
+++ b/src/JsonApiDotNetCore/Services/JsonApiContext.cs
@@ -50,6 +50,7 @@ namespace JsonApiDotNetCore.Services
         public Dictionary<AttrAttribute, object> AttributesToUpdate { get; set; } = new Dictionary<AttrAttribute, object>();
         public Dictionary<RelationshipAttribute, object> RelationshipsToUpdate { get; set; } = new Dictionary<RelationshipAttribute, object>();
         public Type ControllerType { get; set; }
+        public Dictionary<string, object> DocumentMeta { get; set; }
 
         public IJsonApiContext ApplyContext<T>(object controller)
         {

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Extensibility/NullValuedAttributeHandlingTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Extensibility/NullValuedAttributeHandlingTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Models;
+using JsonApiDotNetCoreExample;
+using JsonApiDotNetCoreExample.Data;
+using JsonApiDotNetCoreExample.Models;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace JsonApiDotNetCoreExampleTests.Acceptance.Extensibility
+{
+    [Collection("WebHostCollection")]
+    public class NullValuedAttributeHandlingTests : IAsyncLifetime
+    {
+        private readonly TestFixture<Startup> _fixture;
+        private readonly AppDbContext _dbContext;
+        private readonly TodoItem _todoItem;
+
+        public NullValuedAttributeHandlingTests(TestFixture<Startup> fixture)
+        {
+            _fixture = fixture;
+            _dbContext = fixture.GetService<AppDbContext>();
+            _todoItem = new TodoItem
+            {
+                Description = null,
+                Ordinal = 1,
+                CreatedDate = DateTime.Now,
+                AchievedDate = DateTime.Now.AddDays(2)
+            };
+            _todoItem = _dbContext.TodoItems.Add(_todoItem).Entity;
+        }
+
+        public async Task InitializeAsync()
+        {
+            await _dbContext.SaveChangesAsync();
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        [Theory]
+        [InlineData(null, null, null, false)]
+        [InlineData(true, null, null, true)]
+        [InlineData(false, true, "true", true)]
+        [InlineData(false, false, "true", false)]
+        [InlineData(true, true, "false", false)]
+        [InlineData(true, false, "false", true)]
+        [InlineData(null, false, "false", false)]
+        [InlineData(null, false, "true", false)]
+        [InlineData(null, true, "true", true)]
+        [InlineData(null, true, "false", false)]
+        [InlineData(null, true, "foo", false)]
+        [InlineData(null, false, "foo", false)]
+        [InlineData(true, true, "foo", true)]
+        [InlineData(true, false, "foo", true)]
+        [InlineData(null, true, null, false)]
+        [InlineData(null, false, null, false)]
+        public async Task CheckNullBehaviorCombination(bool? omitNullValuedAttributes, bool? allowClientOverride,
+            string clientOverride, bool omitsNulls)
+        {
+
+            // Override some null handling options
+            NullAttributeResponseBehavior nullAttributeResponseBehavior;
+            if (omitNullValuedAttributes.HasValue && allowClientOverride.HasValue)
+            {
+                nullAttributeResponseBehavior = new NullAttributeResponseBehavior(omitNullValuedAttributes.Value, allowClientOverride.Value);
+            }
+            else if (omitNullValuedAttributes.HasValue)
+            {
+                nullAttributeResponseBehavior = new NullAttributeResponseBehavior(omitNullValuedAttributes.Value);
+            }
+            else if (allowClientOverride.HasValue)
+            {
+                nullAttributeResponseBehavior = new NullAttributeResponseBehavior(allowClientOverride: allowClientOverride.Value);
+            }
+            else
+            {
+                nullAttributeResponseBehavior = new NullAttributeResponseBehavior();
+            }
+            var jsonApiOptions = _fixture.GetService<JsonApiOptions>();
+            jsonApiOptions.NullAttributeResponseBehavior = nullAttributeResponseBehavior;
+            jsonApiOptions.AllowCustomQueryParameters = true;
+
+            var httpMethod = new HttpMethod("GET");
+            var queryString = allowClientOverride.HasValue
+                ? $"?omitNullValuedAttributes={clientOverride}"
+                : "";
+            var route = $"/api/v1/todo-items/{_todoItem.Id}{queryString}"; 
+            var request = new HttpRequestMessage(httpMethod, route);
+
+            // act
+            var response = await _fixture.Client.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            var deserializeBody = JsonConvert.DeserializeObject<Document>(body);
+
+            // assert. does response contain a null valued attribute
+            Assert.Equal(omitsNulls, !deserializeBody.Data.Attributes.ContainsKey("description"));
+
+        }
+    }
+
+}

--- a/test/JsonApiDotNetCoreExampleTests/Unit/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Unit/Extensions/IServiceCollectionExtensionsTests.cs
@@ -49,6 +49,7 @@ namespace JsonApiDotNetCoreExampleTests.Unit.Extensions
             Assert.NotNull(provider.GetService<IJsonApiReader>());
             Assert.NotNull(provider.GetService<IJsonApiDeSerializer>());
             Assert.NotNull(provider.GetService<IGenericProcessorFactory>());
+            Assert.NotNull(provider.GetService<IDocumentBuilderOptionsProvider>());
             Assert.NotNull(provider.GetService(typeof(GenericProcessor<TodoItem>)));
         }
     }

--- a/test/UnitTests/Builders/DocumentBuilderBehaviour_Tests.cs
+++ b/test/UnitTests/Builders/DocumentBuilderBehaviour_Tests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using JsonApiDotNetCore.Builders;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Services;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace UnitTests.Builders
+{
+    public class DocumentBuilderBehaviour_Tests
+    {
+
+        [Theory]
+        [InlineData(null, null, null, false)]
+        [InlineData(false, null, null, false)]
+        [InlineData(true, null, null, true)]
+        [InlineData(false, false, "true", false)]
+        [InlineData(false, true, "true", true)]
+        [InlineData(true, true, "false", false)]
+        [InlineData(true, false, "false", true)]
+        [InlineData(null, false, "false", false)]
+        [InlineData(null, false, "true", false)]
+        [InlineData(null, true, "true", true)]
+        [InlineData(null, true, "false", false)]
+        [InlineData(null, true, "foo", false)]
+        [InlineData(null, false, "foo", false)]
+        [InlineData(true, true, "foo", true)]
+        [InlineData(true, false, "foo", true)]
+        [InlineData(null, true, null, false)]
+        [InlineData(null, false, null, false)]
+        public void CheckNullBehaviorCombination(bool? omitNullValuedAttributes, bool? allowClientOverride, string clientOverride, bool omitsNulls)
+        {
+
+            NullAttributeResponseBehavior nullAttributeResponseBehavior; 
+            if (omitNullValuedAttributes.HasValue && allowClientOverride.HasValue)
+            {
+                nullAttributeResponseBehavior = new NullAttributeResponseBehavior(omitNullValuedAttributes.Value, allowClientOverride.Value);
+            }else if (omitNullValuedAttributes.HasValue)
+            {
+                nullAttributeResponseBehavior = new NullAttributeResponseBehavior(omitNullValuedAttributes.Value);
+            }else if
+                (allowClientOverride.HasValue)
+            {
+                nullAttributeResponseBehavior = new NullAttributeResponseBehavior(allowClientOverride: allowClientOverride.Value);
+            }
+            else
+            {
+                nullAttributeResponseBehavior = new NullAttributeResponseBehavior();
+            }
+
+            var jsonApiContextMock = new Mock<IJsonApiContext>();
+            jsonApiContextMock.SetupGet(m => m.Options)
+                .Returns(new JsonApiOptions() {NullAttributeResponseBehavior = nullAttributeResponseBehavior});
+
+            var httpContext = new DefaultHttpContext();
+            if (clientOverride != null)
+            {
+                httpContext.Request.QueryString = new QueryString($"?omitNullValuedAttributes={clientOverride}");
+            }
+            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+            httpContextAccessorMock.SetupGet(m => m.HttpContext).Returns(httpContext);
+
+            var sut = new DocumentBuilderOptionsProvider(jsonApiContextMock.Object, httpContextAccessorMock.Object);
+            var documentBuilderOptions = sut.GetDocumentBuilderOptions();
+
+            Assert.Equal(omitsNulls, documentBuilderOptions.OmitNullValuedAttributes);
+        }
+
+    }
+}


### PR DESCRIPTION
Closes #226

#### FEATURE
- [x] write tests that address the requirements outlined in the issue
- [x] fulfill the feature requirements
- [ ] bump package version

Looked into adding support for omitting null valued attributes from responses. This can be enabled globally by setting option 'OmitNullValuedAttributesFromResponses' to true. Default value for the option is false.

To consider before the merge: JsonApi is spec does not specify anything about omitting null values in responses - least as far as I can tell. It may be better to allow clients to opt-in for this functionality instead of having a global configuration, so only compliant clients can opt-in. What do you think?

