### PR TITLE
Exact Error Codes for Error Collections

### DIFF
--- a/src/JsonApiDotNetCore/Internal/JsonApiException.cs
+++ b/src/JsonApiDotNetCore/Internal/JsonApiException.cs
@@ -41,7 +41,7 @@ namespace JsonApiDotNetCore.Internal
 
         public int GetStatusCode()
         {
-            if (_errors.Errors.Count == 1)
+            if (_errors.Errors.Select(a => a.StatusCode).Distinct().Count() == 1)
                 return _errors.Errors[0].StatusCode;
 
             if (_errors.Errors.FirstOrDefault(e => e.StatusCode >= 500) != null)

--- a/test/UnitTests/Internal/JsonApiException_Test.cs
+++ b/test/UnitTests/Internal/JsonApiException_Test.cs
@@ -1,0 +1,31 @@
+using JsonApiDotNetCore.Internal;
+using Xunit;
+
+namespace UnitTests.Internal
+{
+    public class JsonApiException_Test
+    {
+        [Fact]
+        public void Can_GetStatusCode()
+        {
+            var errors = new ErrorCollection();
+            var exception = new JsonApiException(errors);
+
+            // Add First 422 error
+            errors.Add(new Error(422, "Something wrong"));
+            Assert.Equal(422, exception.GetStatusCode());
+
+            // Add a second 422 error
+            errors.Add(new Error(422, "Something else wrong"));
+            Assert.Equal(422, exception.GetStatusCode());
+
+            // Add 4xx error not 422
+            errors.Add(new Error(401, "Unauthorized"));
+            Assert.Equal(400, exception.GetStatusCode());
+
+            // Add 5xx error not 4xx
+            errors.Add(new Error(502, "Not good"));
+            Assert.Equal(500, exception.GetStatusCode());
+        }
+    }
+}


### PR DESCRIPTION
#### FEATURE
- [X] write tests that address the requirements outlined in the issue
 
This change makes it so that error collections will send a status based on the status code of all items in the collection.

If the items in the collection have the same status code, then it return the status code of the entire collection.

If not, it will return 500 or 400 as before.