### PR TITLE
Update TypeMatchFilter.cs

### DIFF
--- a/src/JsonApiDotNetCore/Middleware/TypeMatchFilter.cs
+++ b/src/JsonApiDotNetCore/Middleware/TypeMatchFilter.cs
@@ -22,7 +22,7 @@ namespace JsonApiDotNetCore.Middleware
         public void OnActionExecuting(ActionExecutingContext context)
         {
             var request = context.HttpContext.Request;
-            if (IsJsonApiRequest(request) && request.Method == "PATCH" || request.Method == "POST")
+            if (IsJsonApiRequest(request) && (request.Method == "PATCH" || request.Method == "POST"))
             {
                 var deserializedType = context.ActionArguments.FirstOrDefault().Value?.GetType();
                 var targetType = context.ActionDescriptor.Parameters.FirstOrDefault()?.ParameterType;


### PR DESCRIPTION
should only be typechecking on json api requests that are patch or post... because of left to right evaluation and lack of parens  this was evaluating as false || is post if the request was not a jsonapi request.

