### PR TITLE
Initializing PageOffset to be 1 (instead of default 0) so that the 'n…

### DIFF
--- a/src/JsonApiDotNetCore/Internal/Query/PageQuery.cs
+++ b/src/JsonApiDotNetCore/Internal/Query/PageQuery.cs
@@ -3,6 +3,6 @@ namespace JsonApiDotNetCore.Internal.Query
     public class PageQuery
     {
        public int PageSize { get; set; }
-       public int PageOffset { get; set; }
+       public int PageOffset { get; set; } = 1;
     }
 }


### PR DESCRIPTION
…ext' pagination link is set properly when no 'page[number]' is passed in the query string.

Closes #242 

#### BUG FIX
- [x] reproduce issue in tests
- [x] fix issue
- [x] bump package version

#### FEATURE
- [ ] write tests that address the requirements outlined in the issue
- [ ] fulfill the feature requirements
- [ ] bump package version
