### PR TITLE
Omit null attributes in included array

### DIFF
--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Extensibility/NullValuedAttributeHandlingTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Extensibility/NullValuedAttributeHandlingTests.cs
@@ -21,12 +21,14 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Extensibility
         {
             _fixture = fixture;
             _dbContext = fixture.GetService<AppDbContext>();
+            var person = new Person { FirstName = "Bob", LastName = null };
             _todoItem = new TodoItem
             {
                 Description = null,
                 Ordinal = 1,
                 CreatedDate = DateTime.Now,
-                AchievedDate = DateTime.Now.AddDays(2)
+                AchievedDate = DateTime.Now.AddDays(2),
+                Owner = person
             };
             _todoItem = _dbContext.TodoItems.Add(_todoItem).Entity;
         }
@@ -86,9 +88,9 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Extensibility
 
             var httpMethod = new HttpMethod("GET");
             var queryString = allowClientOverride.HasValue
-                ? $"?omitNullValuedAttributes={clientOverride}"
+                ? $"&omitNullValuedAttributes={clientOverride}"
                 : "";
-            var route = $"/api/v1/todo-items/{_todoItem.Id}{queryString}"; 
+            var route = $"/api/v1/todo-items/{_todoItem.Id}?include=owner{queryString}"; 
             var request = new HttpRequestMessage(httpMethod, route);
 
             // act
@@ -98,6 +100,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Extensibility
 
             // assert. does response contain a null valued attribute
             Assert.Equal(omitsNulls, !deserializeBody.Data.Attributes.ContainsKey("description"));
+            Assert.Equal(omitsNulls, !deserializeBody.Included[0].Attributes.ContainsKey("last-name"));
 
         }
     }

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/SparseFieldSetTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/SparseFieldSetTests.cs
@@ -194,8 +194,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             Assert.Equal(owner.StringId, included.Id);      
             Assert.Equal(owner.FirstName, included.Attributes["first-name"]);
             Assert.Equal((long)owner.Age, included.Attributes["age"]);
-            Assert.Null(included.Attributes["last-name"]);
-
+            Assert.DoesNotContain("last-name", included.Attributes.Keys);
         }
 
         [Fact]
@@ -233,8 +232,8 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
                 var todoItem = todoItems.FirstOrDefault(i => i.StringId == includedItem.Id);
                 Assert.NotNull(todoItem);
                 Assert.Equal(todoItem.Description, includedItem.Attributes["description"]);
-                Assert.Equal(default(long), includedItem.Attributes["ordinal"]);
-                Assert.Equal(default(DateTime), (DateTime)includedItem.Attributes["created-date"]);
+                Assert.DoesNotContain("ordinal", includedItem.Attributes.Keys);
+                Assert.DoesNotContain("created-date", includedItem.Attributes.Keys);
             }
         }
     }


### PR DESCRIPTION
Closes #454 

Concept - I had to provide extra parameter RelationshipAttribute to ShouldIncludeAttribute(). In case of nested sparse fields and it's values like "Nested.Attribute", there was no chance to recognize, if  user asks for "Attribute" of resource or relationship.

I had to update nested sparse fields tests. With this fix I can just check presence of attributes instead of null value check.
