### PR TITLE
Fix the return variable for the Resource Services doc

### DIFF
--- a/docs/ResourceServices.md
+++ b/docs/ResourceServices.md
@@ -37,7 +37,7 @@ public class TodoItemService : EntityResourceService<TodoItem> {
         _notificationService.Notify($"Entity created: { newEntity.Id }");
 
         // don't forget to return the new entity
-        return entity;
+        return newEntity;
     }
 }
 ```


### PR DESCRIPTION
In the code sample on the Resource Services documentation, it was returning the wrong variable.