### PR TITLE
De-Couple deserializer from GenericProcessorFactory

### DIFF
--- a/src/JsonApiDotNetCore/Builders/DocumentBuilder.cs
+++ b/src/JsonApiDotNetCore/Builders/DocumentBuilder.cs
@@ -107,7 +107,7 @@ namespace JsonApiDotNetCore.Builders
                 Id = entity.StringId
             };
 
-            if (_jsonApiContext.IsRelationshipData)
+            if (_jsonApiContext.IsRelationshipPath)
                 return data;
 
             data.Attributes = new Dictionary<string, object>();

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -85,8 +85,27 @@ namespace JsonApiDotNetCore.Data
         public virtual async Task<TEntity> CreateAsync(TEntity entity)
         {
             _dbSet.Add(entity);
+
+            DetachHasManyPointers();
+
             await _context.SaveChangesAsync();
             return entity;
+        }
+
+        /// <summary>
+        /// This is used to allow creation of HasMany relationships when the
+        /// dependent side of the relationship already exists.
+        /// </summary>
+        private void DetachHasManyPointers()
+        {
+            var relationships = _jsonApiContext.HasManyRelationshipPointers.Get();
+            foreach(var relationship in relationships)
+            {
+                foreach(var pointer in relationship.Value)
+                {
+                    _context.Entry(pointer).State = EntityState.Unchanged;
+                }
+            }
         }
 
         public virtual async Task<TEntity> UpdateAsync(TId id, TEntity entity)

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -84,9 +84,8 @@ namespace JsonApiDotNetCore.Data
 
         public virtual async Task<TEntity> CreateAsync(TEntity entity)
         {
+            AttachHasManyPointers();
             _dbSet.Add(entity);
-
-            DetachHasManyPointers();
 
             await _context.SaveChangesAsync();
             return entity;
@@ -96,7 +95,7 @@ namespace JsonApiDotNetCore.Data
         /// This is used to allow creation of HasMany relationships when the
         /// dependent side of the relationship already exists.
         /// </summary>
-        private void DetachHasManyPointers()
+        private void AttachHasManyPointers()
         {
             var relationships = _jsonApiContext.HasManyRelationshipPointers.Get();
             foreach(var relationship in relationships)

--- a/src/JsonApiDotNetCore/Data/IEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/IEntityRepository.cs
@@ -1,7 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using JsonApiDotNetCore.Internal.Query;
 using JsonApiDotNetCore.Models;
 
 namespace JsonApiDotNetCore.Data

--- a/src/JsonApiDotNetCore/Extensions/DbContextExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/DbContextExtensions.cs
@@ -1,20 +1,12 @@
-using Microsoft.EntityFrameworkCore;
 using System;
+using Microsoft.EntityFrameworkCore;
 
 namespace JsonApiDotNetCore.Extensions
 {
     public static class DbContextExtensions
     {
-        public static DbSet<T> GetDbSet<T>(this DbContext context) where T : class
-        {
-            var contextProperties = context.GetType().GetProperties();
-            foreach(var property in contextProperties)
-            {
-                if (property.PropertyType == typeof(DbSet<T>))
-                    return (DbSet<T>)property.GetValue(context);
-            }
-
-            throw new ArgumentException($"DbSet of type {typeof(T).FullName} not found on the DbContext", nameof(T));
-        }
+        [Obsolete("This is no longer required since the introduction of context.Set<T>", error: false)]
+        public static DbSet<T> GetDbSet<T>(this DbContext context) where T : class 
+            => context.Set<T>();
     }
 }

--- a/src/JsonApiDotNetCore/Extensions/TypeExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/TypeExtensions.cs
@@ -35,12 +35,12 @@ namespace JsonApiDotNetCore.Extensions
         /// <summary>
         /// Creates a List{TInterface} where TInterface is the generic for type specified by t
         /// </summary>
-        public static IEnumerable<TInterface> GetEmptyCollection<TInterface>(this Type t)
+        public static IEnumerable GetEmptyCollection(this Type t)
         {
             if (t == null) throw new ArgumentNullException(nameof(t));
 
             var listType = typeof(List<>).MakeGenericType(t);
-            var list = (IEnumerable<TInterface>)Activator.CreateInstance(listType);
+            var list = (IEnumerable)Activator.CreateInstance(listType);
             return list;
         }
 

--- a/src/JsonApiDotNetCore/Extensions/TypeExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/TypeExtensions.cs
@@ -31,5 +31,28 @@ namespace JsonApiDotNetCore.Extensions
 
             return elementType;
         }
+
+        /// <summary>
+        /// Creates a List{TInterface} where TInterface is the generic for type specified by t
+        /// </summary>
+        public static List<TInterface> GetEmptyCollection<TInterface>(this Type t)
+        {
+            if (t == null) throw new ArgumentNullException(nameof(t));
+
+            var listType = typeof(List<>).MakeGenericType(t);
+            var list = (List<TInterface>)Activator.CreateInstance(listType);
+            return list;
+        }
+
+        /// <summary>
+        /// Creates a new instance of type t, casting it to the specified TInterface 
+        /// </summary>
+        public static TInterface New<TInterface>(this Type t)
+        {
+            if (t == null) throw new ArgumentNullException(nameof(t));
+
+            var instance = (TInterface)Activator.CreateInstance(t);
+            return instance;
+        }
     }
 }

--- a/src/JsonApiDotNetCore/Extensions/TypeExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/TypeExtensions.cs
@@ -35,12 +35,12 @@ namespace JsonApiDotNetCore.Extensions
         /// <summary>
         /// Creates a List{TInterface} where TInterface is the generic for type specified by t
         /// </summary>
-        public static List<TInterface> GetEmptyCollection<TInterface>(this Type t)
+        public static IEnumerable<TInterface> GetEmptyCollection<TInterface>(this Type t)
         {
             if (t == null) throw new ArgumentNullException(nameof(t));
 
             var listType = typeof(List<>).MakeGenericType(t);
-            var list = (List<TInterface>)Activator.CreateInstance(listType);
+            var list = (IEnumerable<TInterface>)Activator.CreateInstance(listType);
             return list;
         }
 

--- a/src/JsonApiDotNetCore/Internal/TypeHelper.cs
+++ b/src/JsonApiDotNetCore/Internal/TypeHelper.cs
@@ -7,6 +7,14 @@ namespace JsonApiDotNetCore.Internal
 {
     public static class TypeHelper
     {
+        public static IList ConvertCollection(IEnumerable<object> collection, Type targetType)
+        {
+            var list = Activator.CreateInstance(typeof(List<>).MakeGenericType(targetType)) as IList;
+            foreach(var item in collection)
+                list.Add(ConvertType(item, targetType));
+            return list;
+        }
+
         public static object ConvertType(object value, Type type)
         {
             if (value == null)

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>2.2.4</VersionPrefix>
+    <VersionPrefix>2.2.5/VersionPrefix>
     <TargetFrameworks>$(NetStandardVersion)</TargetFrameworks>
     <AssemblyName>JsonApiDotNetCore</AssemblyName>
     <PackageId>JsonApiDotNetCore</PackageId>

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>2.2.5/VersionPrefix>
+    <VersionPrefix>2.2.5</VersionPrefix>
     <TargetFrameworks>$(NetStandardVersion)</TargetFrameworks>
     <AssemblyName>JsonApiDotNetCore</AssemblyName>
     <PackageId>JsonApiDotNetCore</PackageId>

--- a/src/JsonApiDotNetCore/Models/HasManyAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/HasManyAttribute.cs
@@ -12,7 +12,7 @@ namespace JsonApiDotNetCore.Models
                 .GetType()
                 .GetProperty(InternalRelationshipName);
             
-            propertyInfo.SetValue(entity, newValue);        
+            propertyInfo.SetValue(entity, newValue);
         }
     }
 }

--- a/src/JsonApiDotNetCore/Models/HasOneAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/HasOneAttribute.cs
@@ -39,9 +39,14 @@ namespace JsonApiDotNetCore.Models
             ? $"{InternalRelationshipName}Id"
             : _explicitIdentifiablePropertyName;
 
+        /// <summary>
+        /// Sets the value of the property identified by this attribute
+        /// </summary>
+        /// <param name="entity">The target object</param>
+        /// <param name="newValue">The new property value</param>
         public override void SetValue(object entity, object newValue)
         {
-            var propertyName = (newValue.GetType() == Type)
+            var propertyName = (newValue?.GetType() == Type)
                 ? InternalRelationshipName
                 : IdentifiablePropertyName;
 

--- a/src/JsonApiDotNetCore/Models/RelationshipAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/RelationshipAttribute.cs
@@ -19,6 +19,28 @@ namespace JsonApiDotNetCore.Models
         public Link DocumentLinks { get; } = Link.All;
         public bool CanInclude { get; }
 
+        public bool TryGetHasOne(out HasOneAttribute result)
+        {
+            if (IsHasOne)
+            {
+                result = (HasOneAttribute)this;
+                return true;
+            }
+            result = null;
+            return false;
+        }
+
+        public bool TryGetHasMany(out HasManyAttribute result)
+        {
+            if (IsHasMany)
+            {
+                result = (HasManyAttribute)this;
+                return true;
+            }
+            result = null;
+            return false;
+        }
+
         public abstract void SetValue(object entity, object newValue);
 
         public override string ToString()

--- a/src/JsonApiDotNetCore/Request/HasManyRelationshipPointers.cs
+++ b/src/JsonApiDotNetCore/Request/HasManyRelationshipPointers.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace JsonApiDotNetCore.Request
+{
+    /// <summary>
+    /// Stores information to set relationships for the request resource. 
+    /// These relationships must already exist and should not be re-created.
+    /// 
+    /// The expected use case is POST-ing or PATCH-ing 
+    /// an entity with HasMany relaitonships:
+    /// <code>
+    /// {
+    ///    "data": {
+    ///      "type": "photos",
+    ///      "attributes": {
+    ///        "title": "Ember Hamster",
+    ///        "src": "http://example.com/images/productivity.png"
+    ///      },
+    ///      "relationships": {
+    ///        "tags": {
+    ///          "data": [
+    ///            { "type": "tags", "id": "2" },
+    ///            { "type": "tags", "id": "3" }
+    ///          ]
+    ///        }
+    ///      }
+    ///    }
+    ///  }
+    /// </code>
+    /// </summary>
+    public class HasManyRelationshipPointers
+    {
+        private Dictionary<Type, IList> _hasManyRelationships = new Dictionary<Type, IList>();
+
+        /// <summary>
+        /// Add the relationship to the list of relationships that should be 
+        /// set in the repository layer.
+        /// </summary>
+        public void Add(Type dependentType, IList entities)
+            => _hasManyRelationships[dependentType] = entities;
+
+        /// <summary>
+        /// Get all the models that should be associated
+        /// </summary>
+        public Dictionary<Type, IList> Get() => _hasManyRelationships;
+    }
+}

--- a/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
@@ -209,20 +209,23 @@ namespace JsonApiDotNetCore.Serialization
 
                 var foreignKey = attr.IdentifiablePropertyName;
                 var entityProperty = entityProperties.FirstOrDefault(p => p.Name == foreignKey);
-                if (entityProperty == null)
+                if (entityProperty == null && rio != null)
                     throw new JsonApiException(400, $"{contextEntity.EntityType.Name} does not contain a foreign key property '{foreignKey}' for has one relationship '{attr.InternalRelationshipName}'");
 
-                // e.g. PATCH /articles
-                // {... { "relationships":{ "Owner": { "data" :null } } } }
-                if (rio == null && Nullable.GetUnderlyingType(entityProperty.PropertyType) == null)
-                    throw new JsonApiException(400, $"Cannot set required relationship identifier '{attr.IdentifiablePropertyName}' to null.");
+                if (entityProperty != null)
+                {
+                    // e.g. PATCH /articles
+                    // {... { "relationships":{ "Owner": { "data" :null } } } }
+                    if (rio == null && Nullable.GetUnderlyingType(entityProperty.PropertyType) == null)
+                        throw new JsonApiException(400, $"Cannot set required relationship identifier '{attr.IdentifiablePropertyName}' to null.");
 
-                var newValue = rio?.Id ?? null;
-                var convertedValue = TypeHelper.ConvertType(newValue, entityProperty.PropertyType);
+                    var newValue = rio?.Id ?? null;
+                    var convertedValue = TypeHelper.ConvertType(newValue, entityProperty.PropertyType);
 
-                _jsonApiContext.RelationshipsToUpdate[relationshipAttr] = convertedValue;
+                    _jsonApiContext.RelationshipsToUpdate[relationshipAttr] = convertedValue;
 
-                entityProperty.SetValue(entity, convertedValue);
+                    entityProperty.SetValue(entity, convertedValue);
+                }
             }
 
             return entity;

--- a/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
@@ -232,12 +232,6 @@ namespace JsonApiDotNetCore.Serialization
             ContextEntity contextEntity,
             Dictionary<string, RelationshipData> relationships)
         {
-            // TODO: is this necessary? if not, remove
-            // var entityProperty = entityProperties.FirstOrDefault(p => p.Name == attr.InternalRelationshipName);
-
-            // if (entityProperty == null)
-            //     throw new JsonApiException(400, $"{contextEntity.EntityType.Name} does not contain a relationsip named '{attr.InternalRelationshipName}'");
-
             var relationshipName = attr.PublicRelationshipName;
 
             if (relationships.TryGetValue(relationshipName, out RelationshipData relationshipData))
@@ -255,9 +249,9 @@ namespace JsonApiDotNetCore.Serialization
 
                 var convertedCollection = TypeHelper.ConvertCollection(relationshipShells, attr.Type);
 
-                // var convertedCollection = TypeHelper.ConvertCollection(relationshipShells, attr.Type);
-
                 attr.SetValue(entity, convertedCollection);
+
+                _jsonApiContext.HasManyRelationshipPointers.Add(attr.Type, convertedCollection);
             }
 
             return entity;

--- a/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using JsonApiDotNetCore.Extensions;
 using JsonApiDotNetCore.Internal;
 using JsonApiDotNetCore.Internal.Generics;
 using JsonApiDotNetCore.Models;
@@ -9,7 +10,6 @@ using JsonApiDotNetCore.Models.Operations;
 using JsonApiDotNetCore.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using JsonApiDotNetCore.Extensions;
 
 namespace JsonApiDotNetCore.Serialization
 {
@@ -246,8 +246,6 @@ namespace JsonApiDotNetCore.Serialization
 
                 if (data == null) return entity;
 
-                var resourceRelationships = attr.Type.GetEmptyCollection<IIdentifiable>();
-
                 var relationshipShells = relationshipData.ManyData.Select(r =>
                 {
                     var instance = attr.Type.New<IIdentifiable>();
@@ -255,7 +253,11 @@ namespace JsonApiDotNetCore.Serialization
                     return instance;
                 });
 
-                attr.SetValue(entity, relationshipShells);
+                var convertedCollection = TypeHelper.ConvertCollection(relationshipShells, attr.Type);
+
+                // var convertedCollection = TypeHelper.ConvertCollection(relationshipShells, attr.Type);
+
+                attr.SetValue(entity, convertedCollection);
             }
 
             return entity;

--- a/src/JsonApiDotNetCore/Services/EntityResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/EntityResourceService.cs
@@ -133,7 +133,7 @@ namespace JsonApiDotNetCore.Services
                 .Relationships
                 .FirstOrDefault(r => r.InternalRelationshipName == relationshipName);
 
-            var relationshipIds = relationships.Select(r => r.Id?.ToString());
+            var relationshipIds = relationships.Select(r => r?.Id?.ToString());
 
             await _entities.UpdateRelationshipsAsync(entity, relationship, relationshipIds);
         }

--- a/src/JsonApiDotNetCore/Services/EntityResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/EntityResourceService.cs
@@ -80,10 +80,7 @@ namespace JsonApiDotNetCore.Services
         }
 
         public virtual async Task<object> GetRelationshipsAsync(TId id, string relationshipName)
-        {
-            _jsonApiContext.IsRelationshipData = true;
-            return await GetRelationshipAsync(id, relationshipName);
-        }
+            => await GetRelationshipAsync(id, relationshipName);
 
         public virtual async Task<object> GetRelationshipAsync(TId id, string relationshipName)
         {

--- a/src/JsonApiDotNetCore/Services/IJsonApiContext.cs
+++ b/src/JsonApiDotNetCore/Services/IJsonApiContext.cs
@@ -25,7 +25,16 @@ namespace JsonApiDotNetCore.Services
 
     public interface IUpdateRequest
     {
+        /// <summary>
+        /// The attributes that were included in a PATCH request. 
+        /// Only the attributes in this dictionary should be updated.
+        /// </summary>
         Dictionary<AttrAttribute, object> AttributesToUpdate { get; set; }
+
+        /// <summary>
+        /// Any relationships that were included in a PATCH request. 
+        /// Only the relationships in this dictionary should be updated.
+        /// </summary>
         Dictionary<RelationshipAttribute, object> RelationshipsToUpdate { get; set; }
     }
 

--- a/src/JsonApiDotNetCore/Services/IJsonApiContext.cs
+++ b/src/JsonApiDotNetCore/Services/IJsonApiContext.cs
@@ -10,27 +10,113 @@ using JsonApiDotNetCore.Request;
 
 namespace JsonApiDotNetCore.Services
 {
-    public interface IJsonApiContext
+    public interface IJsonApiApplication
     {
         JsonApiOptions Options { get; set; }
-        IJsonApiContext ApplyContext<T>(object controller);
         IContextGraph ContextGraph { get; set; }
-        ContextEntity RequestEntity { get; set; }
-        string BasePath { get; set; }
-        QuerySet QuerySet { get; set; }
-        bool IsRelationshipData { get; set; }
+    }
+
+    public interface IQueryRequest
+    {
         List<string> IncludedRelationships { get; set; }
-        bool IsRelationshipPath { get; }
+        QuerySet QuerySet { get; set; }
         PageManager PageManager { get; set; }
-        IMetaBuilder MetaBuilder { get; set; }
-        IGenericProcessorFactory GenericProcessorFactory { get; set; }
+    }
+
+    public interface IUpdateRequest
+    {
         Dictionary<AttrAttribute, object> AttributesToUpdate { get; set; }
         Dictionary<RelationshipAttribute, object> RelationshipsToUpdate { get; set; }
-        Type ControllerType { get; set; }
-        Dictionary<string, object> DocumentMeta { get; set; }
-        bool IsBulkOperationRequest { get; set; }
+    }
+
+    public interface IJsonApiRequest : IJsonApiApplication, IUpdateRequest, IQueryRequest
+    {
+        /// <summary>
+        /// The request namespace. This may be an absolute or relative path
+        /// depending upon the configuration.
+        /// </summary>
+        /// <example>
+        /// Absolute: https://example.com/api/v1
+        /// 
+        /// Relative: /api/v1
+        /// </example>
+        string BasePath { get; set; }
+
+        /// <summary>
+        /// Stores information to set relationships for the request resource. 
+        /// These relationships must already exist and should not be re-created.
+        /// By default, it is the responsibility of the repository to use the 
+        /// relationship pointers to persist the relationship.
+        /// 
+        /// The expected use case is POST-ing or PATCH-ing an entity with HasMany 
+        /// relaitonships:
+        /// <code>
+        /// {
+        ///    "data": {
+        ///      "type": "photos",
+        ///      "attributes": {
+        ///        "title": "Ember Hamster",
+        ///        "src": "http://example.com/images/productivity.png"
+        ///      },
+        ///      "relationships": {
+        ///        "tags": {
+        ///          "data": [
+        ///            { "type": "tags", "id": "2" },
+        ///            { "type": "tags", "id": "3" }
+        ///          ]
+        ///        }
+        ///      }
+        ///    }
+        ///  }
+        /// </code>
+        /// </summary>
         HasManyRelationshipPointers HasManyRelationshipPointers { get; }
 
+        /// <summary>
+        /// If the request is a bulk json:api v1.1 operations request.
+        /// This is determined by the `
+        /// <see cref="JsonApiDotNetCore.Serialization.JsonApiDeSerializer" />` class.
+        /// 
+        /// See [json-api/1254](https://github.com/json-api/json-api/pull/1254) for details.
+        /// </summary>
+        bool IsBulkOperationRequest { get; set; }
+
+        /// <summary>
+        /// The `<see cref="ContextEntity" />`for the target route.
+        /// </summary>
+        /// 
+        /// <example>
+        /// For a `GET /articles` request, `RequestEntity` will be set
+        /// to the `Article` resource representation on the `JsonApiContext`.
+        /// </example>
+        ContextEntity RequestEntity { get; set; }
+
+        /// <summary>
+        /// The concrete type of the controller that was activated by the MVC routing middleware
+        /// </summary>
+        Type ControllerType { get; set; }
+
+        /// <summary>
+        /// The json:api meta data at the document level
+        /// </summary>
+        Dictionary<string, object> DocumentMeta { get; set; }
+
+        /// <summary>
+        /// If the request is on the `{id}/relationships/{relationshipName}` route
+        /// </summary>
+        bool IsRelationshipPath { get; }
+
+        [Obsolete("Use `IsRelationshipPath` instead.")]
+        bool IsRelationshipData { get; set; }
+    }
+
+    public interface IJsonApiContext : IJsonApiRequest
+    {
+        IJsonApiContext ApplyContext<T>(object controller);
+        IMetaBuilder MetaBuilder { get; set; }
+        IGenericProcessorFactory GenericProcessorFactory { get; set; }
+
+        [Obsolete("Use the proxied method IControllerContext.GetControllerAttribute instead.")]
         TAttribute GetControllerAttribute<TAttribute>() where TAttribute : Attribute;
     }
 }

--- a/src/JsonApiDotNetCore/Services/IJsonApiContext.cs
+++ b/src/JsonApiDotNetCore/Services/IJsonApiContext.cs
@@ -6,6 +6,7 @@ using JsonApiDotNetCore.Internal;
 using JsonApiDotNetCore.Internal.Generics;
 using JsonApiDotNetCore.Internal.Query;
 using JsonApiDotNetCore.Models;
+using JsonApiDotNetCore.Request;
 
 namespace JsonApiDotNetCore.Services
 {
@@ -28,6 +29,7 @@ namespace JsonApiDotNetCore.Services
         Type ControllerType { get; set; }
         Dictionary<string, object> DocumentMeta { get; set; }
         bool IsBulkOperationRequest { get; set; }
+        HasManyRelationshipPointers HasManyRelationshipPointers { get; }
 
         TAttribute GetControllerAttribute<TAttribute>() where TAttribute : Attribute;
     }

--- a/src/JsonApiDotNetCore/Services/JsonApiContext.cs
+++ b/src/JsonApiDotNetCore/Services/JsonApiContext.cs
@@ -6,6 +6,7 @@ using JsonApiDotNetCore.Internal;
 using JsonApiDotNetCore.Internal.Generics;
 using JsonApiDotNetCore.Internal.Query;
 using JsonApiDotNetCore.Models;
+using JsonApiDotNetCore.Request;
 using Microsoft.AspNetCore.Http;
 
 namespace JsonApiDotNetCore.Services
@@ -51,6 +52,7 @@ namespace JsonApiDotNetCore.Services
         public Type ControllerType { get; set; }
         public Dictionary<string, object> DocumentMeta { get; set; }
         public bool IsBulkOperationRequest { get; set; }
+        public HasManyRelationshipPointers HasManyRelationshipPointers { get; } = new HasManyRelationshipPointers();
 
         public IJsonApiContext ApplyContext<T>(object controller)
         {

--- a/test/UnitTests/Builders/DocumentBuilder_Tests.cs
+++ b/test/UnitTests/Builders/DocumentBuilder_Tests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using JsonApiDotNetCore.Builders;

--- a/test/UnitTests/Builders/MetaBuilderTests.cs
+++ b/test/UnitTests/Builders/MetaBuilderTests.cs
@@ -1,8 +1,8 @@
-using Xunit;
-using JsonApiDotNetCore.Builders;
 using System.Collections.Generic;
+using JsonApiDotNetCore.Builders;
+using Xunit;
 
-namespace JsonApiDotNetCoreExampleTests.Unit.Builders
+namespace UnitTests.Builders
 {
     public class MetaBuilderTests
     {

--- a/test/UnitTests/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/test/UnitTests/Extensions/IServiceCollectionExtensionsTests.cs
@@ -10,12 +10,11 @@ using JsonApiDotNetCore.Services;
 using JsonApiDotNetCoreExample.Data;
 using JsonApiDotNetCoreExample.Models;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
-using UnitTests;
 using Xunit;
+using Microsoft.EntityFrameworkCore;
 
-namespace JsonApiDotNetCoreExampleTests.Unit.Extensions
+namespace UnitTests.Extensions
 {
     public class IServiceCollectionExtensionsTests
     {
@@ -28,7 +27,7 @@ namespace JsonApiDotNetCoreExampleTests.Unit.Extensions
 
             services.AddDbContext<AppDbContext>(options =>
             {
-                options.UseMemoryCache(new MemoryCache(new MemoryCacheOptions()));
+                options.UseInMemoryDatabase();
             }, ServiceLifetime.Transient);
 
             // act

--- a/test/UnitTests/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/test/UnitTests/Extensions/IServiceCollectionExtensionsTests.cs
@@ -25,10 +25,7 @@ namespace UnitTests.Extensions
             var services = new ServiceCollection();
             var jsonApiOptions = new JsonApiOptions();
 
-            services.AddDbContext<AppDbContext>(options =>
-            {
-                options.UseInMemoryDatabase();
-            }, ServiceLifetime.Transient);
+            services.AddDbContext<AppDbContext>(options => options.UseInMemoryDatabase("UnitTestDb"), ServiceLifetime.Transient);
 
             // act
             services.AddJsonApiInternals<AppDbContext>(jsonApiOptions);

--- a/test/UnitTests/Extensions/TypeExtensions_Tests.cs
+++ b/test/UnitTests/Extensions/TypeExtensions_Tests.cs
@@ -1,7 +1,7 @@
+using System.Collections.Generic;
+using JsonApiDotNetCore.Extensions;
 using JsonApiDotNetCore.Models;
 using Xunit;
-using JsonApiDotNetCore.Extensions;
-using System.Collections.Generic;
 
 namespace UnitTests.Extensions
 {
@@ -14,7 +14,7 @@ namespace UnitTests.Extensions
             var type = typeof(Model);
 
             // act
-            var collection = type.GetEmptyCollection<IIdentifiable>();
+            var collection = type.GetEmptyCollection();
 
             // assert
             Assert.NotNull(collection);

--- a/test/UnitTests/Extensions/TypeExtensions_Tests.cs
+++ b/test/UnitTests/Extensions/TypeExtensions_Tests.cs
@@ -1,0 +1,44 @@
+using JsonApiDotNetCore.Models;
+using Xunit;
+using JsonApiDotNetCore.Extensions;
+using System.Collections.Generic;
+
+namespace UnitTests.Extensions
+{
+    public class TypeExtensions_Tests
+    {
+        [Fact]
+        public void GetCollection_Creates_List_If_T_Implements_Interface()
+        {
+            // arrange
+            var type = typeof(Model);
+
+            // act
+            var collection = type.GetEmptyCollection<IIdentifiable>();
+
+            // assert
+            Assert.NotNull(collection);
+            Assert.Empty(collection);
+            Assert.IsType<List<Model>>(collection);
+        }
+
+        [Fact]
+        public void New_Creates_An_Instance_If_T_Implements_Interface()
+        {
+            // arrange
+            var type = typeof(Model);
+
+            // act
+            var instance = type.New<IIdentifiable>();
+
+            // assert
+            Assert.NotNull(instance);
+            Assert.IsType<Model>(instance);
+        }
+
+        private class Model : IIdentifiable
+        {
+            public string StringId { get; set; }
+        }
+    }
+}

--- a/test/UnitTests/Models/AttributesEqualsTests.cs
+++ b/test/UnitTests/Models/AttributesEqualsTests.cs
@@ -1,7 +1,7 @@
 ﻿using JsonApiDotNetCore.Models;
 using Xunit;
 
-namespace JsonApiDotNetCoreExampleTests.Unit.Models
+namespace UnitTests.Models
 {
     public class AttributesEqualsTests
     {

--- a/test/UnitTests/Serialization/JsonApiDeSerializerTests.cs
+++ b/test/UnitTests/Serialization/JsonApiDeSerializerTests.cs
@@ -345,8 +345,6 @@ namespace UnitTests.Serialization
             public int IndependentId { get; set; }
         }
 
-
-
         [Fact]
         public void Can_Deserialize_Object_With_HasManyRelationship()
         {

--- a/test/UnitTests/Serialization/JsonApiDeSerializerTests.cs
+++ b/test/UnitTests/Serialization/JsonApiDeSerializerTests.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using JsonApiDotNetCore.Builders;
 using JsonApiDotNetCore.Configuration;
-using JsonApiDotNetCore.Internal.Generics;
 using JsonApiDotNetCore.Models;
+using JsonApiDotNetCore.Request;
 using JsonApiDotNetCore.Serialization;
 using JsonApiDotNetCore.Services;
 using Moq;
@@ -11,10 +11,13 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Xunit;
 
-namespace UnitTests.Serialization {
-    public class JsonApiDeSerializerTests {
+namespace UnitTests.Serialization
+{
+    public class JsonApiDeSerializerTests
+    {
         [Fact]
-        public void Can_Deserialize_Complex_Types() {
+        public void Can_Deserialize_Complex_Types()
+        {
             // arrange
             var contextGraphBuilder = new ContextGraphBuilder();
             contextGraphBuilder.AddResource<TestResource>("test-resource");
@@ -29,20 +32,18 @@ namespace UnitTests.Serialization {
             jsonApiOptions.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
             jsonApiContextMock.Setup(m => m.Options).Returns(jsonApiOptions);
 
-            var genericProcessorFactoryMock = new Mock<IGenericProcessorFactory>();
+            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object);
 
-            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object, genericProcessorFactoryMock.Object);
-
-            var content = new Document {
-                Data = new DocumentData {
-                Type = "test-resource",
-                Id = "1",
-                Attributes = new Dictionary<string, object> {
+            var content = new Document
+            {
+                Data = new DocumentData
                 {
-                "complex-member",
-                new { compoundName = "testName" }
-                }
-                }
+                    Type = "test-resource",
+                    Id = "1",
+                    Attributes = new Dictionary<string, object>
+                    {
+                        { "complex-member", new { compoundName = "testName" } }
+                    }
                 }
             };
 
@@ -55,7 +56,8 @@ namespace UnitTests.Serialization {
         }
 
         [Fact]
-        public void Can_Deserialize_Complex_List_Types() {
+        public void Can_Deserialize_Complex_List_Types()
+        {
             // arrange
             var contextGraphBuilder = new ContextGraphBuilder();
             contextGraphBuilder.AddResource<TestResourceWithList>("test-resource");
@@ -69,22 +71,18 @@ namespace UnitTests.Serialization {
             jsonApiOptions.SerializerSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
             jsonApiContextMock.Setup(m => m.Options).Returns(jsonApiOptions);
 
-            var genericProcessorFactoryMock = new Mock<IGenericProcessorFactory>();
+            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object);
 
-            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object, genericProcessorFactoryMock.Object);
-
-            var content = new Document {
-                Data = new DocumentData {
-                Type = "test-resource",
-                Id = "1",
-                Attributes = new Dictionary<string, object> {
+            var content = new Document
+            {
+                Data = new DocumentData
                 {
-                "complex-members",
-                new [] {
-                new { compoundName = "testName" }
-                }
-                }
-                }
+                    Type = "test-resource",
+                    Id = "1",
+                    Attributes = new Dictionary<string, object>
+                    {
+                        { "complex-members", new [] { new { compoundName = "testName" } } }
+                    }
                 }
             };
 
@@ -98,7 +96,8 @@ namespace UnitTests.Serialization {
         }
 
         [Fact]
-        public void Can_Deserialize_Complex_Types_With_Dasherized_Attrs() {
+        public void Can_Deserialize_Complex_Types_With_Dasherized_Attrs()
+        {
             // arrange
             var contextGraphBuilder = new ContextGraphBuilder();
             contextGraphBuilder.AddResource<TestResource>("test-resource");
@@ -113,20 +112,20 @@ namespace UnitTests.Serialization {
             jsonApiOptions.SerializerSettings.ContractResolver = new DasherizedResolver(); // <--
             jsonApiContextMock.Setup(m => m.Options).Returns(jsonApiOptions);
 
-            var genericProcessorFactoryMock = new Mock<IGenericProcessorFactory>();
+            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object);
 
-            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object, genericProcessorFactoryMock.Object);
-
-            var content = new Document {
-                Data = new DocumentData {
-                Type = "test-resource",
-                Id = "1",
-                Attributes = new Dictionary<string, object> {
+            var content = new Document
+            {
+                Data = new DocumentData
                 {
-                "complex-member",
-                new Dictionary<string, string> { { "compound-name", "testName" } }
-                }
-                }
+                    Type = "test-resource",
+                    Id = "1",
+                    Attributes = new Dictionary<string, object>
+                    {
+                        {
+                            "complex-member", new Dictionary<string, string> { { "compound-name", "testName" } }
+                        }
+                    }
                 }
             };
 
@@ -139,7 +138,8 @@ namespace UnitTests.Serialization {
         }
 
         [Fact]
-        public void Immutable_Attrs_Are_Not_Included_In_AttributesToUpdate() {
+        public void Immutable_Attrs_Are_Not_Included_In_AttributesToUpdate()
+        {
             // arrange
             var contextGraphBuilder = new ContextGraphBuilder();
             contextGraphBuilder.AddResource<TestResource>("test-resource");
@@ -156,22 +156,21 @@ namespace UnitTests.Serialization {
             jsonApiOptions.SerializerSettings.ContractResolver = new DasherizedResolver();
             jsonApiContextMock.Setup(m => m.Options).Returns(jsonApiOptions);
 
-            var genericProcessorFactoryMock = new Mock<IGenericProcessorFactory>();
+            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object);
 
-            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object, genericProcessorFactoryMock.Object);
-
-            var content = new Document {
-                Data = new DocumentData {
-                Type = "test-resource",
-                Id = "1",
-                Attributes = new Dictionary<string, object> {
+            var content = new Document
+            {
+                Data = new DocumentData
                 {
-                "complex-member",
-                new Dictionary<string, string> { { "compound-name", "testName" }
-                }
-                },
-                { "immutable", "value" }
-                }
+                    Type = "test-resource",
+                    Id = "1",
+                    Attributes = new Dictionary<string, object>
+                    {
+                        {
+                            "complex-member", new Dictionary<string, string> { { "compound-name", "testName" } }
+                        },
+                        { "immutable", "value" }
+                    }
                 }
             };
 
@@ -189,7 +188,8 @@ namespace UnitTests.Serialization {
         }
 
         [Fact]
-        public void Can_Deserialize_Independent_Side_Of_One_To_One_Relationship() {
+        public void Can_Deserialize_Independent_Side_Of_One_To_One_Relationship()
+        {
             // arrange
             var contextGraphBuilder = new ContextGraphBuilder();
             contextGraphBuilder.AddResource<Independent>("independents");
@@ -204,17 +204,16 @@ namespace UnitTests.Serialization {
             var jsonApiOptions = new JsonApiOptions();
             jsonApiContextMock.Setup(m => m.Options).Returns(jsonApiOptions);
 
-            var genericProcessorFactoryMock = new Mock<IGenericProcessorFactory>();
-
-            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object, genericProcessorFactoryMock.Object);
+            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object);
 
             var property = Guid.NewGuid().ToString();
-            var content = new Document {
-                Data = new DocumentData {
-                Type = "independents",
-                Id = "1",
-                Attributes = new Dictionary<string, object> { { "property", property }
-                }
+            var content = new Document
+            {
+                Data = new DocumentData
+                {
+                    Type = "independents",
+                    Id = "1",
+                    Attributes = new Dictionary<string, object> { { "property", property } }
                 }
             };
 
@@ -229,7 +228,8 @@ namespace UnitTests.Serialization {
         }
 
         [Fact]
-        public void Can_Deserialize_Independent_Side_Of_One_To_One_Relationship_With_Relationship_Body() {
+        public void Can_Deserialize_Independent_Side_Of_One_To_One_Relationship_With_Relationship_Body()
+        {
             // arrange
             var contextGraphBuilder = new ContextGraphBuilder();
             contextGraphBuilder.AddResource<Independent>("independents");
@@ -244,20 +244,18 @@ namespace UnitTests.Serialization {
             var jsonApiOptions = new JsonApiOptions();
             jsonApiContextMock.Setup(m => m.Options).Returns(jsonApiOptions);
 
-            var genericProcessorFactoryMock = new Mock<IGenericProcessorFactory>();
-
-            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object, genericProcessorFactoryMock.Object);
+            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object);
 
             var property = Guid.NewGuid().ToString();
-            var content = new Document {
-                Data = new DocumentData {
-                Type = "independents",
-                Id = "1",
-                Attributes = new Dictionary<string, object> { { "property", property }
-                },
-                // a common case for this is deserialization in unit tests
-                Relationships = new Dictionary<string, RelationshipData> { { "dependent", new RelationshipData { } }
-                }
+            var content = new Document
+            {
+                Data = new DocumentData
+                {
+                    Type = "independents",
+                    Id = "1",
+                    Attributes = new Dictionary<string, object> { { "property", property } },
+                    // a common case for this is deserialization in unit tests
+                    Relationships = new Dictionary<string, RelationshipData> { { "dependent", new RelationshipData { } } }
                 }
             };
 
@@ -288,24 +286,21 @@ namespace UnitTests.Serialization {
             var jsonApiOptions = new JsonApiOptions();
             jsonApiContextMock.Setup(m => m.Options).Returns(jsonApiOptions);
 
-            var genericProcessorFactoryMock = new Mock<IGenericProcessorFactory>();
 
-            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object, genericProcessorFactoryMock.Object);
+            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object);
 
             var property = Guid.NewGuid().ToString();
-            
+
             var content = new Document
-            {   
-                Meta = new Dictionary<string, object>() { {"foo", "bar"}},
+            {
+                Meta = new Dictionary<string, object>() { { "foo", "bar" } },
                 Data = new DocumentData
                 {
                     Type = "independents",
                     Id = "1",
-                    Attributes = new Dictionary<string, object> { { "property", property }
-                    },
+                    Attributes = new Dictionary<string, object> { { "property", property } },
                     // a common case for this is deserialization in unit tests
-                    Relationships = new Dictionary<string, RelationshipData> { { "dependent", new RelationshipData { } }
-                    }
+                    Relationships = new Dictionary<string, RelationshipData> { { "dependent", new RelationshipData { } } }
                 }
             };
 
@@ -318,32 +313,102 @@ namespace UnitTests.Serialization {
             jsonApiContextMock.VerifySet(mock => mock.DocumentMeta = content.Meta);
         }
 
-
-        private class TestResource : Identifiable {
+        private class TestResource : Identifiable
+        {
             [Attr("complex-member")]
             public ComplexType ComplexMember { get; set; }
 
-            [Attr("immutable", isImmutable : true)]
+            [Attr("immutable", isImmutable: true)]
             public string Immutable { get; set; }
         }
 
-        private class TestResourceWithList : Identifiable {
+        private class TestResourceWithList : Identifiable
+        {
             [Attr("complex-members")]
             public List<ComplexType> ComplexMembers { get; set; }
         }
 
-        private class ComplexType {
+        private class ComplexType
+        {
             public string CompoundName { get; set; }
         }
 
-        private class Independent : Identifiable {
+        private class Independent : Identifiable
+        {
             [Attr("property")] public string Property { get; set; }
             [HasOne("dependent")] public Dependent Dependent { get; set; }
         }
 
-        private class Dependent : Identifiable {
+        private class Dependent : Identifiable
+        {
             [HasOne("independent")] public Independent Independent { get; set; }
             public int IndependentId { get; set; }
+        }
+
+
+
+        [Fact]
+        public void Can_Deserialize_Object_With_HasManyRelationship()
+        {
+            // arrange
+            var contextGraphBuilder = new ContextGraphBuilder();
+            contextGraphBuilder.AddResource<OneToManyIndependent>("independents");
+            contextGraphBuilder.AddResource<OneToManyDependent>("dependents");
+            var contextGraph = contextGraphBuilder.Build();
+
+            var jsonApiContextMock = new Mock<IJsonApiContext>();
+            jsonApiContextMock.SetupAllProperties();
+            jsonApiContextMock.Setup(m => m.ContextGraph).Returns(contextGraph);
+            jsonApiContextMock.Setup(m => m.AttributesToUpdate).Returns(new Dictionary<AttrAttribute, object>());
+            jsonApiContextMock.Setup(m => m.HasManyRelationshipPointers).Returns(new HasManyRelationshipPointers());
+
+            var jsonApiOptions = new JsonApiOptions();
+            jsonApiContextMock.Setup(m => m.Options).Returns(jsonApiOptions);
+
+            var deserializer = new JsonApiDeSerializer(jsonApiContextMock.Object);
+
+            var contentString =
+            @"{
+                ""data"": {
+                    ""type"": ""independents"",
+                    ""id"": ""1"",
+                    ""attributes"": { },
+                    ""relationships"": {
+                        ""dependents"": {
+                            ""data"": [
+                                {
+                                    ""type"": ""dependents"",
+                                    ""id"": ""2""
+                                }
+                            ]
+                        }
+                    }
+                }
+            }";
+
+            // act
+            var result = deserializer.Deserialize<OneToManyIndependent>(contentString);
+
+            // assert
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Id);
+            Assert.NotNull(result.Dependents);
+            Assert.NotEmpty(result.Dependents);
+            Assert.Equal(1, result.Dependents.Count);
+
+            var dependent = result.Dependents[0];
+            Assert.Equal(2, dependent.Id);
+        }
+
+        private class OneToManyDependent : Identifiable
+        {
+            [HasOne("independent")] public OneToManyIndependent Independent { get; set; }
+            public int IndependentId { get; set; }
+        }
+
+        private class OneToManyIndependent : Identifiable
+        {
+            [HasMany("dependents")] public List<OneToManyDependent> Dependents { get; set; }
         }
     }
 }

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -12,5 +12,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="$(XUnitVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #237
Closes #282 

Rather than fetching data from the database during deserialization, we can set the relationships with instances that just carry the id. It will then be the responsibility of the repository to handle those relationships

#### TODO:

- [x] Decouple deserializer and IGenericProcessorFactory
- [x] Set HasOne.HasManies = new List<HasMany> { new HasMany { Id = id } };
- [x] Update relationships in the Repository
- [x] Add test for #237
- [x] Add test for bug described by https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/282#issuecomment-390759282
- [x] Fix https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/282#issuecomment-390759282
- [x] Bump package version (2.2.5)

Current version is available on the pre-release feed:

```ps
Install-Package JsonApiDotNetCore -Version 2.2.5-alpha1-0086 -Source https://www.myget.org/F/research-institute/api/v3/index.json
```
