### PR TITLE
fix: sparse fields set not applied to query

### DIFF
--- a/JsonApiDotnetCore.sln
+++ b/JsonApiDotnetCore.sln
@@ -204,6 +204,7 @@ Global
 		{09C0C8D8-B721-4955-8889-55CB149C3B5C}.Release|x86.ActiveCfg = Release|Any CPU
 		{09C0C8D8-B721-4955-8889-55CB149C3B5C}.Release|x86.Build.0 = Release|Any CPU
 		{DF9BFD82-D937-4907-B0B4-64670417115F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF9BFD82-D937-4907-B0B4-64670417115F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -140,7 +140,7 @@ namespace JsonApiDotNetCore.Data
         /// <inheritdoc />
         public virtual async Task<TEntity> GetAsync(TId id)
         {
-            return await GetQueryable().SingleOrDefaultAsync(e => e.Id.Equals(id));
+            return await Select(GetQueryable(), _jsonApiContext.QuerySet?.Fields).SingleOrDefaultAsync(e => e.Id.Equals(id));
         }
 
         /// <inheritdoc />
@@ -148,7 +148,7 @@ namespace JsonApiDotNetCore.Data
         {
             _logger?.LogDebug($"[JADN] GetAndIncludeAsync({id}, {relationshipName})");
 
-            var includedSet = Include(GetQueryable(), relationshipName);
+            var includedSet = Include(Select(GetQueryable(), _jsonApiContext.QuerySet?.Fields), relationshipName);
             var result = await includedSet.SingleOrDefaultAsync(e => e.Id.Equals(id));
 
             return result;

--- a/src/JsonApiDotNetCore/Services/EntityResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/EntityResourceService.cs
@@ -108,8 +108,7 @@ namespace JsonApiDotNetCore.Services
             if (_jsonApiContext.Options.IncludeTotalRecordCount)
                 _jsonApiContext.PageManager.TotalRecords = await _entities.CountAsync(entities);
 
-            if (_jsonApiContext.QuerySet?.Fields?.Count > 0)
-                entities = _entities.Select(entities, _jsonApiContext.QuerySet.Fields);
+            entities = _entities.Select(entities, _jsonApiContext.QuerySet?.Fields);
 
             // pagination should be done last since it will execute the query
             var pagedEntities = await ApplyPageQueryAsync(entities);
@@ -243,7 +242,7 @@ namespace JsonApiDotNetCore.Services
 
         private async Task<TResource> GetWithRelationshipsAsync(TId id)
         {
-            var query = _entities.GetQueryable().Where(e => e.Id.Equals(id));
+            var query = _entities.Select(_entities.GetQueryable(), _jsonApiContext.QuerySet?.Fields).Where(e => e.Id.Equals(id));
 
             _jsonApiContext.QuerySet.IncludedRelationships.ForEach(r =>
             {


### PR DESCRIPTION
continuation of #476 

Indeed, @milosloub, there are still some issues; I was too hasty with replacing `Get` with the new `GetQueryable`.

Interestingly enough tests are not failing. Some investigation about this:

* `Fields_Query_Selects_Sparse_Field_Sets` is not failing because, even though the sparse field set is not processed in the SQL query, the `DocumentBuilder` [still removes the fields](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/11fe0dac79468af58f55c7c56bab013e1fdeb8f0/src/JsonApiDotNetCore/Builders/DocumentBuilder.cs#L134) from the output JSON. This behaviour annoys me: (de)serialization should be decoupled from `JsonApiContext`, see #497. I don't think we can properly integration test the usage of the new `GetQueryable` without getting rid of this behaviour in the serialization layer, but that is beyond the scope of this PR.

* I suspect the same goes for the other sparse field set tests. 


I have changed a few things that should apply it to the queries again. All tests are passing, let me know if you have any more comments or an idea how we could more thoroughly test the new `GetQueryable`. (Note that the previous `Get` wasn't properly tested for sparse field selection neither)