### PR TITLE
fix(#383): add operation processor overloads

### DIFF
--- a/src/JsonApiDotNetCore/Services/Operations/Processors/CreateOpProcessor.cs
+++ b/src/JsonApiDotNetCore/Services/Operations/Processors/CreateOpProcessor.cs
@@ -26,6 +26,22 @@ namespace JsonApiDotNetCore.Services.Operations.Processors
             IContextGraph contextGraph
         ) : base(service, deSerializer, documentBuilder, contextGraph)
         { }
+
+        public CreateOpProcessor(
+            IResourceCmdService<T, int> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph
+        ) : base(service, deSerializer, documentBuilder, contextGraph)
+        { }
+
+        public CreateOpProcessor(
+            IResourceService<T, int> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph
+        ) : base(service, deSerializer, documentBuilder, contextGraph)
+        { }
     }
 
     public class CreateOpProcessor<T, TId> : ICreateOpProcessor<T, TId>
@@ -38,6 +54,30 @@ namespace JsonApiDotNetCore.Services.Operations.Processors
 
         public CreateOpProcessor(
             ICreateService<T, TId> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph)
+        {
+            _service = service;
+            _deSerializer = deSerializer;
+            _documentBuilder = documentBuilder;
+            _contextGraph = contextGraph;
+        }
+
+        public CreateOpProcessor(
+            IResourceCmdService<T, TId> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph)
+        {
+            _service = service;
+            _deSerializer = deSerializer;
+            _documentBuilder = documentBuilder;
+            _contextGraph = contextGraph;
+        }
+
+        public CreateOpProcessor(
+            IResourceService<T, TId> service,
             IJsonApiDeSerializer deSerializer,
             IDocumentBuilder documentBuilder,
             IContextGraph contextGraph)

--- a/src/JsonApiDotNetCore/Services/Operations/Processors/GetOpProcessor.cs
+++ b/src/JsonApiDotNetCore/Services/Operations/Processors/GetOpProcessor.cs
@@ -42,6 +42,24 @@ namespace JsonApiDotNetCore.Services.Operations.Processors
             IJsonApiContext jsonApiContext
         ) : base(getAll, getById, getRelationship, deSerializer, documentBuilder, contextGraph, jsonApiContext)
         { }
+
+        public GetOpProcessor(
+            IResourceQueryService<T, int> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph,
+            IJsonApiContext jsonApiContext
+        ) : base(service, service, service, deSerializer, documentBuilder, contextGraph, jsonApiContext)
+        { }
+
+        public GetOpProcessor(
+            IResourceService<T, int> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph,
+            IJsonApiContext jsonApiContext
+        ) : base(service, service, service, deSerializer, documentBuilder, contextGraph, jsonApiContext)
+        { }
     }
 
     /// <inheritdoc />
@@ -69,6 +87,38 @@ namespace JsonApiDotNetCore.Services.Operations.Processors
             _getAll = getAll;
             _getById = getById;
             _getRelationship = getRelationship;
+            _deSerializer = deSerializer;
+            _documentBuilder = documentBuilder;
+            _contextGraph = contextGraph;
+            _jsonApiContext = jsonApiContext.ApplyContext<T>(this);
+        }
+
+        public GetOpProcessor(
+            IResourceQueryService<T, TId> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph,
+            IJsonApiContext jsonApiContext)
+        {
+            _getAll = service;
+            _getById = service;
+            _getRelationship = service;
+            _deSerializer = deSerializer;
+            _documentBuilder = documentBuilder;
+            _contextGraph = contextGraph;
+            _jsonApiContext = jsonApiContext.ApplyContext<T>(this);
+        }
+
+        public GetOpProcessor(
+            IResourceService<T, TId> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph,
+            IJsonApiContext jsonApiContext)
+        {
+            _getAll = service;
+            _getById = service;
+            _getRelationship = service;
             _deSerializer = deSerializer;
             _documentBuilder = documentBuilder;
             _contextGraph = contextGraph;

--- a/src/JsonApiDotNetCore/Services/Operations/Processors/RemoveOpProcessor.cs
+++ b/src/JsonApiDotNetCore/Services/Operations/Processors/RemoveOpProcessor.cs
@@ -25,6 +25,22 @@ namespace JsonApiDotNetCore.Services.Operations.Processors
             IContextGraph contextGraph
         ) : base(service, deSerializer, documentBuilder, contextGraph)
         { }
+
+        public RemoveOpProcessor(
+            IResourceCmdService<T, int> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph
+        ) : base(service, deSerializer, documentBuilder, contextGraph)
+        { }
+
+        public RemoveOpProcessor(
+            IResourceService<T, int> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph
+        ) : base(service, deSerializer, documentBuilder, contextGraph)
+        { }
     }
 
     public class RemoveOpProcessor<T, TId> : IRemoveOpProcessor<T, TId>
@@ -37,6 +53,30 @@ namespace JsonApiDotNetCore.Services.Operations.Processors
 
         public RemoveOpProcessor(
             IDeleteService<T, TId> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph)
+        {
+            _service = service;
+            _deSerializer = deSerializer;
+            _documentBuilder = documentBuilder;
+            _contextGraph = contextGraph;
+        }
+
+        public RemoveOpProcessor(
+            IResourceCmdService<T, TId> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph)
+        {
+            _service = service;
+            _deSerializer = deSerializer;
+            _documentBuilder = documentBuilder;
+            _contextGraph = contextGraph;
+        }
+
+        public RemoveOpProcessor(
+            IResourceService<T, TId> service,
             IJsonApiDeSerializer deSerializer,
             IDocumentBuilder documentBuilder,
             IContextGraph contextGraph)

--- a/src/JsonApiDotNetCore/Services/Operations/Processors/UpdateOpProcessor.cs
+++ b/src/JsonApiDotNetCore/Services/Operations/Processors/UpdateOpProcessor.cs
@@ -25,6 +25,22 @@ namespace JsonApiDotNetCore.Services.Operations.Processors
             IContextGraph contextGraph
         ) : base(service, deSerializer, documentBuilder, contextGraph)
         { }
+
+        public UpdateOpProcessor(
+            IResourceCmdService<T, int> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph
+        ) : base(service, deSerializer, documentBuilder, contextGraph)
+        { }
+
+        public UpdateOpProcessor(
+            IResourceService<T, int> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph
+        ) : base(service, deSerializer, documentBuilder, contextGraph)
+        { }
     }
 
     public class UpdateOpProcessor<T, TId> : IUpdateOpProcessor<T, TId>
@@ -37,6 +53,30 @@ namespace JsonApiDotNetCore.Services.Operations.Processors
 
         public UpdateOpProcessor(
             IUpdateService<T, TId> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph)
+        {
+            _service = service;
+            _deSerializer = deSerializer;
+            _documentBuilder = documentBuilder;
+            _contextGraph = contextGraph;
+        }
+
+        public UpdateOpProcessor(
+            IResourceCmdService<T, TId> service,
+            IJsonApiDeSerializer deSerializer,
+            IDocumentBuilder documentBuilder,
+            IContextGraph contextGraph)
+        {
+            _service = service;
+            _deSerializer = deSerializer;
+            _documentBuilder = documentBuilder;
+            _contextGraph = contextGraph;
+        }
+
+        public UpdateOpProcessor(
+            IResourceService<T, TId> service,
             IJsonApiDeSerializer deSerializer,
             IDocumentBuilder documentBuilder,
             IContextGraph contextGraph)


### PR DESCRIPTION
Closes #383 

---

Currently failing because this creates ambiguous constructors 🙁 

```
JsonApiDotNetCore.Internal.JsonApiException: Transaction failed on operation[0] (add) for an unexpected reason. ---> System.InvalidOperationException: Unable to activate type 'JsonApiDotNetCore.Services.Operations.Processors.CreateOpProcessor`2[JsonApiDotNetCoreExample.Models.Author,System.Int32]'. The following constructors are ambiguous:
Void .ctor(JsonApiDotNetCore.Services.ICreateService`2[JsonApiDotNetCoreExample.Models.Author,System.Int32], JsonApiDotNetCore.Serialization.IJsonApiDeSerializer, JsonApiDotNetCore.Builders.IDocumentBuilder, JsonApiDotNetCore.Internal.IContextGraph)
Void .ctor(JsonApiDotNetCore.Services.IResourceService`2[JsonApiDotNetCoreExample.Models.Author,System.Int32], JsonApiDotNetCore.Serialization.IJsonApiDeSerializer, JsonApiDotNetCore.Builders.IDocumentBuilder, JsonApiDotNetCore.Internal.IContextGraph)
```

---

I think this should be closed in favor of #399 

If we register all forms automatically, there should be no need for these overloads...