### PR TITLE
#218 Defaults data to be included in relationships rather than only w…

### DIFF
--- a/src/JsonApiDotNetCore/Builders/DocumentBuilder.cs
+++ b/src/JsonApiDotNetCore/Builders/DocumentBuilder.cs
@@ -158,20 +158,17 @@ namespace JsonApiDotNetCore.Builders
                     if (r.DocumentLinks.HasFlag(Link.Related))
                         relationshipData.Links.Related = linkBuilder.GetRelatedRelationLink(contextEntity.EntityName, entity.StringId, r.PublicRelationshipName);
                 }
+                
+                var navigationEntity = _jsonApiContext.ContextGraph
+                    .GetRelationship(entity, r.InternalRelationshipName);
 
-                if (RelationshipIsIncluded(r.PublicRelationshipName))
-                {
-                    var navigationEntity = _jsonApiContext.ContextGraph
-                        .GetRelationship(entity, r.InternalRelationshipName);
-
-                    if (navigationEntity == null)
-                        relationshipData.SingleData = null;
-                    else if (navigationEntity is IEnumerable)
-                        relationshipData.ManyData = GetRelationships((IEnumerable<object>)navigationEntity);
-                    else
-                        relationshipData.SingleData = GetRelationship(navigationEntity);
-                }
-
+                if (navigationEntity == null)
+                    relationshipData.SingleData = null;
+                else if (navigationEntity is IEnumerable)
+                    relationshipData.ManyData = GetRelationships((IEnumerable<object>)navigationEntity);
+                else
+                    relationshipData.SingleData = GetRelationship(navigationEntity);
+                
                 data.Relationships.Add(r.PublicRelationshipName, relationshipData);
             });
         }

--- a/test/UnitTests/Builders/DocumentBuilder_Tests.cs
+++ b/test/UnitTests/Builders/DocumentBuilder_Tests.cs
@@ -60,7 +60,7 @@ namespace UnitTests
         [Fact]
         public void Includes_Paging_Links_By_Default()
         {
-            // arrange            
+            // arrange
             _pageManager.PageSize = 1;
             _pageManager.TotalRecords = 1;
             _pageManager.CurrentPage = 1;
@@ -126,7 +126,8 @@ namespace UnitTests
         public void Related_Data_Included_In_Relationships_By_Default()
         {
             // arrange
-            const string relationshipName = "related-models";
+            const string relatedTypeName = "related-models";
+            const string relationshipName = "related-model";
             const int relatedId = 1;
             _jsonApiContextMock
                 .Setup(m => m.ContextGraph)
@@ -150,7 +151,7 @@ namespace UnitTests
             Assert.NotNull(relationshipData.SingleData);
             Assert.NotNull(relationshipData.SingleData);
             Assert.Equal(relatedId.ToString(), relationshipData.SingleData.Id);
-            Assert.Equal(relationshipName, relationshipData.SingleData.Type);
+            Assert.Equal(relatedTypeName, relationshipData.SingleData.Type);
         }
 
         [Fact]
@@ -177,12 +178,12 @@ namespace UnitTests
 
 
         [Theory]
-        [InlineData(null,null,true)]
-        [InlineData(false,null,true)]
-        [InlineData(true,null,false)]
-        [InlineData(null,"foo",true)]
-        [InlineData(false,"foo",true)]
-        [InlineData(true,"foo",true)]
+        [InlineData(null, null, true)]
+        [InlineData(false, null, true)]
+        [InlineData(true, null, false)]
+        [InlineData(null, "foo", true)]
+        [InlineData(false, "foo", true)]
+        [InlineData(true, "foo", true)]
         public void DocumentBuilderOptions(bool? omitNullValuedAttributes,
             string attributeValue,
             bool resultContainsAttribute)
@@ -194,7 +195,7 @@ namespace UnitTests
                     .Returns(new DocumentBuilderOptions(omitNullValuedAttributes.Value));
             }
             var documentBuilder = new DocumentBuilder(_jsonApiContextMock.Object, null, omitNullValuedAttributes.HasValue ? documentBuilderBehaviourMock.Object : null);
-            var document = documentBuilder.Build(new Model(){StringProperty = attributeValue});
+            var document = documentBuilder.Build(new Model() { StringProperty = attributeValue });
 
             Assert.Equal(resultContainsAttribute, document.Data.Attributes.ContainsKey("StringProperty"));
         }

--- a/test/UnitTests/Builders/DocumentBuilder_Tests.cs
+++ b/test/UnitTests/Builders/DocumentBuilder_Tests.cs
@@ -28,6 +28,7 @@ namespace UnitTests
             _options.BuildContextGraph(builder =>
             {
                 builder.AddResource<Model>("models");
+                builder.AddResource<RelatedModel>("related-models");
             });
 
             _jsonApiContextMock
@@ -119,6 +120,37 @@ namespace UnitTests
 
             // assert
             Assert.Null(document.Data.Relationships["related-model"].Links);
+        }
+
+        [Fact]
+        public void Related_Data_Included_In_Relationships_By_Default()
+        {
+            // arrange
+            const string relationshipName = "related-models";
+            const int relatedId = 1;
+            _jsonApiContextMock
+                .Setup(m => m.ContextGraph)
+                .Returns(_options.ContextGraph);
+
+            var documentBuilder = new DocumentBuilder(_jsonApiContextMock.Object);
+            var entity = new Model
+            {
+                RelatedModel = new RelatedModel
+                {
+                    Id = relatedId
+                }
+            };
+
+            // act
+            var document = documentBuilder.Build(entity);
+
+            // assert
+            var relationshipData = document.Data.Relationships[relationshipName];
+            Assert.NotNull(relationshipData);
+            Assert.NotNull(relationshipData.SingleData);
+            Assert.NotNull(relationshipData.SingleData);
+            Assert.Equal(relatedId.ToString(), relationshipData.SingleData.Id);
+            Assert.Equal(relationshipName, relationshipData.SingleData.Type);
         }
 
         [Fact]


### PR DESCRIPTION
"data" element for relationships included on all responses regardless if an "include" for that relationship was sent in the request.

Closes #218 

#### FEATURE
- [x] write tests that address the requirements outlined in the issue
- [x] fulfill the feature requirements
- [ ] bump package version
