### PR TITLE
WIP: Support Filtering using ne:null on nullable attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,41 @@ public class Startup
     }
 }
 ```
+
+### Development
+
+Restore all nuget packages with:
+
+```bash
+dotnet restore
+```
+
+#### Testing
+
+Running tests locally requires access to a postgresql database.  
+If you have docker installed, this can be propped up via: 
+
+```bash
+docker run --rm --name jsonapi-dotnet-core-testing \
+  -e POSTGRES_DB=JsonApiDotNetCoreExample \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -p 5432:5432 \
+  postgres
+```
+
+And then to run the tests:
+
+```bash
+dotnet test
+```
+
+#### Cleaning
+
+Sometimes the compiled files can be dirty / corrupt from other branches / failed builds.
+If your bash prompt supports the globstar, you can recursively delete the `bin` and `obj` directories:
+
+```bash
+shopt -s globstar
+rm -rf **/bin && rm -rf **/obj
+```

--- a/src/Examples/JsonApiDotNetCoreExample/Models/TodoItem.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Models/TodoItem.cs
@@ -24,6 +24,12 @@ namespace JsonApiDotNetCoreExample.Models
 
         [Attr("achieved-date", isFilterable: false, isSortable: false)]
         public DateTime? AchievedDate { get; set; }
+
+
+        [Attr("updated-date")]
+        public DateTime? UpdatedDate { get; set; }
+
+
         
         public int? OwnerId { get; set; }
         public int? AssigneeId { get; set; }

--- a/src/JsonApiDotNetCore/Extensions/IQueryableExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IQueryableExtensions.cs
@@ -127,9 +127,14 @@ namespace JsonApiDotNetCore.Extensions
                     return source.Where(lambdaIn);
                 }
                 else
-                {   // convert the incoming value to the target value type
+                {   
+                    var isNullabe = IsNullable(property.PropertyType);
+                    var propertyValue = filterQuery.PropertyValue;
+                    var value = isNullabe && propertyValue == "" ? null : propertyValue;
+
+                    // convert the incoming value to the target value type
                     // "1" -> 1
-                    var convertedValue = TypeHelper.ConvertType(filterQuery.PropertyValue, property.PropertyType);
+                    var convertedValue = TypeHelper.ConvertType(value, property.PropertyType);
                     // {model}
                     var parameter = Expression.Parameter(concreteType, "model");
                     // {model.Id}
@@ -203,6 +208,9 @@ namespace JsonApiDotNetCore.Extensions
                 throw new JsonApiException(400, $"Could not cast {filterQuery.PropertyValue} to {relatedAttr.PropertyType.Name}");
             }
         }
+
+        private static bool IsNullable(Type type) => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+
 
         private static Expression GetFilterExpressionLambda(Expression left, Expression right, FilterOperations operation)
         {

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/TodoItemsControllerTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/TodoItemsControllerTests.cs
@@ -100,7 +100,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
             _context.SaveChanges();
 
             var httpMethod = new HttpMethod("GET");
-            var route = $"/api/v1/todo-items?filter[updated-date]=ne:null";
+            var route = $"/api/v1/todo-items?filter[updated-date]=ne:";
             var request = new HttpRequestMessage(httpMethod, route);
 
             // Act

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/TodoItemsControllerTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/TodoItemsControllerTests.cs
@@ -91,6 +91,29 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
         }
 
         [Fact]
+        public async Task Can_Filter_TodoItems_Using_NotEqual_Operator()
+        {
+            // Arrange
+            var todoItem = _todoItemFaker.Generate();
+            todoItem.UpdatedDate = null;
+            _context.TodoItems.Add(todoItem);
+            _context.SaveChanges();
+
+            var httpMethod = new HttpMethod("GET");
+            var route = $"/api/v1/todo-items?filter[updated-date]=ne:null";
+            var request = new HttpRequestMessage(httpMethod, route);
+
+            // Act
+            var response = await _fixture.Client.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            var deserializedBody = _fixture.GetService<IJsonApiDeSerializer>().DeserializeList<TodoItem>(body);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Empty(deserializedBody);
+        }
+
+        [Fact]
         public async Task Can_Filter_TodoItems_Using_Like_Operator()
         {
             // Arrange


### PR DESCRIPTION
#### BUG FIX
- [x] reproduce issue in tests
- [x] fix issue
- [ ] bump package version


The root of this was that I wanted to be able to `?filter[nullable-field]=ne:`, meaning that I wanted all resources where `nullable-field` had a value. 

I had originally tried using `?filter[nullable-field]=ne:null` but, this was interpreting `null` as `"null"`, which resulted in the error: `Could not cast null to Nullable'1`. 

Since checking if something is not null can be handy, I added a check for the `Nullable` generic type, and if the value is an empty string, swap it out for null. :-\

This _may_ be a breaking change. idk.

