### PR TITLE
Fixed HasManyThrough relationships returning empty data array without 'include'

### DIFF
--- a/src/JsonApiDotNetCore/Internal/ResourceGraph.cs
+++ b/src/JsonApiDotNetCore/Internal/ResourceGraph.cs
@@ -144,11 +144,18 @@ namespace JsonApiDotNetCore.Internal
             var throughProperty = GetRelationship(parent, hasManyThrough.InternalThroughName);
             if (throughProperty is IEnumerable hasManyNavigationEntity)
             {
-                foreach (var includedEntity in hasManyNavigationEntity)
-                {
-                    var targetValue = hasManyThrough.RightProperty.GetValue(includedEntity) as IIdentifiable;
-                    yield return targetValue;
-                }
+                // wrap "yield return" in a sub-function so we can correctly return null if the property is null.
+                return GetHasManyThroughIter(hasManyThrough, hasManyNavigationEntity);
+            }
+            return null;
+        }
+
+        private IEnumerable<IIdentifiable> GetHasManyThroughIter(HasManyThroughAttribute hasManyThrough, IEnumerable hasManyNavigationEntity)
+        {
+            foreach (var includedEntity in hasManyNavigationEntity)
+            {
+                var targetValue = hasManyThrough.RightProperty.GetValue(includedEntity) as IIdentifiable;
+                yield return targetValue;
             }
         }
 

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/ManyToManyTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/ManyToManyTests.cs
@@ -111,6 +111,34 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
         }
 
         [Fact]
+        public async Task Can_Fetch_Many_To_Many_Without_Include()
+        {
+            // arrange
+            var context = _fixture.GetService<AppDbContext>();
+            var article = _articleFaker.Generate();
+            var tag = _tagFaker.Generate();
+            var articleTag = new ArticleTag
+            {
+                Article = article,
+                Tag = tag
+            };
+            context.ArticleTags.Add(articleTag);
+            await context.SaveChangesAsync();
+
+            var route = $"/api/v1/articles/{article.Id}";
+
+            // act
+            var response = await _fixture.Client.GetAsync(route);
+
+            // assert
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.True(HttpStatusCode.OK == response.StatusCode, $"{route} returned {response.StatusCode} status code with payload: {body}");
+
+            var document = JsonConvert.DeserializeObject<Document>(body);
+            Assert.Null(document.Data.Relationships["tags"].ManyData);
+        }
+
+        [Fact]
         public async Task Can_Create_Many_To_Many()
         {
             // arrange


### PR DESCRIPTION

Closes #453

#### BUG FIX
- [x] reproduce issue in tests
- [x] fix issue
- [ ] bump package version

The basic gist here is that there was an iterator function that was returning an empty IEnumerable even if the property value for the relationship was `null`. All fixed now.

Let me know if I should bump the package version or anything. I'm not totally sure what the process is there.