### PR TITLE
Nested sparse fields

### DIFF
--- a/src/JsonApiDotNetCore/Extensions/IQueryableExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IQueryableExtensions.cs
@@ -304,7 +304,7 @@ namespace JsonApiDotNetCore.Extensions
         private static IQueryable<TSource> CallGenericSelectMethod<TSource>(IQueryable<TSource> source, List<string> columns)
         {
             var sourceBindings = new List<MemberAssignment>();
-            var sourceType = typeof(TSource);       
+            var sourceType = typeof(TSource);
             var parameter = Expression.Parameter(source.ElementType, "x");
             var sourceProperties = new List<string>() { };
 
@@ -375,7 +375,7 @@ namespace JsonApiDotNetCore.Extensions
                         // {x.Owner.Name}
                         var nestedBody = Expression.PropertyOrField(srcBody, nested);
                         var propInfo = nestedPropertyType.GetProperty(nested);
-                        nestedBindings.Add(Expression.Bind(propInfo, nestedBody));                  
+                        nestedBindings.Add(Expression.Bind(propInfo, nestedBody));
                     }
                     // { new Owner() }
                     var newExp = Expression.New(nestedPropertyType);
@@ -397,10 +397,10 @@ namespace JsonApiDotNetCore.Extensions
 
             var sourceInit = Expression.MemberInit(Expression.New(sourceType), sourceBindings);
             var finalBody = Expression.Lambda(sourceInit, parameter);
-          
+
             return source.Provider.CreateQuery<TSource>(Expression.Call(
-                typeof(Queryable), 
-                "Select", // It would be better to call generic IQueryable<TSource>.Select() method (FirstOrDefaultAsync can't be called on non-generic)
+                typeof(Queryable),
+                "Select",
                 new[] { source.ElementType, typeof(TSource) },
                 source.Expression,
                 Expression.Quote(finalBody)));

--- a/src/JsonApiDotNetCore/Extensions/IQueryableExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IQueryableExtensions.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JsonApiDotNetCore.Internal;
 using JsonApiDotNetCore.Internal.Query;
+using JsonApiDotNetCore.Models;
 using JsonApiDotNetCore.Services;
 
 namespace JsonApiDotNetCore.Extensions
@@ -297,29 +299,111 @@ namespace JsonApiDotNetCore.Extensions
         }
 
         public static IQueryable<TSource> Select<TSource>(this IQueryable<TSource> source, List<string> columns)
+            => CallGenericSelectMethod(source, columns);
+
+        private static IQueryable<TSource> CallGenericSelectMethod<TSource>(IQueryable<TSource> source, List<string> columns)
         {
-            if (columns == null || columns.Count == 0)
-                return source;
+            var sourceBindings = new List<MemberAssignment>();
+            var sourceType = typeof(TSource);       
+            var parameter = Expression.Parameter(source.ElementType, "x");
+            var sourceProperties = new List<string>() { };
 
-            var sourceType = source.ElementType;
+            // Store all property names to it's own related property (name as key)
+            var nestedTypesAndProperties = new Dictionary<string, List<string>>();
+            foreach (var column in columns)
+            {
+                var props = column.Split('.');
+                if (props.Length > 1) // Nested property
+                {
+                    if (nestedTypesAndProperties.TryGetValue(props[0], out var properties) == false)
+                        nestedTypesAndProperties.Add(props[0], new List<string>() { nameof(Identifiable.Id), props[1] });
+                    else
+                        properties.Add(props[1]);
+                }
+                else
+                    sourceProperties.Add(props[0]);
+            }
 
-            var resultType = typeof(TSource);
+            // Bind attributes on TSource
+            sourceBindings = sourceProperties.Select(prop => Expression.Bind(sourceType.GetProperty(prop), Expression.PropertyOrField(parameter, prop))).ToList();
 
-            // {model}
-            var parameter = Expression.Parameter(sourceType, "model");
+            // Bind attributes on nested types
+            var nestedBindings = new List<MemberAssignment>();
+            Expression bindExpression;
+            foreach (var item in nestedTypesAndProperties)
+            {
+                var nestedProperty = sourceType.GetProperty(item.Key);
+                var nestedPropertyType = nestedProperty.PropertyType;
+                // [HasMany] attribute
+                if (nestedPropertyType != typeof(string) && typeof(IEnumerable).IsAssignableFrom(nestedPropertyType))
+                {
+                    // Concrete type of Collection
+                    var singleType = nestedPropertyType.GetGenericArguments().Single();
+                    // {y}
+                    var nestedParameter = Expression.Parameter(singleType, "y");
+                    nestedBindings = item.Value.Select(prop => Expression.Bind(
+                        singleType.GetProperty(prop), Expression.PropertyOrField(nestedParameter, prop))).ToList();
 
-            var bindings = columns.Select(column => Expression.Bind(
-                resultType.GetProperty(column), Expression.PropertyOrField(parameter, column)));
+                    // { new Item() }
+                    var newNestedExp = Expression.New(singleType);
+                    var initNestedExp = Expression.MemberInit(newNestedExp, nestedBindings);
+                    // { y => new Item() {Id = y.Id, Name = y.Name}}
+                    var body = Expression.Lambda(initNestedExp, nestedParameter);
+                    // { x.Items }
+                    Expression propertyExpression = Expression.Property(parameter, nestedProperty.Name);
+                    // { x.Items.Select(y => new Item() {Id = y.Id, Name = y.Name}) }
+                    Expression selectMethod = Expression.Call(
+                        typeof(Enumerable),
+                        "Select",
+                        new Type[] { singleType, singleType },
+                        propertyExpression, body);
 
-            // { new Model () { Property = model.Property } }
-            var body = Expression.MemberInit(Expression.New(resultType), bindings);
+                    // { x.Items.Select(y => new Item() {Id = y.Id, Name = y.Name}).ToList() }
+                    bindExpression = Expression.Call(
+                         typeof(Enumerable),
+                         "ToList",
+                         new Type[] { singleType },
+                         selectMethod);
+                }
+                // [HasOne] attribute
+                else
+                {
+                    // {x.Owner}
+                    var srcBody = Expression.PropertyOrField(parameter, item.Key);
+                    foreach (var nested in item.Value)
+                    {
+                        // {x.Owner.Name}
+                        var nestedBody = Expression.PropertyOrField(srcBody, nested);
+                        var propInfo = nestedPropertyType.GetProperty(nested);
+                        nestedBindings.Add(Expression.Bind(propInfo, nestedBody));                  
+                    }
+                    // { new Owner() }
+                    var newExp = Expression.New(nestedPropertyType);
+                    // { new Owner() { Id = x.Owner.Id, Name = x.Owner.Name }}
+                    var newInit = Expression.MemberInit(newExp, nestedBindings);
 
-            // { model => new TodoItem() { Property = model.Property } }
-            var selector = Expression.Lambda(body, parameter);
+                    // Handle nullable relationships
+                    // { Owner = x.Owner == null ? null : new Owner() {...} }
+                    bindExpression = Expression.Condition(
+                           Expression.Equal(srcBody, Expression.Constant(null)),
+                           Expression.Convert(Expression.Constant(null), nestedPropertyType),
+                           newInit
+                         );
+                }
 
-            return source.Provider.CreateQuery<TSource>(
-                Expression.Call(typeof(Queryable), "Select", new[] { sourceType, resultType },
-                source.Expression, Expression.Quote(selector)));
+                sourceBindings.Add(Expression.Bind(nestedProperty, bindExpression));
+                nestedBindings.Clear();
+            }
+
+            var sourceInit = Expression.MemberInit(Expression.New(sourceType), sourceBindings);
+            var finalBody = Expression.Lambda(sourceInit, parameter);
+          
+            return source.Provider.CreateQuery<TSource>(Expression.Call(
+                typeof(Queryable), 
+                "Select", // It would be better to call generic IQueryable<TSource>.Select() method (FirstOrDefaultAsync can't be called on non-generic)
+                new[] { source.ElementType, typeof(TSource) },
+                source.Expression,
+                Expression.Quote(finalBody)));
         }
 
         public static IQueryable<T> PageForward<T>(this IQueryable<T> source, int pageSize, int pageNumber)

--- a/src/JsonApiDotNetCore/Services/EntityResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/EntityResourceService.cs
@@ -247,7 +247,12 @@ namespace JsonApiDotNetCore.Services
                 query = _entities.Include(query, r);
             });
 
-            var value = await _entities.FirstOrDefaultAsync(query);
+            TEntity value;
+            // FirstOrDefaultAsync exprects Queryable<TEntity>, but CallGenericSelectMethod creates Queryable only
+            if (_jsonApiContext.QuerySet?.Fields?.Count > 0)
+                value = query.FirstOrDefault();
+            else
+                value = await _entities.FirstOrDefaultAsync(query);
 
             return MapOut(value);
         }

--- a/src/JsonApiDotNetCore/Services/EntityResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/EntityResourceService.cs
@@ -248,7 +248,7 @@ namespace JsonApiDotNetCore.Services
             });
 
             TEntity value;
-            // FirstOrDefaultAsync exprects Queryable<TEntity>, but CallGenericSelectMethod creates Queryable only
+            // https://github.com/aspnet/EntityFrameworkCore/issues/6573
             if (_jsonApiContext.QuerySet?.Fields?.Count > 0)
                 value = query.FirstOrDefault();
             else

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/SparseFieldSetTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/SparseFieldSetTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Bogus;
 using JsonApiDotNetCore.Extensions;
 using JsonApiDotNetCore.Models;
 using JsonApiDotNetCoreExample;
@@ -15,6 +16,9 @@ using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using Xunit;
 using StringExtensions = JsonApiDotNetCoreExampleTests.Helpers.Extensions.StringExtensions;
+using Person = JsonApiDotNetCoreExample.Models.Person;
+using System.Net;
+using JsonApiDotNetCore.Serialization;
 
 namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
 {
@@ -23,11 +27,22 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
     {
         private TestFixture<TestStartup> _fixture;
         private readonly AppDbContext _dbContext;
+        private Faker<Person> _personFaker;
+        private Faker<TodoItem> _todoItemFaker;
 
         public SparseFieldSetTests(TestFixture<TestStartup> fixture)
         {
             _fixture = fixture;
             _dbContext = fixture.GetService<AppDbContext>();
+            _personFaker = new Faker<Person>()
+                .RuleFor(p => p.FirstName, f => f.Name.FirstName())
+                .RuleFor(p => p.LastName, f => f.Name.LastName())
+                .RuleFor(p => p.Age, f => f.Random.Int(20, 80));
+
+            _todoItemFaker = new Faker<TodoItem>()
+                .RuleFor(t => t.Description, f => f.Lorem.Sentence())
+                .RuleFor(t => t.Ordinal, f => f.Random.Number(1,10))
+                .RuleFor(t => t.CreatedDate, f => f.Date.Past());
         }
 
         [Fact]
@@ -97,6 +112,130 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             Assert.Equal(2, deserializeBody.Data.Attributes.Count);
             Assert.Equal(todoItem.Description, deserializeBody.Data.Attributes["description"]);
             Assert.Equal(todoItem.CreatedDate.ToString("G"), ((DateTime)deserializeBody.Data.Attributes["created-date"]).ToString("G"));
+        }
+
+        [Fact]
+        public async Task Fields_Query_Selects_All_Fieldset_With_HasOne()
+        {
+            // arrange
+            var owner = _personFaker.Generate();
+            var ordinal = _dbContext.TodoItems.Count();
+            var todoItem = new TodoItem
+            {
+                Description = "s",
+                Ordinal = ordinal,
+                CreatedDate = DateTime.Now,
+                Owner = owner
+            };
+            _dbContext.TodoItems.Add(todoItem);
+            _dbContext.SaveChanges();
+
+            var builder = new WebHostBuilder()
+                .UseStartup<Startup>();
+            var httpMethod = new HttpMethod("GET");
+            var server = new TestServer(builder);
+            var client = server.CreateClient();
+
+            var route = $"/api/v1/todo-items?include=owner&fields[owner]=first-name,age";
+            var request = new HttpRequestMessage(httpMethod, route);
+
+            // act
+            var response = await client.SendAsync(request);
+
+            // assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var body = await response.Content.ReadAsStringAsync();
+            var deserializedTodoItems = _fixture
+                .GetService<IJsonApiDeSerializer>()
+                .DeserializeList<TodoItem>(body);
+
+            foreach(var item in deserializedTodoItems.Where(i => i.Owner != null))
+            {
+                Assert.Null(item.Owner.LastName);
+                Assert.NotNull(item.Owner.FirstName);
+                Assert.NotEqual(0, item.Owner.Age);
+            }
+        }
+
+        [Fact]
+        public async Task Fields_Query_Selects_Fieldset_With_HasOne()
+        {
+            // arrange
+            var owner = _personFaker.Generate();
+            var todoItem = new TodoItem
+            {
+                Description = "description",
+                Ordinal = 1,
+                CreatedDate = DateTime.Now,
+                Owner = owner
+            };
+            _dbContext.TodoItems.Add(todoItem);
+            _dbContext.SaveChanges();
+
+            var builder = new WebHostBuilder()
+                .UseStartup<Startup>();
+            var httpMethod = new HttpMethod("GET");
+            var server = new TestServer(builder);
+            var client = server.CreateClient();
+
+            var route = $"/api/v1/todo-items/{todoItem.Id}?include=owner&fields[owner]=first-name,age";
+            var request = new HttpRequestMessage(httpMethod, route);
+
+            // act
+            var response = await client.SendAsync(request);
+
+            // assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var body = await response.Content.ReadAsStringAsync();
+            var deserializeBody = JsonConvert.DeserializeObject<Document>(body);
+
+            // check owner attributes
+            var included = deserializeBody.Included.First();
+            Assert.Equal(owner.StringId, included.Id);      
+            Assert.Equal(owner.FirstName, included.Attributes["first-name"]);
+            Assert.Equal((long)owner.Age, included.Attributes["age"]);
+            Assert.Null(included.Attributes["last-name"]);
+
+        }
+
+        [Fact]
+        public async Task Fields_Query_Selects_Fieldset_With_HasMany()
+        {
+            // arrange
+            var owner = _personFaker.Generate();
+            var todoItems = _todoItemFaker.Generate(2);
+
+            owner.TodoItems = todoItems;
+
+            _dbContext.People.Add(owner);
+            _dbContext.SaveChanges();
+
+            var builder = new WebHostBuilder()
+                .UseStartup<Startup>();
+            var httpMethod = new HttpMethod("GET");
+            var server = new TestServer(builder);
+            var client = server.CreateClient();
+
+            var route = $"/api/v1/people/{owner.Id}?include=todo-items&fields[todo-items]=description";
+            var request = new HttpRequestMessage(httpMethod, route);
+
+            // act
+            var response = await client.SendAsync(request);
+
+            // assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var body = await response.Content.ReadAsStringAsync();
+            var deserializeBody = JsonConvert.DeserializeObject<Document>(body);
+
+            // check owner attributes
+            foreach (var includedItem in deserializeBody.Included)
+            {
+                var todoItem = todoItems.FirstOrDefault(i => i.StringId == includedItem.Id);
+                Assert.NotNull(todoItem);
+                Assert.Equal(todoItem.Description, includedItem.Attributes["description"]);
+                Assert.Equal(default(long), includedItem.Attributes["ordinal"]);
+                Assert.Equal(default(DateTime), (DateTime)includedItem.Attributes["created-date"]);
+            }
         }
     }
 }

--- a/test/UnitTests/Services/QueryParser_Tests.cs
+++ b/test/UnitTests/Services/QueryParser_Tests.cs
@@ -252,7 +252,8 @@ namespace UnitTests.Services
                             {
                                 InternalAttributeName = internalAttrName
                             }
-                        }
+                        },
+                    Relationships = new List<RelationshipAttribute>()
                 });
 
             var queryParser = new QueryParser(_controllerContextMock.Object, new JsonApiOptions());
@@ -285,7 +286,8 @@ namespace UnitTests.Services
                 .Returns(new ContextEntity
                 {
                     EntityName = type,
-                    Attributes = new List<AttrAttribute>()
+                    Attributes = new List<AttrAttribute>(),
+                    Relationships = new List<RelationshipAttribute>()
                 });
 
             var queryParser = new QueryParser(_controllerContextMock.Object, new JsonApiOptions());


### PR DESCRIPTION
Closes #434

Changed files:
1) IQueryableExtensions - new CallGenericSelectMethod() to build Select() expression trees for requested entity, [HasOne] and [HasMany] relationships
2) EntityResourceService - only fix to return FirstOrDefault() instead of FirstOrDefaultAsync() if fields are requested. See https://github.com/aspnet/EntityFrameworkCore/issues/6573
3) QueryParser - expanded to load relationship attributes and build field queries like "Owner.FirstName"
4) SparseFieldSetTests - 3 new tests: Get all, Get one with HasOne included and Get one with HasMany included
5) QueryParser_Tests - only new `List<Relationships>` in mock