### PR TITLE
Feature/#252 valid modelstate

### DIFF
--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using JsonApiDotNetCore.Extensions;
 using JsonApiDotNetCore.Internal;
 using JsonApiDotNetCore.Models;
 using JsonApiDotNetCore.Services;
@@ -152,6 +153,7 @@ namespace JsonApiDotNetCore.Controllers
 
             if (!_jsonApiContext.Options.AllowClientGeneratedIds && !string.IsNullOrEmpty(entity.StringId))
                 return Forbidden();
+            if (!ModelState.IsValid) return BadRequest(ModelState.ConvertToErrorCollection());
 
             entity = await _create.CreateAsync(entity);
 
@@ -164,6 +166,7 @@ namespace JsonApiDotNetCore.Controllers
 
             if (entity == null)
                 return UnprocessableEntity();
+            if (!ModelState.IsValid) return BadRequest(ModelState.ConvertToErrorCollection());
 
             var updatedEntity = await _update.UpdateAsync(id, entity);
 

--- a/src/JsonApiDotNetCore/Extensions/ModelStateExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/ModelStateExtensions.cs
@@ -1,0 +1,23 @@
+using JsonApiDotNetCore.Internal;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace JsonApiDotNetCore.Extensions
+{
+    public static class ModelStateExtensions
+    {
+        public static ErrorCollection ConvertToErrorCollection(this ModelStateDictionary modelState)
+        {
+            ErrorCollection errors = new ErrorCollection();
+            foreach (var entry in modelState)
+            {
+                if (!entry.Value.Errors.Any()) continue;
+                foreach (var modelError in entry.Value.Errors)
+                {
+                    errors.Errors.Add(new Error(400, entry.Key, modelError.ErrorMessage, modelError.Exception != null ? ErrorMeta.FromException(modelError.Exception) : null));
+                }
+            }
+            return errors;
+        }
+    }
+}

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>2.3.1</VersionPrefix>
+    <VersionPrefix>2.3.2</VersionPrefix>
     <TargetFrameworks>$(NetStandardVersion)</TargetFrameworks>
     <AssemblyName>JsonApiDotNetCore</AssemblyName>
     <PackageId>JsonApiDotNetCore</PackageId>

--- a/test/UnitTests/Controllers/BaseJsonApiController_Tests.cs
+++ b/test/UnitTests/Controllers/BaseJsonApiController_Tests.cs
@@ -5,7 +5,10 @@ using JsonApiDotNetCore.Services;
 using Moq;
 using Xunit;
 using System.Threading.Tasks;
+using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Internal;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
 namespace UnitTests
 {
@@ -154,6 +157,25 @@ namespace UnitTests
         }
 
         [Fact]
+        public async Task PatchAsync_ModelStateInvalid()
+        {
+            // arrange
+            const int id = 0;
+            var resource = new Resource();
+            var serviceMock = new Mock<IUpdateService<Resource>>();
+            var controller = new BaseJsonApiController<Resource>(_jsonApiContextMock.Object, update: serviceMock.Object);
+            controller.ModelState.AddModelError("Id", "Failed Validation");
+
+            // act
+            var response = await controller.PatchAsync(id, resource);
+
+            // assert
+            serviceMock.Verify(m => m.UpdateAsync(id, It.IsAny<Resource>()), Times.Never);
+            Assert.IsType<BadRequestObjectResult>(response);
+            Assert.IsType<ErrorCollection>(((BadRequestObjectResult) response).Value);
+        }
+
+        [Fact]
         public async Task PatchAsync_Throws_405_If_No_Service()
         {
             // arrange
@@ -166,6 +188,46 @@ namespace UnitTests
 
             // assert
             Assert.Equal(405, exception.GetStatusCode());
+        }
+
+        [Fact]
+        public async Task PostAsync_Calls_Service()
+        {
+            // arrange
+            var resource = new Resource();
+            var serviceMock = new Mock<ICreateService<Resource>>();
+            _jsonApiContextMock.Setup(a => a.ApplyContext<Resource>(It.IsAny<BaseJsonApiController<Resource>>())).Returns(_jsonApiContextMock.Object);
+            _jsonApiContextMock.SetupGet(a => a.Options).Returns(new JsonApiOptions());
+            var controller = new BaseJsonApiController<Resource>(_jsonApiContextMock.Object, create: serviceMock.Object);
+            serviceMock.Setup(m => m.CreateAsync(It.IsAny<Resource>())).ReturnsAsync(resource);
+            controller.ControllerContext = new Microsoft.AspNetCore.Mvc.ControllerContext {HttpContext = new DefaultHttpContext()};
+
+            // act
+            await controller.PostAsync(resource);
+
+            // assert
+            serviceMock.Verify(m => m.CreateAsync(It.IsAny<Resource>()), Times.Once);
+            VerifyApplyContext();
+        }
+
+        [Fact]
+        public async Task PostAsync_ModelStateInvalid()
+        {
+            // arrange
+            var resource = new Resource();
+            var serviceMock = new Mock<ICreateService<Resource>>();
+            _jsonApiContextMock.Setup(a => a.ApplyContext<Resource>(It.IsAny<BaseJsonApiController<Resource>>())).Returns(_jsonApiContextMock.Object);
+            _jsonApiContextMock.SetupGet(a => a.Options).Returns(new JsonApiOptions());
+            var controller = new BaseJsonApiController<Resource>(_jsonApiContextMock.Object, create: serviceMock.Object);
+            controller.ModelState.AddModelError("Id", "Failed Validation");
+
+            // act
+            var response = await controller.PostAsync(resource);
+
+            // assert
+            serviceMock.Verify(m => m.CreateAsync(It.IsAny<Resource>()), Times.Never);
+            Assert.IsType<BadRequestObjectResult>(response);
+            Assert.IsType<ErrorCollection>(((BadRequestObjectResult)response).Value);
         }
 
         [Fact]


### PR DESCRIPTION
Closes #252

#### FEATURE

Addressing Breaking Change - As there are no implicit Validation providers in MVC core, you need to explicitly add validation to the pipeline e.g. services.AddMvcCore().AddDataAnnotations()
Without this ModelState should always be valid. 
