### PR TITLE
fix(#337): run tests serially

### DIFF
--- a/test/UnitTests/xunit.runner.json
+++ b/test/UnitTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
Closes #337

this is because we made the ContextGraph a static instance...if C# ever supports interfaced statics, we could swap the IContextGraph source when the test assembly starts executing