### PR TITLE
Add IN filter operation for array searching

### DIFF
--- a/src/JsonApiDotNetCore/Internal/Query/FilterOperations.cs
+++ b/src/JsonApiDotNetCore/Internal/Query/FilterOperations.cs
@@ -9,6 +9,7 @@ namespace JsonApiDotNetCore.Internal.Query
         le = 3,
         ge = 4,
         like = 5,
-        ne = 6
+        ne = 6,
+        @in = 7, // prefix with @ to use keyword
     }
 }

--- a/src/JsonApiDotNetCore/Internal/TypeHelper.cs
+++ b/src/JsonApiDotNetCore/Internal/TypeHelper.cs
@@ -63,19 +63,15 @@ namespace JsonApiDotNetCore.Internal
         /// <param name="values">Collection like ["10","20","30"]</param>
         /// <param name="type">Non array type. For e.g. int</param>
         /// <returns>Collection of concrete type</returns>
-        public static object ConvertListType(IEnumerable<string> values, Type type)
+        public static IList ConvertListType(IEnumerable<string> values, Type type)
         {
-            var convertedArray = new List<object>();
-            foreach (var value in values)
-            {
-                convertedArray.Add(ConvertType(value, type));
-            }
             var listType = typeof(List<>).MakeGenericType(type);
             IList list = (IList)Activator.CreateInstance(listType);
-            foreach (var item in convertedArray)
+            foreach (var value in values)
             {
-                list.Add(item);
+                list.Add(ConvertType(value, type));
             }
+
             return list;
         }
     }

--- a/src/JsonApiDotNetCore/Internal/TypeHelper.cs
+++ b/src/JsonApiDotNetCore/Internal/TypeHelper.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace JsonApiDotNetCore.Internal
@@ -53,6 +55,28 @@ namespace JsonApiDotNetCore.Internal
         public static T ConvertType<T>(object value)
         {
             return (T)ConvertType(value, typeof(T));
+        }
+
+        /// <summary>
+        /// Convert collection of query string params to Collection of concrete Type
+        /// </summary>
+        /// <param name="values">Collection like ["10","20","30"]</param>
+        /// <param name="type">Non array type. For e.g. int</param>
+        /// <returns>Collection of concrete type</returns>
+        public static object ConvertListType(IEnumerable<string> values, Type type)
+        {
+            var convertedArray = new List<object>();
+            foreach (var value in values)
+            {
+                convertedArray.Add(ConvertType(value, type));
+            }
+            var listType = typeof(List<>).MakeGenericType(type);
+            IList list = (IList)Activator.CreateInstance(listType);
+            foreach (var item in convertedArray)
+            {
+                list.Add(item);
+            }
+            return list;
         }
     }
 }

--- a/src/JsonApiDotNetCore/Services/QueryParser.cs
+++ b/src/JsonApiDotNetCore/Services/QueryParser.cs
@@ -85,8 +85,8 @@ namespace JsonApiDotNetCore.Services
             var propertyName = key.Split(QueryConstants.OPEN_BRACKET, QueryConstants.CLOSE_BRACKET)[1];
 
             // InArray case
-            var op = GetFilterOperation(value);
-            if (op == FilterOperations.@in.ToString())
+            string op = GetFilterOperation(value);
+            if (string.Equals(op, FilterOperations.@in.ToString(), StringComparison.OrdinalIgnoreCase))
             {
                 (var operation, var filterValue) = ParseFilterOperation(value);
                 queries.Add(new FilterQuery(propertyName, filterValue, op));
@@ -232,16 +232,17 @@ namespace JsonApiDotNetCore.Services
 
         private string GetFilterOperation(string value)
         {
-            var operation = value.Split(QueryConstants.COLON);
+            var values = value.Split(QueryConstants.COLON);
 
-            if (operation.Length == 1)
+            if (values.Length == 1)
                 return string.Empty;
 
+            var operation = values[0];
             // remove prefix from value
-            if (Enum.TryParse(operation[0], out FilterOperations op) == false)
+            if (Enum.TryParse(operation, out FilterOperations op) == false)
                 return string.Empty;
 
-            return operation[0];
+            return operation;
         }
 
         private FilterQuery BuildFilterQuery(ReadOnlySpan<char> query, string propertyName)

--- a/src/JsonApiDotNetCore/Services/QueryParser.cs
+++ b/src/JsonApiDotNetCore/Services/QueryParser.cs
@@ -82,14 +82,23 @@ namespace JsonApiDotNetCore.Services
             // expected input = filter[id]=1
             // expected input = filter[id]=eq:1
             var queries = new List<FilterQuery>();
-
             var propertyName = key.Split(QueryConstants.OPEN_BRACKET, QueryConstants.CLOSE_BRACKET)[1];
 
-            var values = value.Split(QueryConstants.COMMA);
-            foreach (var val in values)
+            // InArray case
+            var op = GetFilterOperation(value);
+            if (op == FilterOperations.@in.ToString())
             {
-                (var operation, var filterValue) = ParseFilterOperation(val);
-                queries.Add(new FilterQuery(propertyName, filterValue, operation));
+                (var operation, var filterValue) = ParseFilterOperation(value);
+                queries.Add(new FilterQuery(propertyName, filterValue, op));
+            }
+            else
+            {
+                var values = value.Split(QueryConstants.COMMA);
+                foreach (var val in values)
+                {
+                    (var operation, var filterValue) = ParseFilterOperation(val);
+                    queries.Add(new FilterQuery(propertyName, filterValue, operation));
+                }
             }
 
             return queries;
@@ -100,19 +109,15 @@ namespace JsonApiDotNetCore.Services
             if (value.Length < 3)
                 return (string.Empty, value);
 
-            var operation = value.Split(QueryConstants.COLON);
+            var operation = GetFilterOperation(value);
+            var values = value.Split(QueryConstants.COLON);
 
-            if (operation.Length == 1)
+            if (string.IsNullOrEmpty(operation))
                 return (string.Empty, value);
 
-            // remove prefix from value
-            if (Enum.TryParse(operation[0], out FilterOperations op) == false)
-                return (string.Empty, value);
+            value = string.Join(QueryConstants.COLON_STR, values.Skip(1));
 
-            var prefix = operation[0];
-            value = string.Join(QueryConstants.COLON_STR, operation.Skip(1));
-
-            return (prefix, value);
+            return (operation, value);
         }
 
         protected virtual PageQuery ParsePageQuery(PageQuery pageQuery, string key, string value)
@@ -223,6 +228,20 @@ namespace JsonApiDotNetCore.Services
             {
                 throw new JsonApiException(400, $"Attribute '{propertyName}' does not exist on resource '{_controllerContext.RequestEntity.EntityName}'", e);
             }
+        }
+
+        private string GetFilterOperation(string value)
+        {
+            var operation = value.Split(QueryConstants.COLON);
+
+            if (operation.Length == 1)
+                return string.Empty;
+
+            // remove prefix from value
+            if (Enum.TryParse(operation[0], out FilterOperations op) == false)
+                return string.Empty;
+
+            return operation[0];
         }
 
         private FilterQuery BuildFilterQuery(ReadOnlySpan<char> query, string propertyName)

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/AttributeFilterTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/AttributeFilterTests.cs
@@ -139,12 +139,17 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
         {
             // arrange
             var context = _fixture.GetService<AppDbContext>();
-            var todoItems = _todoItemFaker.Generate(3);
+            var todoItems = _todoItemFaker.Generate(5);
             var guids = new List<Guid>();
+            var notInGuids = new List<Guid>();
             foreach (var item in todoItems)
             {
                 context.TodoItems.Add(item);
-                guids.Add(item.GuidProperty);
+                // Exclude 2 items
+                if (guids.Count < (todoItems.Count() - 2))
+                    guids.Add(item.GuidProperty);
+                else 
+                    notInGuids.Add(item.GuidProperty);
             }
             context.SaveChanges();
 
@@ -164,7 +169,10 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(guids.Count(), deserializedTodoItems.Count());
             foreach (var item in deserializedTodoItems)
+            {
                 Assert.True(guids.Contains(item.GuidProperty));
+                Assert.False(notInGuids.Contains(item.GuidProperty));
+            }
         }
 
         [Fact]

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/AttributeFilterTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/AttributeFilterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -8,6 +9,7 @@ using JsonApiDotNetCore.Models;
 using JsonApiDotNetCore.Serialization;
 using JsonApiDotNetCoreExample.Data;
 using JsonApiDotNetCoreExample.Models;
+using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using Xunit;
 using Person = JsonApiDotNetCoreExample.Models.Person;
@@ -130,6 +132,75 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             // assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.False(deserializedTodoItems.Any(i => i.Ordinal == todoItem.Ordinal));
+        }
+
+        [Fact]
+        public async Task Can_Filter_On_In_Array_Values()
+        {
+            // arrange
+            var context = _fixture.GetService<AppDbContext>();
+            var todoItems = _todoItemFaker.Generate(3);
+            var guids = new List<Guid>();
+            foreach (var item in todoItems)
+            {
+                context.TodoItems.Add(item);
+                guids.Add(item.GuidProperty);
+            }
+            context.SaveChanges();
+
+            var totalCount = context.TodoItems.Count();
+            var httpMethod = new HttpMethod("GET");
+            var route = $"/api/v1/todo-items?filter[guid-property]=in:{string.Join(",", guids)}";
+            var request = new HttpRequestMessage(httpMethod, route);
+
+            // act
+            var response = await _fixture.Client.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            var deserializedTodoItems = _fixture
+                .GetService<IJsonApiDeSerializer>()
+                .DeserializeList<TodoItem>(body);
+
+            // assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(guids.Count(), deserializedTodoItems.Count());
+            foreach (var item in deserializedTodoItems)
+                Assert.True(guids.Contains(item.GuidProperty));
+        }
+
+        [Fact]
+        public async Task Can_Filter_On_Related_In_Array_Values()
+        {
+            // arrange
+            var context = _fixture.GetService<AppDbContext>();
+            var todoItems = _todoItemFaker.Generate(3);
+            var ownerFirstNames = new List<string>();
+            foreach (var item in todoItems)
+            {
+                var person = _personFaker.Generate();
+                ownerFirstNames.Add(person.FirstName);
+                item.Owner = person;
+                context.TodoItems.Add(item);               
+            }
+            context.SaveChanges();
+
+            var httpMethod = new HttpMethod("GET");
+            var route = $"/api/v1/todo-items?include=owner&filter[owner.first-name]=in:{string.Join(",", ownerFirstNames)}";
+            var request = new HttpRequestMessage(httpMethod, route);
+
+            // act
+            var response = await _fixture.Client.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            var documents = JsonConvert.DeserializeObject<Documents>(await response.Content.ReadAsStringAsync());
+            var included = documents.Included;
+
+            // assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(ownerFirstNames.Count(), documents.Data.Count());
+            Assert.NotNull(included);
+            Assert.NotEmpty(included);
+            foreach (var item in included)
+                Assert.True(ownerFirstNames.Contains(item.Attributes["first-name"]));
+
         }
     }
 }


### PR DESCRIPTION
Add new IN filtering options:
a) "?filter[attribute]=in:value1,value2,value3"
b) "?include=relation&filter[relation.attribute]=in:value1,value2,value3"

Edited files:
1) FilterOperations. Only added @in value to enum.
2) IQueryableExtensions. IN operation can´t be handled in standard Expression builder as other properties, so I created new ArrayContainsPredicate() handler, to build predicate like this
`Items.Where(i => array.Contains(i.attribute))` which is translated to SQL as WHERE IN clause.
3) TypeHelper. There is new ConvertListType method, which is only helper method for ArrayContainsPredicate()
4) QueryParser. There is new method GetFilterOperation(). It is shared for standard and IN filter operations. In case of IN, value can't be comma separated, so whole IN value is send as one FilterQuery and then converted to array in Filter() method of IQueryableExtensions class.
5) There are two acceptance tests for attribute test case and for included relationship test case.

I'll be glad for your feedback
