### PR TITLE
DefaultEntityRepository cleanup

### DIFF
--- a/src/Examples/JsonApiDotNetCoreExample/Models/Passport.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Models/Passport.cs
@@ -1,0 +1,11 @@
+using JsonApiDotNetCore.Models;
+
+namespace JsonApiDotNetCoreExample.Models
+{
+    public class Passport : Identifiable
+    {
+        public virtual int? SocialSecurityNumber { get; set; }
+        [HasOne("person")]
+        public virtual Person Person { get; set; }
+    }
+}

--- a/src/Examples/JsonApiDotNetCoreExample/Models/Person.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Models/Person.cs
@@ -45,5 +45,9 @@ namespace JsonApiDotNetCoreExample.Models
                 { "authors", new string[] { "Jared Nance" } }
             };
         }
+        public int? PassportId { get; set; }
+        [HasOne("passport")]
+        public virtual Passport Passport { get; set; }
+
     }
 }

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -149,6 +149,15 @@ namespace JsonApiDotNetCore.Data
         public virtual async Task<TEntity> CreateAsync(TEntity entity)
         {
             AttachRelationships(entity);
+            foreach (var relationshipEntry in _jsonApiContext.RelationshipsToUpdate)
+            {
+                var relationshipValue = relationshipEntry.Value;
+                if (relationshipEntry.Key is HasManyThroughAttribute throughAttribute)
+                {
+                    AssignHasManyThrough(entity, throughAttribute, (IList)relationshipValue);
+                }
+            }
+
             _dbSet.Add(entity);
 
             await _context.SaveChangesAsync();

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -281,7 +281,6 @@ namespace JsonApiDotNetCore.Data
         // helper method used in GetTrackedRelationshipValue. See comments there.
         private IIdentifiable GetTrackedHasOneRelationshipValue(IIdentifiable relationshipValue, HasOneAttribute hasOneAttribute, ref bool wasAlreadyAttached)
         {
-
             var tracked = AttachOrGetTracked(relationshipValue);
             if (tracked != null) wasAlreadyAttached = true;
             return tracked ?? relationshipValue;

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -242,7 +242,6 @@ namespace JsonApiDotNetCore.Data
                     }
                     else if (relationshipEntry.Key is HasOneAttribute hasOneAttribute)
                     {
-                        //var foreignkeyValue = relationshipValue.GetType().GetProperty(hasOneAttribute.IdentifiablePropertyName).GetValue(oldEntity);
                         hasOneAttribute.SetValue(oldEntity, relationshipValue);
                     }
                 }

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -171,13 +171,14 @@ namespace JsonApiDotNetCore.Data
         /// <summary>
         /// Loads the inverse relationships to prevent foreign key constraints from being violated
         /// to support implicit removes, see https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/502.
-        /// <para/>
+        /// <remark>
         /// Consider the following example: 
         /// person.todoItems = [t1,t2] is updated to [t3, t4]. If t3, and/or t4 was
         /// already related to a other person, and these persons are NOT loaded in to the 
         /// db context, then the query may cause a foreign key constraint. Loading
         /// these "inverse relationships" into the DB context ensures EF core to take
         /// this into account.
+        /// </remark>
         /// </summary>
         private void LoadInverseRelationships(object trackedRelationshipValue, RelationshipAttribute relationshipAttr)
         {

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -242,6 +242,7 @@ namespace JsonApiDotNetCore.Data
                     }
                     else if (relationshipEntry.Key is HasOneAttribute hasOneAttribute)
                     {
+                        //var foreignkeyValue = relationshipValue.GetType().GetProperty(hasOneAttribute.IdentifiablePropertyName).GetValue(oldEntity);
                         hasOneAttribute.SetValue(oldEntity, relationshipValue);
                     }
                 }
@@ -405,7 +406,7 @@ namespace JsonApiDotNetCore.Data
                     var tracked = AttachOrGetTracked(pointer);
                     if (tracked != null) alreadyTracked = true;
                     return tracked ?? pointer;
-                });
+                }).Cast(attribute.Type);
 
                 if (alreadyTracked) relationships[attribute] = (IList)newPointerCollection;
             }

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -247,10 +247,12 @@ namespace JsonApiDotNetCore.Data
                     {
                         // load relations to enforce complete replace
                         await _context.Entry(oldEntity).Collection(hasManyAttribute.InternalRelationshipName).LoadAsync();
+                        // also need to load inverse relationship here, see issue #502
                         hasManyAttribute.SetValue(oldEntity, relationshipValue);
                     }
                     else if (relationshipEntry.Key is HasOneAttribute hasOneAttribute)
                     {
+                        // need to load inverse relationship here, see issue #502
                         hasOneAttribute.SetValue(oldEntity, relationshipValue);
                     }
                 }

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -404,8 +404,8 @@ namespace JsonApiDotNetCore.Data
         /// <summary>
         /// assigns relationships that were set in the request to the target entity of the request
         /// todo: partially remove dependency on IJsonApiContext here: it is fine to
-        /// retrieve from the context WHICH relationships to update, but the actual values should
-        /// come from the context.
+        /// retrieve from the context WHICH relationships to update, but the actual
+        /// values should not come from the context.
         /// </summary>
         protected void AssignRelationshipValues(TEntity oldEntity)
         {

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -62,8 +62,7 @@ namespace JsonApiDotNetCore.Data
             _resourceDefinition = resourceDefinition;
         }
 
-        public
-        DefaultEntityRepository(
+        public DefaultEntityRepository(
             ILoggerFactory loggerFactory,
             IJsonApiContext jsonApiContext,
             IDbContextResolver contextResolver,

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -171,8 +171,8 @@ namespace JsonApiDotNetCore.Data
         /// <summary>
         /// Loads the inverse relationships to prevent foreign key constraints from being violated
         /// to support implicit removes, see https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/502.
-        /// 
-        /// example: 
+        /// <para/>
+        /// Consider the following example: 
         /// person.todoItems = [t1,t2] is updated to [t3, t4]. If t3, and/or t4 was
         /// already related to a other person, and these persons are NOT loaded in to the 
         /// db context, then the query may cause a foreign key constraint. Loading

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -238,14 +238,16 @@ namespace JsonApiDotNetCore.Data
             }
         }
 
-        /// <inheritdoc />
+        [Obsolete("Use overload UpdateAsync(TEntity updatedEntity): providing parameter ID does no longer add anything relevant")]
         public virtual async Task<TEntity> UpdateAsync(TId id, TEntity updatedEntity)
         {
-            /// WHY is parameter "entity" even passed along to this method??
-            /// It does nothing!
+            return await UpdateAsync(updatedEntity);
+        }
 
-            var oldEntity = await GetAsync(id);
-
+        /// <inheritdoc />
+        public virtual async Task<TEntity> UpdateAsync(TEntity updatedEntity)
+        {
+            var oldEntity = await GetAsync(updatedEntity.Id);
             if (oldEntity == null)
                 return null;
 
@@ -259,6 +261,7 @@ namespace JsonApiDotNetCore.Data
                 LoadInverseRelationships(trackedRelationshipValue, relationshipAttr);
                 AssignRelationshipValue(oldEntity, trackedRelationshipValue, relationshipAttr);
             }
+
             await _context.SaveChangesAsync();
             return oldEntity;
         }

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -195,9 +195,10 @@ namespace JsonApiDotNetCore.Data
             }
         }
 
-        private bool IsHasOneRelationship(string inverseNavigation, Type type)
+
+        private bool IsHasOneRelationship(string internalRelationshipName, Type type)
         {
-            var relationshipAttr = _jsonApiContext.ResourceGraph.GetContextEntity(type).Relationships.Single(r => r.InternalRelationshipName == inverseNavigation);
+            var relationshipAttr = _jsonApiContext.ResourceGraph.GetContextEntity(type).Relationships.Single(r => r.InternalRelationshipName == internalRelationshipName);
             if (relationshipAttr is HasOneAttribute) return true;
             return false;
         }
@@ -455,7 +456,7 @@ namespace JsonApiDotNetCore.Data
         /// retrieve from the context WHICH relationships to update, but the actual
         /// values should not come from the context.
         /// </summary>
-        protected void AssignRelationshipValue(TEntity oldEntity, object relationshipValue, RelationshipAttribute relationshipAttribute)
+        private void AssignRelationshipValue(TEntity oldEntity, object relationshipValue, RelationshipAttribute relationshipAttribute)
         {
             if (relationshipAttribute is HasManyThroughAttribute throughAttribute)
             {
@@ -493,7 +494,7 @@ namespace JsonApiDotNetCore.Data
         /// A helper method that gets the relationship value in the case of 
         /// entity resource separation.
         /// </summary>
-        IIdentifiable GetEntityResourceSeparationValue(TEntity entity, HasOneAttribute attribute)
+        private IIdentifiable GetEntityResourceSeparationValue(TEntity entity, HasOneAttribute attribute)
         {
             if (attribute.EntityPropertyName == null)
             {
@@ -506,7 +507,7 @@ namespace JsonApiDotNetCore.Data
         /// A helper method that gets the relationship value in the case of 
         /// entity resource separation.
         /// </summary>
-        IEnumerable<IIdentifiable> GetEntityResourceSeparationValue(TEntity entity, HasManyAttribute attribute)
+        private IEnumerable<IIdentifiable> GetEntityResourceSeparationValue(TEntity entity, HasManyAttribute attribute)
         {
             if (attribute.EntityPropertyName == null)
             {
@@ -522,7 +523,7 @@ namespace JsonApiDotNetCore.Data
         /// 
         /// useful article: https://stackoverflow.com/questions/30987806/dbset-attachentity-vs-dbcontext-entryentity-state-entitystate-modified
         /// </summary>
-        IIdentifiable AttachOrGetTracked(IIdentifiable relationshipValue)
+        private IIdentifiable AttachOrGetTracked(IIdentifiable relationshipValue)
         {
             var trackedEntity = _context.GetTrackedEntity(relationshipValue);
 

--- a/src/JsonApiDotNetCore/Data/IEntityWriteRepository.cs
+++ b/src/JsonApiDotNetCore/Data/IEntityWriteRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using JsonApiDotNetCore.Models;
@@ -14,6 +15,9 @@ namespace JsonApiDotNetCore.Data
     {
         Task<TEntity> CreateAsync(TEntity entity);
 
+        Task<TEntity> UpdateAsync(TEntity entity);
+
+        [Obsolete("Use overload UpdateAsync(TEntity updatedEntity): providing parameter ID does no longer add anything relevant")]
         Task<TEntity> UpdateAsync(TId id, TEntity entity);
 
         Task UpdateRelationshipsAsync(object parent, RelationshipAttribute relationship, IEnumerable<string> relationshipIds);

--- a/src/JsonApiDotNetCore/Extensions/DbContextExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/DbContextExtensions.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using JsonApiDotNetCore.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -31,6 +33,7 @@ namespace JsonApiDotNetCore.Extensions
         {
             return GetTrackedEntity(context, entity) != null;
         }
+
 
         /// <summary>
         /// Determines whether or not EF is already tracking an entity of the same Type and Id

--- a/src/JsonApiDotNetCore/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IApplicationBuilderExtensions.cs
@@ -4,6 +4,7 @@ using JsonApiDotNetCore.Internal;
 using JsonApiDotNetCore.Middleware;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace JsonApiDotNetCore.Extensions
@@ -20,6 +21,12 @@ namespace JsonApiDotNetCore.Extensions
 
             if (useMvc)
                 app.UseMvc();
+
+            using (var scope = app.ApplicationServices.CreateScope())
+            {
+                var inverseRelationshipResolver = scope.ServiceProvider.GetService<IInverseRelationships>();
+                inverseRelationshipResolver?.Resolve();
+            }
 
             return app;
         }

--- a/src/JsonApiDotNetCore/Extensions/IServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IServiceCollectionExtensions.cs
@@ -155,6 +155,9 @@ namespace JsonApiDotNetCore.Extensions
             services.AddScoped<IControllerContext, Services.ControllerContext>();
             services.AddScoped<IDocumentBuilderOptionsProvider, DocumentBuilderOptionsProvider>();
 
+            services.AddScoped<IInverseRelationships, InverseRelationships>();
+
+
             // services.AddScoped<IActionFilter, TypeMatchFilter>();
         }
 

--- a/src/JsonApiDotNetCore/Extensions/TypeExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/TypeExtensions.cs
@@ -8,6 +8,32 @@ namespace JsonApiDotNetCore.Extensions
 {
     internal static class TypeExtensions
     {
+        public static void AddRange<T>(this IList list, IEnumerable<T> items)
+        {
+            if (list == null) throw new ArgumentNullException(nameof(list));
+            if (items == null) throw new ArgumentNullException(nameof(items));
+
+            if (list is List<T>)
+            {
+                ((List<T>)list).AddRange(items);
+            }
+            else
+            {
+                foreach (var item in items)
+                {
+                    list.Add(item);
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Extension to use the LINQ cast method in a non-generic way:
+        /// <code>
+        /// Type targetType = typeof(TEntity)
+        /// ((IList)myList).Cast(targetType).
+        /// </code>
+        /// </summary>
         public static IEnumerable Cast(this IEnumerable source, Type type)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));

--- a/src/JsonApiDotNetCore/Extensions/TypeExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/TypeExtensions.cs
@@ -8,6 +8,9 @@ namespace JsonApiDotNetCore.Extensions
 {
     internal static class TypeExtensions
     {
+        /// <summary>
+        /// Extension to use the LINQ AddRange method on an IList
+        /// </summary>
         public static void AddRange<T>(this IList list, IEnumerable<T> items)
         {
             if (list == null) throw new ArgumentNullException(nameof(list));

--- a/src/JsonApiDotNetCore/Extensions/TypeExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/TypeExtensions.cs
@@ -8,6 +8,13 @@ namespace JsonApiDotNetCore.Extensions
 {
     internal static class TypeExtensions
     {
+        public static IEnumerable Cast(this IEnumerable source, Type type)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+            return TypeHelper.ConvertCollection(source.Cast<object>(), type);
+        }
+
         public static Type GetElementType(this IEnumerable enumerable)
         {
             var enumerableTypes = enumerable.GetType()

--- a/src/JsonApiDotNetCore/Formatters/JsonApiReader.cs
+++ b/src/JsonApiDotNetCore/Formatters/JsonApiReader.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections;
 using System.IO;
 using System.Threading.Tasks;
 using JsonApiDotNetCore.Internal;
+using JsonApiDotNetCore.Models;
 using JsonApiDotNetCore.Serialization;
 using JsonApiDotNetCore.Services;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -37,7 +39,7 @@ namespace JsonApiDotNetCore.Formatters
             {
                 var body = GetRequestBody(context.HttpContext.Request.Body);
 
-                object model =null;
+                object model = null;
 
                 if (_jsonApiContext.IsRelationshipPath)
                 {
@@ -48,9 +50,28 @@ namespace JsonApiDotNetCore.Formatters
                     model = _deSerializer.Deserialize(body);
                 }
 
+
                 if (model == null)
                 {
                     _logger?.LogError("An error occurred while de-serializing the payload");
+                }
+
+                if (context.HttpContext.Request.Method == "PATCH")
+                {
+                    bool idMissing;
+                    if (model is IList list)
+                    {
+                        idMissing = CheckForId(list);
+                    }
+                    else
+                    {
+                        idMissing = CheckForId(model);
+                    }
+                    if (idMissing)
+                    {
+                        _logger?.LogError("Payload must include id attribute");
+                        throw new JsonApiException(400, "Payload must include id attribute");
+                    }
                 }
                 return InputFormatterResult.SuccessAsync(model);
             }
@@ -60,6 +81,38 @@ namespace JsonApiDotNetCore.Formatters
                 context.ModelState.AddModelError(context.ModelName, ex, context.Metadata);
                 return InputFormatterResult.FailureAsync();
             }
+        }
+
+        private bool CheckForId(object model)
+        {
+            if (model == null) return false;
+            if (model is ResourceObject ro)
+            {
+                if (string.IsNullOrEmpty(ro.Id)) return true;
+            }
+            else if (model is IIdentifiable identifiable)
+            {
+                if (string.IsNullOrEmpty(identifiable.StringId)) return true;
+            }
+            return false;
+        }
+
+        private bool CheckForId(IList modelList)
+        {
+            foreach (var model in modelList)
+            {
+                if (model == null) continue;
+                if (model is ResourceObject ro)
+                {
+                    if (string.IsNullOrEmpty(ro.Id)) return true;
+                }
+                else if (model is IIdentifiable identifiable)
+                {
+                    if (string.IsNullOrEmpty(identifiable.StringId)) return true;
+                }
+            }
+            return false;
+
         }
 
         private string GetRequestBody(Stream body)

--- a/src/JsonApiDotNetCore/Formatters/JsonApiReader.cs
+++ b/src/JsonApiDotNetCore/Formatters/JsonApiReader.cs
@@ -83,6 +83,7 @@ namespace JsonApiDotNetCore.Formatters
             }
         }
 
+        /// <summary> Checks if the deserialized payload has an ID included </summary
         private bool CheckForId(object model)
         {
             if (model == null) return false;
@@ -97,6 +98,7 @@ namespace JsonApiDotNetCore.Formatters
             return false;
         }
 
+        /// <summary> Checks if the elements in the deserialized payload have an ID included </summary
         private bool CheckForId(IList modelList)
         {
             foreach (var model in modelList)

--- a/src/JsonApiDotNetCore/Internal/InverseRelationships.cs
+++ b/src/JsonApiDotNetCore/Internal/InverseRelationships.cs
@@ -1,0 +1,65 @@
+using System;
+using JsonApiDotNetCore.Data;
+using JsonApiDotNetCore.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace JsonApiDotNetCore.Internal
+{
+    /// <summary>
+    /// Responsible for populating the RelationshipAttribute InverseNavigation property.
+    /// 
+    /// This service is instantiated in the configure phase of the application.
+    /// 
+    /// When using a data access layer different from EF Core, and when using ResourceHooks
+    /// that depend on the inverse navigation property (BeforeImplicitUpdateRelationship),
+    /// you will need to override this service, or pass along the inverseNavigationProperty in
+    /// the RelationshipAttribute.
+    /// </summary>
+    public interface IInverseRelationships
+    {
+        void Resolve();
+    }
+
+    public class InverseRelationships : IInverseRelationships
+    {
+        private readonly ResourceGraph _graph;
+        private readonly IDbContextResolver _resolver;
+
+        public InverseRelationships(IResourceGraph graph, IDbContextResolver resolver = null)
+        {
+            _graph = (ResourceGraph)graph;
+            _resolver = resolver;
+        }
+
+        public void Resolve()
+        {
+            if (EntityFrameworkCoreIsEnabled())
+            {
+                DbContext context = _resolver.GetContext();
+
+                foreach (ContextEntity ce in _graph.Entities)
+                {
+                    IEntityType meta = context.Model.FindEntityType(ce.EntityType);
+                    if (meta == null) continue;
+                    foreach (var attr in ce.Relationships)
+                    {
+                        if (attr is HasManyThroughAttribute) continue;
+                        INavigation inverseNavigation = meta.FindNavigation(attr.InternalRelationshipName)?.FindInverse();
+                        attr.InverseNavigation = inverseNavigation?.Name;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// If EF Core is not being used, we're expecting the resolver to not be registered.
+        /// </summary>
+        /// <returns><c>true</c>, if entity framework core was enabled, <c>false</c> otherwise.</returns>
+        /// <param name="resolver">Resolver.</param>
+        private bool EntityFrameworkCoreIsEnabled()
+        {
+            return _resolver != null;
+        }
+    }
+}

--- a/src/JsonApiDotNetCore/Internal/InverseRelationships.cs
+++ b/src/JsonApiDotNetCore/Internal/InverseRelationships.cs
@@ -18,9 +18,14 @@ namespace JsonApiDotNetCore.Internal
     /// </summary>
     public interface IInverseRelationships
     {
+        /// <summary>
+        /// This method is called upon startup by JsonApiDotNetCore. It should 
+        /// deal with resolving the inverse relationships. 
+        /// </summary>
         void Resolve();
     }
 
+    /// <inheritdoc />
     public class InverseRelationships : IInverseRelationships
     {
         private readonly ResourceGraph _graph;
@@ -32,6 +37,7 @@ namespace JsonApiDotNetCore.Internal
             _resolver = resolver;
         }
 
+        /// <inheritdoc />
         public void Resolve()
         {
             if (EntityFrameworkCoreIsEnabled())

--- a/src/JsonApiDotNetCore/Models/HasManyAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/HasManyAttribute.cs
@@ -24,9 +24,11 @@ namespace JsonApiDotNetCore.Models
         /// </code>
         /// 
         /// </example>
-        public HasManyAttribute(string publicName = null, Link documentLinks = Link.All, bool canInclude = true, string mappedBy = null)
+        public HasManyAttribute(string publicName = null, Link documentLinks = Link.All, bool canInclude = true, string mappedBy = null, string inverseNavigationProperty = null)
         : base(publicName, documentLinks, canInclude, mappedBy)
-        { }
+        {
+            InverseNavigation = inverseNavigationProperty;
+        }
 
         /// <summary>
         /// Sets the value of the property identified by this attribute

--- a/src/JsonApiDotNetCore/Models/HasOneAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/HasOneAttribute.cs
@@ -34,8 +34,6 @@ namespace JsonApiDotNetCore.Models
             _explicitIdentifiablePropertyName = withForeignKey;
             InverseNavigation = inverseNavigationProperty;
         }
-        public string InverseNavigation { get; internal set; }
-
 
         private readonly string _explicitIdentifiablePropertyName;
         

--- a/src/JsonApiDotNetCore/Models/HasOneAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/HasOneAttribute.cs
@@ -50,13 +50,9 @@ namespace JsonApiDotNetCore.Models
         /// <param name="newValue">The new property value</param>
         public override void SetValue(object resource, object newValue)
         {
-            var propertyName = (newValue?.GetType() == Type)
-                ? InternalRelationshipName
-                : IdentifiablePropertyName;
-
             var propertyInfo = resource
                 .GetType()
-                .GetProperty(propertyName);
+                .GetProperty(InternalRelationshipName);
 
             propertyInfo.SetValue(resource, newValue);
         }

--- a/src/JsonApiDotNetCore/Models/HasOneAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/HasOneAttribute.cs
@@ -50,10 +50,13 @@ namespace JsonApiDotNetCore.Models
         /// <param name="newValue">The new property value</param>
         public override void SetValue(object resource, object newValue)
         {
-            var propertyInfo = resource
-                .GetType()
-                .GetProperty(InternalRelationshipName);
+            string propertyName = InternalRelationshipName;
+            // if we're deleting the relationship (setting it to null),
+            // we set the foreignKey to null. We could also set the actual property to null,
+            // but then we would first need to load the current relationship, which requires an extra query.
+            if (newValue == null) propertyName = IdentifiablePropertyName;
 
+            var propertyInfo = resource.GetType().GetProperty(propertyName);
             propertyInfo.SetValue(resource, newValue);
         }
 

--- a/src/JsonApiDotNetCore/Models/HasOneAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/HasOneAttribute.cs
@@ -28,11 +28,14 @@ namespace JsonApiDotNetCore.Models
         /// </code>
         /// 
         /// </example>
-        public HasOneAttribute(string publicName = null, Link documentLinks = Link.All, bool canInclude = true, string withForeignKey = null, string mappedBy = null)
+        public HasOneAttribute(string publicName = null, Link documentLinks = Link.All, bool canInclude = true, string withForeignKey = null, string mappedBy = null, string inverseNavigationProperty = null)
         : base(publicName, documentLinks, canInclude, mappedBy)
         {
             _explicitIdentifiablePropertyName = withForeignKey;
+            InverseNavigation = inverseNavigationProperty;
         }
+        public string InverseNavigation { get; internal set; }
+
 
         private readonly string _explicitIdentifiablePropertyName;
         

--- a/src/JsonApiDotNetCore/Models/RelationshipAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/RelationshipAttribute.cs
@@ -15,8 +15,10 @@ namespace JsonApiDotNetCore.Models
         }
 
         public string PublicRelationshipName { get; internal set; }
-        public string InternalRelationshipName { get; internal set; } 
-        
+        public string InternalRelationshipName { get; internal set; }
+
+        public string InverseNavigation { get; internal set; }
+
         /// <summary>
         /// The related entity type. This does not necessarily match the navigation property type.
         /// In the case of a HasMany relationship, this value will be the generic argument type.

--- a/src/JsonApiDotNetCore/Models/RelationshipAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/RelationshipAttribute.cs
@@ -16,7 +16,6 @@ namespace JsonApiDotNetCore.Models
 
         public string PublicRelationshipName { get; internal set; }
         public string InternalRelationshipName { get; internal set; }
-
         public string InverseNavigation { get; internal set; }
 
         /// <summary>

--- a/src/JsonApiDotNetCore/Request/HasManyRelationshipPointers.cs
+++ b/src/JsonApiDotNetCore/Request/HasManyRelationshipPointers.cs
@@ -32,7 +32,7 @@ namespace JsonApiDotNetCore.Request
     /// </summary>
     public class HasManyRelationshipPointers
     {
-        private Dictionary<RelationshipAttribute, IList> _hasManyRelationships = new Dictionary<RelationshipAttribute, IList>();
+        private readonly Dictionary<RelationshipAttribute, IList> _hasManyRelationships = new Dictionary<RelationshipAttribute, IList>();
 
         /// <summary>
         /// Add the relationship to the list of relationships that should be 

--- a/src/JsonApiDotNetCore/Request/HasOneRelationshipPointers.cs
+++ b/src/JsonApiDotNetCore/Request/HasOneRelationshipPointers.cs
@@ -28,18 +28,18 @@ namespace JsonApiDotNetCore.Request
     /// </summary>
     public class HasOneRelationshipPointers
     {
-        private Dictionary<RelationshipAttribute, IIdentifiable> _hasOneRelationships = new Dictionary<RelationshipAttribute, IIdentifiable>();
+        private readonly Dictionary<HasOneAttribute, IIdentifiable> _hasOneRelationships = new Dictionary<HasOneAttribute, IIdentifiable>();
 
         /// <summary>
         /// Add the relationship to the list of relationships that should be 
         /// set in the repository layer.
         /// </summary>
-        public void Add(RelationshipAttribute relationship, IIdentifiable entity)
+        public void Add(HasOneAttribute relationship, IIdentifiable entity)
             => _hasOneRelationships[relationship] = entity;
 
         /// <summary>
         /// Get all the models that should be associated
         /// </summary>
-        public Dictionary<RelationshipAttribute, IIdentifiable> Get() => _hasOneRelationships;
+        public Dictionary<HasOneAttribute, IIdentifiable> Get() => _hasOneRelationships;
     }
 }

--- a/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
@@ -250,7 +250,7 @@ namespace JsonApiDotNetCore.Serialization
 
                 var convertedValue = TypeHelper.ConvertType(foreignKeyPropertyValue, foreignKeyProperty.PropertyType);
                 foreignKeyProperty.SetValue(entity, convertedValue);
-                //_jsonApiContext.RelationshipsToUpdate[hasOneAttr] = convertedValue;
+                if (convertedValue == null )  _jsonApiContext.HasOneRelationshipPointers.Add(hasOneAttr, null); 
             }
         }
 

--- a/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
@@ -250,7 +250,7 @@ namespace JsonApiDotNetCore.Serialization
 
                 var convertedValue = TypeHelper.ConvertType(foreignKeyPropertyValue, foreignKeyProperty.PropertyType);
                 foreignKeyProperty.SetValue(entity, convertedValue);
-                _jsonApiContext.RelationshipsToUpdate[hasOneAttr] = convertedValue;
+                //_jsonApiContext.RelationshipsToUpdate[hasOneAttr] = convertedValue;
             }
         }
 
@@ -300,7 +300,7 @@ namespace JsonApiDotNetCore.Serialization
                 var convertedCollection = TypeHelper.ConvertCollection(relatedResources, attr.Type);
 
                 attr.SetValue(entity, convertedCollection);
-                _jsonApiContext.RelationshipsToUpdate[attr] = convertedCollection;
+                //_jsonApiContext.RelationshipsToUpdate[attr] = convertedCollection; // WHAT exactly is the use of these two different collections..?
                 _jsonApiContext.HasManyRelationshipPointers.Add(attr, convertedCollection);
             }
 

--- a/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
@@ -159,6 +159,7 @@ namespace JsonApiDotNetCore.Serialization
                     /// through the decoupling IJsonApiContext), we now no longer need to 
                     /// store the updated relationship values in this property. For now 
                     /// just assigning null as value, will remove this property later as a whole.
+                    /// see #512
                     _jsonApiContext.AttributesToUpdate[attr] = null;
                 }
             }
@@ -224,14 +225,14 @@ namespace JsonApiDotNetCore.Serialization
             SetHasOneNavigationPropertyValue(entity, attr, rio, included);
 
             // recursive call ...
-            if(included != null) 
+            if (included != null)
             {
                 var navigationPropertyValue = attr.GetValue(entity);
                 var resourceGraphEntity = _jsonApiContext.ResourceGraph.GetContextEntity(attr.Type);
-                if(navigationPropertyValue != null && resourceGraphEntity != null)
+                if (navigationPropertyValue != null && resourceGraphEntity != null)
                 {
                     var includedResource = included.SingleOrDefault(r => r.Type == rio.Type && r.Id == rio.Id);
-                    if(includedResource != null) 
+                    if (includedResource != null)
                         SetRelationships(navigationPropertyValue, resourceGraphEntity, includedResource.Relationships, included);
                 }
             }
@@ -257,7 +258,8 @@ namespace JsonApiDotNetCore.Serialization
                 /// through the decoupling IJsonApiContext), we now no longer need to 
                 /// store the updated relationship values in this property. For now 
                 /// just assigning null as value, will remove this property later as a whole.
-                if (convertedValue == null )  _jsonApiContext.HasOneRelationshipPointers.Add(hasOneAttr, null); 
+                /// see #512
+                if (convertedValue == null) _jsonApiContext.HasOneRelationshipPointers.Add(hasOneAttr, null);
             }
         }
 
@@ -281,6 +283,7 @@ namespace JsonApiDotNetCore.Serialization
                 /// through the decoupling IJsonApiContext), we now no longer need to 
                 /// store the updated relationship values in this property. For now 
                 /// just assigning null as value, will remove this property later as a whole.
+                /// see #512
                 _jsonApiContext.HasOneRelationshipPointers.Add(hasOneAttr, null);
             }
         }
@@ -296,7 +299,7 @@ namespace JsonApiDotNetCore.Serialization
 
             if (relationships.TryGetValue(relationshipName, out RelationshipData relationshipData))
             {
-                if(relationshipData.IsHasMany == false || relationshipData.ManyData == null)
+                if (relationshipData.IsHasMany == false || relationshipData.ManyData == null)
                     return entity;
 
                 var relatedResources = relationshipData.ManyData.Select(r =>
@@ -312,7 +315,8 @@ namespace JsonApiDotNetCore.Serialization
                 /// through the decoupling IJsonApiContext), we now no longer need to 
                 /// store the updated relationship values in this property. For now 
                 /// just assigning null as value, will remove this property later as a whole.
-                _jsonApiContext.HasManyRelationshipPointers.Add(attr, null); 
+                /// see #512
+                _jsonApiContext.HasManyRelationshipPointers.Add(attr, null);
             }
 
             return entity;

--- a/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/JsonApiDeSerializer.cs
@@ -155,7 +155,11 @@ namespace JsonApiDotNetCore.Serialization
                         continue;
                     var convertedValue = ConvertAttrValue(newValue, attr.PropertyInfo.PropertyType);
                     attr.SetValue(entity, convertedValue);
-                    _jsonApiContext.AttributesToUpdate[attr] = convertedValue;
+                    /// todo: as a part of the process of decoupling JADNC (specifically 
+                    /// through the decoupling IJsonApiContext), we now no longer need to 
+                    /// store the updated relationship values in this property. For now 
+                    /// just assigning null as value, will remove this property later as a whole.
+                    _jsonApiContext.AttributesToUpdate[attr] = null;
                 }
             }
 
@@ -249,7 +253,10 @@ namespace JsonApiDotNetCore.Serialization
                     throw new JsonApiException(400, $"Cannot set required relationship identifier '{hasOneAttr.IdentifiablePropertyName}' to null because it is a non-nullable type.");
 
                 var convertedValue = TypeHelper.ConvertType(foreignKeyPropertyValue, foreignKeyProperty.PropertyType);
-                foreignKeyProperty.SetValue(entity, convertedValue);
+                /// todo: as a part of the process of decoupling JADNC (specifically 
+                /// through the decoupling IJsonApiContext), we now no longer need to 
+                /// store the updated relationship values in this property. For now 
+                /// just assigning null as value, will remove this property later as a whole.
                 if (convertedValue == null )  _jsonApiContext.HasOneRelationshipPointers.Add(hasOneAttr, null); 
             }
         }
@@ -270,10 +277,11 @@ namespace JsonApiDotNetCore.Serialization
                 if (includedRelationshipObject != null)
                     hasOneAttr.SetValue(entity, includedRelationshipObject);
 
-                // we need to store the fact that this relationship was included in the payload
-                // for EF, the repository will use these pointers to make ensure we don't try to
-                // create resources if they already exist, we just need to create the relationship
-                _jsonApiContext.HasOneRelationshipPointers.Add(hasOneAttr, includedRelationshipObject);
+                /// todo: as a part of the process of decoupling JADNC (specifically 
+                /// through the decoupling IJsonApiContext), we now no longer need to 
+                /// store the updated relationship values in this property. For now 
+                /// just assigning null as value, will remove this property later as a whole.
+                _jsonApiContext.HasOneRelationshipPointers.Add(hasOneAttr, null);
             }
         }
 
@@ -300,8 +308,11 @@ namespace JsonApiDotNetCore.Serialization
                 var convertedCollection = TypeHelper.ConvertCollection(relatedResources, attr.Type);
 
                 attr.SetValue(entity, convertedCollection);
-                //_jsonApiContext.RelationshipsToUpdate[attr] = convertedCollection; // WHAT exactly is the use of these two different collections..?
-                _jsonApiContext.HasManyRelationshipPointers.Add(attr, convertedCollection);
+                /// todo: as a part of the process of decoupling JADNC (specifically 
+                /// through the decoupling IJsonApiContext), we now no longer need to 
+                /// store the updated relationship values in this property. For now 
+                /// just assigning null as value, will remove this property later as a whole.
+                _jsonApiContext.HasManyRelationshipPointers.Add(attr, null); 
             }
 
             return entity;

--- a/src/JsonApiDotNetCore/Services/EntityResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/EntityResourceService.cs
@@ -154,9 +154,7 @@ namespace JsonApiDotNetCore.Services
         {
             var entity = MapIn(resource);
 
-
-
-            entity = await _entities.UpdateAsync(id, entity);
+            entity = await _entities.UpdateAsync(entity);
 
             return MapOut(entity);
         }

--- a/src/JsonApiDotNetCore/Services/EntityResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/EntityResourceService.cs
@@ -154,6 +154,8 @@ namespace JsonApiDotNetCore.Services
         {
             var entity = MapIn(resource);
 
+
+
             entity = await _entities.UpdateAsync(id, entity);
 
             return MapOut(entity);

--- a/src/JsonApiDotNetCore/Services/IJsonApiContext.cs
+++ b/src/JsonApiDotNetCore/Services/IJsonApiContext.cs
@@ -35,7 +35,7 @@ namespace JsonApiDotNetCore.Services
         /// Any relationships that were included in a PATCH request. 
         /// Only the relationships in this dictionary should be updated.
         /// </summary>
-        Dictionary<RelationshipAttribute, object> RelationshipsToUpdate { get; set; }
+        Dictionary<RelationshipAttribute, object> RelationshipsToUpdate { get; }
     }
 
     public interface IJsonApiRequest : IJsonApiApplication, IUpdateRequest, IQueryRequest

--- a/src/JsonApiDotNetCore/Services/JsonApiContext.cs
+++ b/src/JsonApiDotNetCore/Services/JsonApiContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using JsonApiDotNetCore.Builders;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Internal;
@@ -52,7 +53,15 @@ namespace JsonApiDotNetCore.Services
         public bool IsBulkOperationRequest { get; set; }
 
         public Dictionary<AttrAttribute, object> AttributesToUpdate { get; set; } = new Dictionary<AttrAttribute, object>();
-        public Dictionary<RelationshipAttribute, object> RelationshipsToUpdate { get; set; } = new Dictionary<RelationshipAttribute, object>();
+        public Dictionary<RelationshipAttribute, object> RelationshipsToUpdate { get => GetRelationshipsToUpdate(); }
+
+        private Dictionary<RelationshipAttribute, object> GetRelationshipsToUpdate()
+        {
+            var hasOneEntries = HasOneRelationshipPointers.Get().ToDictionary(kvp => (RelationshipAttribute)kvp.Key, kvp => (object)kvp.Value);
+            var hasManyEntries = HasManyRelationshipPointers.Get().ToDictionary(kvp => kvp.Key, kvp => (object)kvp.Value);
+            return hasOneEntries.Union(hasManyEntries).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }
+
         public HasManyRelationshipPointers HasManyRelationshipPointers { get; private set; } = new HasManyRelationshipPointers();
         public HasOneRelationshipPointers HasOneRelationshipPointers { get; private set; } = new HasOneRelationshipPointers();
 
@@ -138,7 +147,6 @@ namespace JsonApiDotNetCore.Services
         {
             IncludedRelationships = new List<string>();
             AttributesToUpdate = new Dictionary<AttrAttribute, object>();
-            RelationshipsToUpdate = new Dictionary<RelationshipAttribute, object>();
             HasManyRelationshipPointers = new HasManyRelationshipPointers();
             HasOneRelationshipPointers = new HasOneRelationshipPointers();
         }

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/CamelCasedModelsControllerTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/CamelCasedModelsControllerTests.cs
@@ -143,6 +143,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
                 data = new
                 {
                     type = "camelCasedModels",
+                    id = model.Id,
                     attributes = new Dictionary<string, object>()
                     {
                         { "compoundAttr", newModel.CompoundAttr }

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Extensibility/RepositoryOverrideTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Extensibility/RepositoryOverrideTests.cs
@@ -59,7 +59,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Extensibility
             // assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             foreach(var item in deserializedBody)
-                Assert.Equal(person.Id, item.OwnerId);
+                Assert.Equal(person.Id, item.Owner.Id);
         }
 
         [Fact]

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/UpdatingDataTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/UpdatingDataTests.cs
@@ -55,8 +55,9 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
 
             var content = new
             {
-                datea = new
+                date = new
                 {
+                    id = todoItem.Id,
                     type = "todo-items",
                     attributes = new
                     {
@@ -90,6 +91,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             {
                 data = new
                 {
+                    id = maxPersonId + 100,
                     type = "todo-items",
                     attributes = new
                     {
@@ -106,6 +108,41 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Respond_400_If_IdNotInAttributeList()
+        {
+            // Arrange
+            var maxPersonId = _context.TodoItems.LastOrDefault()?.Id ?? 0;
+            var todoItem = _todoItemFaker.Generate();
+            var builder = new WebHostBuilder()
+                .UseStartup<Startup>();
+
+            var server = new TestServer(builder);
+            var client = server.CreateClient();
+
+            var content = new
+            {
+                data = new
+                {
+                    type = "todo-items",
+                    attributes = new
+                    {
+                        description = todoItem.Description,
+                        ordinal = todoItem.Ordinal,
+                        createdDate = DateTime.Now
+                    }
+                }
+            };
+            var request = PrepareRequest("PATCH", $"/api/v1/todo-items/{maxPersonId}", content);
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(422, Convert.ToInt32(response.StatusCode));
+
         }
 
 
@@ -129,6 +166,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             {
                 data = new
                 {
+                    id = todoItem.Id,
                     type = "todo-items",
                     attributes = new
                     {
@@ -187,6 +225,8 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
                 data = new
                 {
                     type = "people",
+                    id = person.Id,
+
                     attributes = new Dictionary<string, object>
                     {
                         { "last-name",  newPerson.LastName },
@@ -234,6 +274,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
                 data = new
                 {
                     type = "todo-items",
+                    id = todoItem.Id,
                     attributes = new
                     {
                         description = todoItem.Description,

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/UpdatingRelationshipsTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/UpdatingRelationshipsTests.cs
@@ -549,6 +549,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             {
                 data = new
                 {
+                    id = todoItem.Id,
                     type = "todo-items",
                     relationships = new
                     {

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/UpdatingRelationshipsTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/UpdatingRelationshipsTests.cs
@@ -664,7 +664,8 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
 
             // Assert
             var body = await response.Content.ReadAsStringAsync();
-            Assert.True(HttpStatusCode.OK == response.StatusCode, $"{route} returned {response.StatusCode} status code with payload: {body}");
+            // this test currently fails, will be adressed in next PR
+            //Assert.True(HttpStatusCode.OK == response.StatusCode, $"{route} returned {response.StatusCode} status code with payload: {body}");
 
         }
     }

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/UpdatingRelationshipsTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/UpdatingRelationshipsTests.cs
@@ -625,7 +625,6 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
         [Fact]
         public async Task Updating_ToOne_Relationship_With_Implicit_Remove()
         {
-
             // Arrange
             var context = _fixture.GetService<AppDbContext>();
             var passport = new Passport();

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/UpdatingRelationshipsTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/UpdatingRelationshipsTests.cs
@@ -621,5 +621,52 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Null(todoItemResult.Owner);
         }
+
+        [Fact]
+        public async Task Updating_ToOne_Relationship_With_Implicit_Remove()
+        {
+
+            // Arrange
+            var context = _fixture.GetService<AppDbContext>();
+            var passport = new Passport();
+            var person1 = _personFaker.Generate();
+            person1.Passport = passport;
+            var person2 = _personFaker.Generate();
+            context.People.AddRange(new List<Person>() { person1, person2 });
+            await context.SaveChangesAsync();
+
+            var content = new
+            {
+                data = new
+                {
+                    type = "people",
+                    id = person2.Id,
+                    relationships = new Dictionary<string, object>
+                    {
+                        { "passport", new
+                            {
+                                data = new { type = "passports", id = $"{person1.PassportId}" }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var httpMethod = new HttpMethod("PATCH");
+            var route = $"/api/v1/people/{person2.Id}";
+            var request = new HttpRequestMessage(httpMethod, route);
+
+            string serializedContent = JsonConvert.SerializeObject(content);
+            request.Content = new StringContent(serializedContent);
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/vnd.api+json");
+
+            // Act
+            var response = await _fixture.Client.SendAsync(request);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.True(HttpStatusCode.OK == response.StatusCode, $"{route} returned {response.StatusCode} status code with payload: {body}");
+
+        }
     }
 }

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/UpdatingRelationshipsTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/UpdatingRelationshipsTests.cs
@@ -664,8 +664,8 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
 
             // Assert
             var body = await response.Content.ReadAsStringAsync();
-            // this test currently fails, will be adressed in next PR
-            //Assert.True(HttpStatusCode.OK == response.StatusCode, $"{route} returned {response.StatusCode} status code with payload: {body}");
+
+            Assert.True(HttpStatusCode.OK == response.StatusCode, $"{route} returned {response.StatusCode} status code with payload: {body}");
 
         }
     }

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/TodoItemsControllerTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/TodoItemsControllerTests.cs
@@ -588,6 +588,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
             {
                 data = new
                 {
+                    id = todoItem.Id,
                     type = "todo-items",
                     attributes = new Dictionary<string, object>()
                     {
@@ -639,6 +640,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
             {
                 data = new
                 {
+                    id = todoItem.Id,
                     type = "todo-items",
                     attributes = new Dictionary<string, object>()
                     {
@@ -690,6 +692,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
             {
                 data = new
                 {
+                    id = todoItem.Id,
                     type = "todo-items",
                     attributes = new Dictionary<string, object>()
                     {

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/TodoItemsControllerTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/TodoItemsControllerTests.cs
@@ -114,7 +114,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.NotEmpty(deserializedBody);
-            Assert.Contains(deserializedBody, (i) => i.OwnerId == person.Id);
+            Assert.Contains(deserializedBody, (i) => i.Owner.Id == person.Id);
         }
 
         [Fact]
@@ -435,7 +435,8 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             var deserializedBody = (TodoItem)_fixture.GetService<IJsonApiDeSerializer>().Deserialize(body);
-            Assert.Equal(person.Id, deserializedBody.OwnerId);
+
+            Assert.Equal(person.Id, deserializedBody.Owner.Id);
             Assert.Equal(todoItem.Id, deserializedBody.Id);
             Assert.Equal(todoItem.Description, deserializedBody.Description);
             Assert.Equal(todoItem.Ordinal, deserializedBody.Ordinal);

--- a/test/ResourceEntitySeparationExampleTests/Acceptance/AddTests.cs
+++ b/test/ResourceEntitySeparationExampleTests/Acceptance/AddTests.cs
@@ -94,7 +94,7 @@ namespace ResourceEntitySeparationExampleTests.Acceptance
             Assert.Equal(course.Number, data.Number);
             Assert.Equal(course.Title, data.Title);
             Assert.Equal(course.Description, data.Description);
-            Assert.Equal(department.Id, data.DepartmentId);
+            Assert.Equal(department.Id, data.Department.Id);
         }
 
         [Fact]

--- a/test/ResourceEntitySeparationExampleTests/Acceptance/UpdateTests.cs
+++ b/test/ResourceEntitySeparationExampleTests/Acceptance/UpdateTests.cs
@@ -31,6 +31,7 @@ namespace ResourceEntitySeparationExampleTests.Acceptance
             {
                 data = new
                 {
+                    id = course.Id,
                     type = "courses",
                     attributes = new Dictionary<string, object>()
                     {
@@ -64,6 +65,7 @@ namespace ResourceEntitySeparationExampleTests.Acceptance
             {
                 data = new
                 {
+                    id = dept.Id,
                     type = "departments",
                     attributes = new Dictionary<string, object>()
                     {
@@ -97,6 +99,7 @@ namespace ResourceEntitySeparationExampleTests.Acceptance
             {
                 data = new
                 {
+                    id = student.Id,
                     type = "students",
                     attributes = new Dictionary<string, string>()
                     {

--- a/test/UnitTests/Data/DefaultEntityRepository_Tests.cs
+++ b/test/UnitTests/Data/DefaultEntityRepository_Tests.cs
@@ -60,14 +60,14 @@ namespace UnitTests.Data
             {
                 {
                     descAttr,
-                    todoItemUpdates.Description
+                    null //todoItemUpdates.Description
                 }
             };
 
             var repository = GetRepository();
 
             // act
-            var updatedItem = await repository.UpdateAsync(_todoItem.Id, todoItemUpdates);
+            var updatedItem = await repository.UpdateAsync(todoItemUpdates);
 
             // assert
             Assert.NotNull(updatedItem);


### PR DESCRIPTION
This PR fixes of several issues and a bunch of refactoring.


* fixes an issue with EF Core exceptions thrown when `DefaultEntityRepository` tries to attach entities to the `DbContext` that are already attached. This may happened when entities involved to a update or create request were already loaded in the dbcontext elsewhere (eg Resource Hooks). Closes #502. This fix is needed for the tests to pass in #478  
     * added consistent handling for tracked entities
* support for implicit removal of relationships. For this the `IInverseRelationship` service is introduced (actually it was cherry picked from the Resource Hooks PR).  See #502.
* Refactored the `AttachRelationships` method and those associated to it such that
     * it doesn't also *assign* relationshipvalues in (only) the case of many-to-many
     * it no longer depends on `IJsonApiContext` for the *values* of updated relationships and attributes. Still uses it to identify *which* attributes/relationships to update. See #519
* Marked `UpdateAsync(TId id, TEnity entity)` as obsolete, added a new one: `UpdateAsync(TEnity updatedEntity)` which actually uses the updated entity in the repository layer, as opposed to it just being passed along and being left untouched in the previous implementation.  See #519 
* Refactored the fix that was included earlier to support complete replace for PATCH requests (see #492 and #494).
* Refactored the usage of the following properties of `IJsonApiContex` `RelationshipsToUpdate`, `HasOnePointers`, `HasManyPointers`. The first one has become an alias for the latter two, and the latter two are no longer populated with the actual relationship  values as these are not used anymore in the repository layer. This is related to #512.
* No longer allowing PATCH requests that do not contain ID values in the request body. Fixes #520 


