### PR TITLE
Make `AddJsonApi` chainable

### DIFF
--- a/src/Examples/JsonApiDotNetCoreExample/Startup.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Startup.cs
@@ -29,19 +29,16 @@ namespace JsonApiDotNetCoreExample
         {
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddConsole(LogLevel.Trace);
-            services.AddSingleton<ILoggerFactory>(loggerFactory);
 
-            services.AddDbContext<AppDbContext>(options =>
-            {
-                options.UseNpgsql(GetDbConnectionString());
-            }, ServiceLifetime.Transient);
-
-            services.AddJsonApi<AppDbContext>(opt =>
-            {
-                opt.Namespace = "api/v1";
-                opt.DefaultPageSize = 5;
-                opt.IncludeTotalRecordCount = true;
-            });
+            services
+                .AddSingleton<ILoggerFactory>(loggerFactory)
+                .AddDbContext<AppDbContext>(options =>
+                    options.UseNpgsql(GetDbConnectionString()), ServiceLifetime.Transient)
+                .AddJsonApi<AppDbContext>(options => {
+                    options.Namespace = "api/v1";
+                    options.DefaultPageSize = 5;
+                    options.IncludeTotalRecordCount = true;
+                });
 
             var provider = services.BuildServiceProvider();
             var appContext = provider.GetRequiredService<AppDbContext>();

--- a/src/JsonApiDotNetCore/Extensions/IServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IServiceCollectionExtensions.cs
@@ -20,21 +20,21 @@ namespace JsonApiDotNetCore.Extensions
     // ReSharper disable once InconsistentNaming
     public static class IServiceCollectionExtensions
     {
-        public static void AddJsonApi<TContext>(this IServiceCollection services)
+        public static IServiceCollection AddJsonApi<TContext>(this IServiceCollection services)
             where TContext : DbContext
         {
             var mvcBuilder = services.AddMvc();
-            AddJsonApi<TContext>(services, (opt) => { }, mvcBuilder);
+            return AddJsonApi<TContext>(services, (opt) => { }, mvcBuilder);
         }
 
-        public static void AddJsonApi<TContext>(this IServiceCollection services, Action<JsonApiOptions> options)
+        public static IServiceCollection AddJsonApi<TContext>(this IServiceCollection services, Action<JsonApiOptions> options)
             where TContext : DbContext
         {
             var mvcBuilder = services.AddMvc();
-            AddJsonApi<TContext>(services, options, mvcBuilder);
+            return AddJsonApi<TContext>(services, options, mvcBuilder);
         }
 
-        public static void AddJsonApi<TContext>(this IServiceCollection services,
+        public static IServiceCollection AddJsonApi<TContext>(this IServiceCollection services,
            Action<JsonApiOptions> options,
            IMvcBuilder mvcBuilder) where TContext : DbContext
         {
@@ -52,9 +52,10 @@ namespace JsonApiDotNetCore.Extensions
                 });
 
             AddJsonApiInternals<TContext>(services, config);
+            return services;
         }
 
-        public static void AddJsonApi(this IServiceCollection services,
+        public static IServiceCollection AddJsonApi(this IServiceCollection services,
             Action<JsonApiOptions> options,
             IMvcBuilder mvcBuilder)
         {
@@ -70,6 +71,7 @@ namespace JsonApiDotNetCore.Extensions
                 });
 
             AddJsonApiInternals(services, config);
+            return services;
         }
 
         public static void AddJsonApiInternals<TContext>(

--- a/test/JsonApiDotNetCoreExampleTests/Helpers/Startups/MetaStartup.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Helpers/Startups/MetaStartup.cs
@@ -20,25 +20,18 @@ namespace JsonApiDotNetCoreExampleTests.Startups
         public override IServiceProvider ConfigureServices(IServiceCollection services)
         {
             var loggerFactory = new LoggerFactory();
+            loggerFactory.AddConsole(LogLevel.Trace);
 
-            loggerFactory
-              .AddConsole(LogLevel.Trace);
-
-            services.AddSingleton<ILoggerFactory>(loggerFactory);
-
-            services.AddDbContext<AppDbContext>(options =>
-            {
-                options.UseNpgsql(GetDbConnectionString());
-            }, ServiceLifetime.Transient);
-
-            services.AddJsonApi<AppDbContext>(opt =>
-            {
-                opt.Namespace = "api/v1";
-                opt.DefaultPageSize = 5;
-                opt.IncludeTotalRecordCount = true;
-            });
-
-            services.AddScoped<IRequestMeta, MetaService>();
+            services
+                .AddSingleton<ILoggerFactory>(loggerFactory)
+                .AddDbContext<AppDbContext>(options => 
+                    options.UseNpgsql(GetDbConnectionString()), ServiceLifetime.Transient)
+                .AddJsonApi<AppDbContext>(options => {
+                    options.Namespace = "api/v1";
+                    options.DefaultPageSize = 5;
+                    options.IncludeTotalRecordCount = true;
+                })
+                .AddScoped<IRequestMeta, MetaService>();
 
             return services.BuildServiceProvider();
         }


### PR DESCRIPTION
Currently, it is not possible to chain `AddJsonApi`:
`services.AddJsonApi<DbContext>().AddMvcCore()`

It should be, to be inline with all other apis (including all Microsoft).

It's not a breaking change. I've modified the example application and a test to use it.

I also thought about adding it to `AddJsonApiInternals` but that should be private - seems like it will be in the future.