### PR TITLE
Modify global options to reflect read-only SerializerSettings

### DIFF
--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -75,9 +75,6 @@ We use Newtonsoft.Json for all serialization needs.
 If you want to change the default serializer settings, you can:
 
 ```c#
-options.SerializerSettings = new JsonSerializerSettings()
-{
-    NullValueHandling = NullValueHandling.Ignore,
-    ContractResolver = new DasherizedResolver()
-}
+options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+options.SerializerSettings.ContractResolver = new DasherizedResolver();
 ```


### PR DESCRIPTION
Addresses discrepancy between implementation and documentation. SerializerSettings is read-only (it has a [private setter](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/3ade2a7d4f5d05fa7d593abe248450543116afbd/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs#L174)).

So it is not possible to do the following when configuring the JsonApi:

```c#
options.SerializerSettings = new JsonSerializerSettings()
{
    NullValueHandling = NullValueHandling.Ignore,
    ContractResolver = new DasherizedResolver()
}
```

It seems the same is achievable by

```c#
options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
options.SerializerSettings.ContractResolver = new DasherizedResolver();
```