### PR TITLE
Fix sparse fields with DefaultEntityRepository.Get() override

### DIFF
--- a/JsonApiDotnetCore.sln
+++ b/JsonApiDotnetCore.sln
@@ -190,7 +190,7 @@ Global
 		{6DFA30D7-1679-4333-9779-6FB678E48EF5}.Release|x64.ActiveCfg = Release|Any CPU
 		{6DFA30D7-1679-4333-9779-6FB678E48EF5}.Release|x64.Build.0 = Release|Any CPU
 		{6DFA30D7-1679-4333-9779-6FB678E48EF5}.Release|x86.ActiveCfg = Release|Any CPU
-		{6DFA30D7-1679-4333-9779-6FB678E48EF5}.Release|x86.Build.0 = Release|Any CPU\
+		{6DFA30D7-1679-4333-9779-6FB678E48EF5}.Release|x86.Build.0 = Release|Any CPU
 		{09C0C8D8-B721-4955-8889-55CB149C3B5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{09C0C8D8-B721-4955-8889-55CB149C3B5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{09C0C8D8-B721-4955-8889-55CB149C3B5C}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -203,6 +203,7 @@ Global
 		{09C0C8D8-B721-4955-8889-55CB149C3B5C}.Release|x64.Build.0 = Release|Any CPU
 		{09C0C8D8-B721-4955-8889-55CB149C3B5C}.Release|x86.ActiveCfg = Release|Any CPU
 		{09C0C8D8-B721-4955-8889-55CB149C3B5C}.Release|x86.Build.0 = Release|Any CPU
+		{DF9BFD82-D937-4907-B0B4-64670417115F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -79,12 +79,15 @@ namespace JsonApiDotNetCore.Data
         }
 
         /// <inheritdoc />
-        public virtual IQueryable<TEntity> Get()
-        {
-            if (_jsonApiContext.QuerySet?.Fields != null && _jsonApiContext.QuerySet.Fields.Count > 0)
-                return _dbSet.Select(_jsonApiContext.QuerySet?.Fields);
+        public virtual IQueryable<TEntity> Get() 
+            => _dbSet;
 
-            return _dbSet;
+        public virtual IQueryable<TEntity> Select(IQueryable<TEntity> entities, List<string> fields)
+        {
+            if (fields?.Count > 0)
+                return entities.Select(fields);
+
+            return entities;
         }
 
         /// <inheritdoc />

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -78,8 +78,18 @@ namespace JsonApiDotNetCore.Data
             _resourceDefinition = resourceDefinition;
         }
 
+
+        
+        public virtual IQueryable<TEntity> Get()
+        {
+            if (_jsonApiContext.QuerySet?.Fields != null && _jsonApiContext.QuerySet.Fields.Count > 0)
+                return _dbSet.Select(_jsonApiContext.QuerySet?.Fields);
+
+            return _dbSet;
+        }
+
         /// <inheritdoc />
-        public virtual IQueryable<TEntity> Get() 
+        public virtual IQueryable<TEntity> GetQueryable() 
             => _dbSet;
 
         public virtual IQueryable<TEntity> Select(IQueryable<TEntity> entities, List<string> fields)
@@ -130,7 +140,7 @@ namespace JsonApiDotNetCore.Data
         /// <inheritdoc />
         public virtual async Task<TEntity> GetAsync(TId id)
         {
-            return await Get().SingleOrDefaultAsync(e => e.Id.Equals(id));
+            return await GetQueryable().SingleOrDefaultAsync(e => e.Id.Equals(id));
         }
 
         /// <inheritdoc />
@@ -138,7 +148,7 @@ namespace JsonApiDotNetCore.Data
         {
             _logger?.LogDebug($"[JADN] GetAndIncludeAsync({id}, {relationshipName})");
 
-            var includedSet = Include(Get(), relationshipName);
+            var includedSet = Include(GetQueryable(), relationshipName);
             var result = await includedSet.SingleOrDefaultAsync(e => e.Id.Equals(id));
 
             return result;

--- a/src/JsonApiDotNetCore/Data/IEntityReadRepository.cs
+++ b/src/JsonApiDotNetCore/Data/IEntityReadRepository.cs
@@ -21,6 +21,11 @@ namespace JsonApiDotNetCore.Data
         IQueryable<TEntity> Get();
 
         /// <summary>
+        /// Apply fields to the provided queryable
+        /// </summary>
+        IQueryable<TEntity> Select(IQueryable<TEntity> entities,List<string> fields);
+
+        /// <summary>
         /// Include a relationship in the query
         /// </summary>
         /// <example>

--- a/src/JsonApiDotNetCore/Data/IEntityReadRepository.cs
+++ b/src/JsonApiDotNetCore/Data/IEntityReadRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -18,6 +19,9 @@ namespace JsonApiDotNetCore.Data
         /// The base GET query. This is a good place to apply rules that should affect all reads, 
         /// such as authorization of resources.
         /// </summary>
+        IQueryable<TEntity> GetQueryable();
+
+        [Obsolete("This method has been deprecated, use GetQueryable() instead")]
         IQueryable<TEntity> Get();
 
         /// <summary>

--- a/src/JsonApiDotNetCore/Services/EntityResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/EntityResourceService.cs
@@ -108,6 +108,9 @@ namespace JsonApiDotNetCore.Services
             if (_jsonApiContext.Options.IncludeTotalRecordCount)
                 _jsonApiContext.PageManager.TotalRecords = await _entities.CountAsync(entities);
 
+            if (_jsonApiContext.QuerySet?.Fields?.Count > 0)
+                entities = _entities.Select(entities, _jsonApiContext.QuerySet.Fields);
+
             // pagination should be done last since it will execute the query
             var pagedEntities = await ApplyPageQueryAsync(entities);
             return pagedEntities;

--- a/src/JsonApiDotNetCore/Services/EntityResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/EntityResourceService.cs
@@ -98,7 +98,7 @@ namespace JsonApiDotNetCore.Services
 
         public virtual async Task<IEnumerable<TResource>> GetAsync()
         {
-            var entities = _entities.Get();
+            var entities = _entities.GetQueryable();
 
             entities = ApplySortAndFilterQuery(entities);
 
@@ -243,7 +243,7 @@ namespace JsonApiDotNetCore.Services
 
         private async Task<TResource> GetWithRelationshipsAsync(TId id)
         {
-            var query = _entities.Get().Where(e => e.Id.Equals(id));
+            var query = _entities.GetQueryable().Where(e => e.Id.Equals(id));
 
             _jsonApiContext.QuerySet.IncludedRelationships.ForEach(r =>
             {

--- a/test/DiscoveryTests/ServiceDiscoveryFacadeTests.cs
+++ b/test/DiscoveryTests/ServiceDiscoveryFacadeTests.cs
@@ -1,4 +1,3 @@
-using System;
 using GettingStarted.Models;
 using GettingStarted.ResourceDefinitionExample;
 using JsonApiDotNetCore.Builders;
@@ -7,7 +6,6 @@ using JsonApiDotNetCore.Graph;
 using JsonApiDotNetCore.Models;
 using JsonApiDotNetCore.Services;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 

--- a/test/JsonApiDotNetCoreExampleTests/Helpers/Repositories/AuthorizedTodoItemsRepository.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Helpers/Repositories/AuthorizedTodoItemsRepository.cs
@@ -23,9 +23,9 @@ namespace JsonApiDotNetCoreExampleTests.Repositories
             _authService = authService;
         }
 
-        public override IQueryable<TodoItem> Get()
+        public override IQueryable<TodoItem> GetQueryable()
         {
-            return base.Get().Where(todoItem => todoItem.OwnerId == _authService.CurrentUserId);
+            return base.GetQueryable().Where(todoItem => todoItem.OwnerId == _authService.CurrentUserId);
         }
     }
 }


### PR DESCRIPTION
Closes #475 

Current implementation:
- sparse fields calls Select() query first, than follows Filter() (and other methods in IQueryableExtensions). In case Select() (with internal Provider.CreateQuery<TEntity>() call) is applied like that, LINQ Where() method is reduced in runtime and has no info about other properties outside Select() => this is exactly the use-case, when overriding repository Get() method. And this leads to broken sql translation.

Requested implementation:
- Select() call is moved from DefaultEntityRepository.Get() to EntityResourceService.GetAsync() before Skip() and Take(). There is no "reduce" danger.

What do you think about this change? 