### PR TITLE
Hotfixes related to Resource Hooks

### DIFF
--- a/src/Examples/JsonApiDotNetCoreExample/Data/AppDbContext.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Data/AppDbContext.cs
@@ -58,15 +58,11 @@ namespace JsonApiDotNetCoreExample.Data
                 .WithOne(t => t.ParentTodoItem)
                 .HasForeignKey(t => t.ParentTodoItemId);
 
-            modelBuilder.Entity<Person>()
-                .HasOne(p => p.Passport)
-                .WithOne(p => p.Person)
-                .HasForeignKey<Person>(p => p.PassportId);
-
             modelBuilder.Entity<Passport>()
                 .HasOne(p => p.Person)
                 .WithOne(p => p.Passport)
-                .HasForeignKey<Person>(p => p.PassportId);
+                .HasForeignKey<Person>(p => p.PassportId)
+                .OnDelete(DeleteBehavior.SetNull);
 
             modelBuilder.Entity<TodoItem>()
                 .HasOne(p => p.ToOnePerson)

--- a/src/Examples/JsonApiDotNetCoreExample/Resources/LockableResource.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Resources/LockableResource.cs
@@ -7,9 +7,9 @@ using JsonApiDotNetCoreExample.Models;
 
 namespace JsonApiDotNetCoreExample.Resources
 {
-    public abstract class LockableResourceBase<T> : ResourceDefinition<T> where T : class, IIsLockable, IIdentifiable
+    public abstract class LockableResource<T> : ResourceDefinition<T> where T : class, IIsLockable, IIdentifiable
     {
-        protected LockableResourceBase(IResourceGraph graph) : base(graph) { }
+        protected LockableResource(IResourceGraph graph) : base(graph) { }
 
         protected void DisallowLocked(IEnumerable<T> entities)
         {

--- a/src/Examples/JsonApiDotNetCoreExample/Resources/PersonResource.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Resources/PersonResource.cs
@@ -6,25 +6,19 @@ using JsonApiDotNetCoreExample.Models;
 
 namespace JsonApiDotNetCoreExample.Resources
 {
-    public class PersonResource : LockableResourceBase<Person>
+    public class PersonResource : LockableResource<Person>
     {
         public PersonResource(IResourceGraph graph) : base(graph) { }
 
-        public override IEnumerable<string> BeforeUpdateRelationship(HashSet<string> ids, IRelationshipsDictionary<Person> resourcesByRelationship, ResourcePipeline pipeline)
+        public override IEnumerable<string> BeforeUpdateRelationship(HashSet<string> ids, IRelationshipsDictionary<Person> entitiesByRelationship, ResourcePipeline pipeline)
         {
-            BeforeImplicitUpdateRelationship(resourcesByRelationship, pipeline);
+            BeforeImplicitUpdateRelationship(entitiesByRelationship, pipeline);
             return ids;
         }
 
-        //[LoadDatabaseValues(true)]
-        //public override IEnumerable<Person> BeforeUpdate(IResourceDiff<Person> entityDiff, ResourcePipeline pipeline)
-        //{
-        //    return entityDiff.Entities;
-        //}
-
-        public override void BeforeImplicitUpdateRelationship(IRelationshipsDictionary<Person> resourcesByRelationship, ResourcePipeline pipeline)
+        public override void BeforeImplicitUpdateRelationship(IRelationshipsDictionary<Person> entitiesByRelationship, ResourcePipeline pipeline)
         {
-            resourcesByRelationship.GetByRelationship<Passport>().ToList().ForEach(kvp => DisallowLocked(kvp.Value));
+            entitiesByRelationship.GetByRelationship<Passport>().ToList().ForEach(kvp => DisallowLocked(kvp.Value));
         }
     }
 }

--- a/src/Examples/JsonApiDotNetCoreExample/Resources/TodoResource.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Resources/TodoResource.cs
@@ -7,7 +7,7 @@ using JsonApiDotNetCoreExample.Models;
 
 namespace JsonApiDotNetCoreExample.Resources
 {
-    public class TodoResource : LockableResourceBase<TodoItem>
+    public class TodoResource : LockableResource<TodoItem>
     {
         public TodoResource(IResourceGraph graph) : base(graph) { }
 

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -376,7 +376,7 @@ namespace JsonApiDotNetCore.Data
             var entity = await GetAsync(id);
             if (entity == null) return false;
             _dbSet.Remove(entity);
-             await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync();
             return true;
         }
 

--- a/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultEntityRepository.cs
@@ -376,7 +376,7 @@ namespace JsonApiDotNetCore.Data
             var entity = await GetAsync(id);
             if (entity == null) return false;
             _dbSet.Remove(entity);
-            await _context.SaveChangesAsync();
+             await _context.SaveChangesAsync();
             return true;
         }
 

--- a/src/JsonApiDotNetCore/Hooks/Execution/EntityDiffs.cs
+++ b/src/JsonApiDotNetCore/Hooks/Execution/EntityDiffs.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Hooks
     /// Also contains information about updated relationships through 
     /// implementation of IRelationshipsDictionary<typeparamref name="TEntity"/>>
     /// </summary>
-    public interface IEntityDiff<TEntity> : IRelationshipsDictionary<TEntity>, IEnumerable<EntityDiffPair<TEntity>> where TEntity : class, IIdentifiable
+    public interface IEntityDiff<TEntity> : IExposeRelationshipsDictionary<TEntity>, IEnumerable<EntityDiffPair<TEntity>> where TEntity : class, IIdentifiable
     {
         /// <summary>
         /// The database values of the resources affected by the request.
@@ -42,7 +42,7 @@ namespace JsonApiDotNetCore.Hooks
 
         public EntityDiffs(HashSet<TEntity> requestEntities,
                           HashSet<TEntity> databaseEntities,
-                          Dictionary<RelationshipAttribute, HashSet<TEntity>> relationships) 
+                          Dictionary<RelationshipAttribute, HashSet<TEntity>> relationships)
         {
             Entities = requestEntities;
             AffectedRelationships = new RelationshipsDictionary<TEntity>(relationships);
@@ -55,7 +55,7 @@ namespace JsonApiDotNetCore.Hooks
         /// </summary>
         internal EntityDiffs(IEnumerable requestEntities,
                   IEnumerable databaseEntities,
-                  Dictionary<RelationshipAttribute, IEnumerable> relationships) 
+                  Dictionary<RelationshipAttribute, IEnumerable> relationships)
             : this((HashSet<TEntity>)requestEntities, (HashSet<TEntity>)databaseEntities, TypeHelper.ConvertRelationshipDictionary<TEntity>(relationships)) { }
 
 

--- a/src/JsonApiDotNetCore/Hooks/Execution/EntityDiffs.cs
+++ b/src/JsonApiDotNetCore/Hooks/Execution/EntityDiffs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using JsonApiDotNetCore.Internal;
 using JsonApiDotNetCore.Models;
@@ -12,40 +13,38 @@ namespace JsonApiDotNetCore.Hooks
     /// Contains the resources from the request and the corresponding database values.
     /// 
     /// Also contains information about updated relationships through 
-    /// implementation of IRelationshipsDictionary<typeparamref name="TEntity"/>>
+    /// implementation of IRelationshipsDictionary<typeparamref name="TResource"/>>
     /// </summary>
-    public interface IEntityDiff<TEntity> : IExposeRelationshipsDictionary<TEntity>, IEnumerable<EntityDiffPair<TEntity>> where TEntity : class, IIdentifiable
+    public interface IEntityDiffs<TResource> :  IEnumerable<EntityDiffPair<TResource>> where TResource : class, IIdentifiable
     {
         /// <summary>
         /// The database values of the resources affected by the request.
         /// </summary>
-        HashSet<TEntity> DatabaseValues { get; }
+        HashSet<TResource> DatabaseValues { get; }
 
         /// <summary>
         /// The resources that were affected by the request.
         /// </summary>
-        HashSet<TEntity> Entities { get; }
+        EntityHashSet<TResource> Entities { get; }
+
     }
 
     /// <inheritdoc />
-    public class EntityDiffs<TEntity> : IEntityDiff<TEntity> where TEntity : class, IIdentifiable
+    public class EntityDiffs<TResource> : IEntityDiffs<TResource> where TResource : class, IIdentifiable
     {
         /// <inheritdoc />
-        public HashSet<TEntity> DatabaseValues { get => _databaseValues ?? ThrowNoDbValuesError(); }
-        private readonly HashSet<TEntity> _databaseValues;
+        public HashSet<TResource> DatabaseValues { get => _databaseValues ?? ThrowNoDbValuesError(); }
+        /// <inheritdoc />
+        public EntityHashSet<TResource> Entities { get; private set; }
+
+        private readonly HashSet<TResource> _databaseValues;
         private readonly bool _databaseValuesLoaded;
 
-        /// <inheritdoc />
-        public HashSet<TEntity> Entities { get; private set; }
-        /// <inheritdoc />
-        public RelationshipsDictionary<TEntity> AffectedRelationships { get; private set; }
-
-        public EntityDiffs(HashSet<TEntity> requestEntities,
-                          HashSet<TEntity> databaseEntities,
-                          Dictionary<RelationshipAttribute, HashSet<TEntity>> relationships)
+        public EntityDiffs(HashSet<TResource> requestEntities,
+                          HashSet<TResource> databaseEntities,
+                          Dictionary<RelationshipAttribute, HashSet<TResource>> relationships)
         {
-            Entities = requestEntities;
-            AffectedRelationships = new RelationshipsDictionary<TEntity>(relationships);
+            Entities = new EntityHashSet<TResource>(requestEntities, relationships);
             _databaseValues = databaseEntities;
             _databaseValuesLoaded |= _databaseValues != null;
         }
@@ -56,38 +55,26 @@ namespace JsonApiDotNetCore.Hooks
         internal EntityDiffs(IEnumerable requestEntities,
                   IEnumerable databaseEntities,
                   Dictionary<RelationshipAttribute, IEnumerable> relationships)
-            : this((HashSet<TEntity>)requestEntities, (HashSet<TEntity>)databaseEntities, TypeHelper.ConvertRelationshipDictionary<TEntity>(relationships)) { }
+            : this((HashSet<TResource>)requestEntities, (HashSet<TResource>)databaseEntities, TypeHelper.ConvertRelationshipDictionary<TResource>(relationships)) { }
 
 
         /// <inheritdoc />
-        public Dictionary<RelationshipAttribute, HashSet<TEntity>> GetByRelationship<TPrincipalResource>() where TPrincipalResource : class, IIdentifiable
-        {
-            return GetByRelationship(typeof(TPrincipalResource));
-        }
-
-        /// <inheritdoc />
-        public Dictionary<RelationshipAttribute, HashSet<TEntity>> GetByRelationship(Type principalType)
-        {
-            return AffectedRelationships.GetByRelationship(principalType);
-        }
-
-        /// <inheritdoc />
-        public IEnumerator<EntityDiffPair<TEntity>> GetEnumerator()
+        public IEnumerator<EntityDiffPair<TResource>> GetEnumerator()
         {
             if (!_databaseValuesLoaded) ThrowNoDbValuesError();
 
             foreach (var entity in Entities)
             {
-                TEntity currentValueInDatabase = null;
+                TResource currentValueInDatabase = null;
                 currentValueInDatabase = _databaseValues.Single(e => entity.StringId == e.StringId);
-                yield return new EntityDiffPair<TEntity>(entity, currentValueInDatabase);
+                yield return new EntityDiffPair<TResource>(entity, currentValueInDatabase);
             }
         }
 
         /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        private HashSet<TEntity> ThrowNoDbValuesError()
+        private HashSet<TResource> ThrowNoDbValuesError()
         {
             throw new MemberAccessException("Cannot access database entities if the LoadDatabaseValues option is set to false");
         }
@@ -97,9 +84,9 @@ namespace JsonApiDotNetCore.Hooks
     /// A wrapper that contains an entity that is affected by the request, 
     /// matched to its current database value
     /// </summary>
-    public class EntityDiffPair<TEntity> where TEntity : class, IIdentifiable
+    public class EntityDiffPair<TResource> where TResource : class, IIdentifiable
     {
-        public EntityDiffPair(TEntity entity, TEntity databaseValue)
+        public EntityDiffPair(TResource entity, TResource databaseValue)
         {
             Entity = entity;
             DatabaseValue = databaseValue;
@@ -108,10 +95,10 @@ namespace JsonApiDotNetCore.Hooks
         /// <summary>
         /// The resource from the request matching the resource from the database.
         /// </summary>
-        public TEntity Entity { get; private set; }
+        public TResource Entity { get; private set; }
         /// <summary>
         /// The resource from the database matching the resource from the request.
         /// </summary>
-        public TEntity DatabaseValue { get; private set; }
+        public TResource DatabaseValue { get; private set; }
     }
 }

--- a/src/JsonApiDotNetCore/Hooks/Execution/EntityHashSet.cs
+++ b/src/JsonApiDotNetCore/Hooks/Execution/EntityHashSet.cs
@@ -12,7 +12,7 @@ namespace JsonApiDotNetCore.Hooks
     /// Also contains information about updated relationships through 
     /// implementation of IAffectedRelationshipsDictionary<typeparamref name="TResource"/>>
     /// </summary>
-    public interface IEntityHashSet<TResource> : IRelationshipsDictionary<TResource>, IEnumerable<TResource> where TResource : class, IIdentifiable { }
+    public interface IEntityHashSet<TResource> : IExposeRelationshipsDictionary<TResource>, IEnumerable<TResource> where TResource : class, IIdentifiable { }
 
     /// <summary>
     /// Implementation of IResourceHashSet{TResource}.

--- a/src/JsonApiDotNetCore/Hooks/Execution/HookExecutorHelper.cs
+++ b/src/JsonApiDotNetCore/Hooks/Execution/HookExecutorHelper.cs
@@ -82,7 +82,7 @@ namespace JsonApiDotNetCore.Hooks
         public IEnumerable LoadDbValues(PrincipalType entityTypeForRepository, IEnumerable entities, ResourceHook hook, params RelationshipAttribute[] relationships)
         {
             var paths = relationships.Select(p => p.RelationshipPath).ToArray();
-            var idType = GetIdentifierType(entityTypeForRepository);
+            var idType = TypeHelper.GetIdentifierType(entityTypeForRepository);
             var parameterizedGetWhere = GetType()
                     .GetMethod(nameof(GetWhereAndInclude), BindingFlags.NonPublic | BindingFlags.Instance)
                     .MakeGenericMethod(entityTypeForRepository, idType);
@@ -142,11 +142,6 @@ namespace JsonApiDotNetCore.Hooks
                 _hookDiscoveries[entityType] = discovery;
             }
             return discovery;
-        }
-
-        Type GetIdentifierType(Type entityType)
-        {
-            return entityType.GetProperty("Id").PropertyType;
         }
 
         IEnumerable<TEntity> GetWhereAndInclude<TEntity, TId>(IEnumerable<TId> ids, string[] relationshipPaths) where TEntity : class, IIdentifiable<TId>

--- a/src/JsonApiDotNetCore/Hooks/Execution/IHookExecutorHelper.cs
+++ b/src/JsonApiDotNetCore/Hooks/Execution/IHookExecutorHelper.cs
@@ -42,7 +42,20 @@ namespace JsonApiDotNetCore.Hooks
         /// <summary>
         /// For a set of entities, loads current values from the database
         /// </summary>
+        /// <param name="repositoryEntityType">type of the entities to be loaded</param>
+        /// <param name="entities">The set of entities to load the db values for</param>
+        /// <param name="hook">The hook in which the db values will be displayed.</param>
+        /// <param name="relationships">Relationships that need to be included on entities.</param>
         IEnumerable LoadDbValues(Type repositoryEntityType, IEnumerable entities, ResourceHook hook, params RelationshipAttribute[] relationships);
-        bool ShouldLoadDbValues(Type containerEntityType, ResourceHook hook);
+
+        /// <summary>
+        /// Checks if the display database values option is allowed for the targetd hook, and for 
+        /// a given resource of type <paramref name="entityType"/> checks if this hook is implemented and if the
+        /// database values option is enabled.
+        /// </summary>
+        /// <returns><c>true</c>, if load db values was shoulded, <c>false</c> otherwise.</returns>
+        /// <param name="entityType">Container entity type.</param>
+        /// <param name="hook">Hook.</param>
+        bool ShouldLoadDbValues(Type entityType, ResourceHook hook);
     }
 }

--- a/src/JsonApiDotNetCore/Hooks/Execution/RelationshipsDictionary.cs
+++ b/src/JsonApiDotNetCore/Hooks/Execution/RelationshipsDictionary.cs
@@ -22,6 +22,10 @@ namespace JsonApiDotNetCore.Hooks
     public interface IByAffectedRelationships<TDependentResource> : 
         IRelationshipGetters<TDependentResource> where TDependentResource : class, IIdentifiable
     {
+        /// todo: expose getters that behave something like this:
+        /// relationshipDictionary.GetAffected( entity => entity.NavigationProperty ).
+        /// see https://stackoverflow.com/a/17116267/4441216
+
         /// <summary>
         /// Gets a dictionary of affected resources grouped by affected relationships.
         /// </summary>
@@ -39,16 +43,16 @@ namespace JsonApiDotNetCore.Hooks
     /// <summary>
     /// A helper class that provides insights in which relationships have been updated for which entities.
     /// </summary>
-    public interface IRelationshipGetters<TDependentResource> where TDependentResource : class, IIdentifiable
+    public interface IRelationshipGetters<TResource> where TResource : class, IIdentifiable
     {
         /// <summary>
         /// Gets a dictionary of all entities that have an affected relationship to type <typeparamref name="TPrincipalResource"/>
         /// </summary>
-        Dictionary<RelationshipAttribute, HashSet<TDependentResource>> GetByRelationship<TPrincipalResource>() where TPrincipalResource : class, IIdentifiable;
+        Dictionary<RelationshipAttribute, HashSet<TResource>> GetByRelationship<TRelatedResource>() where TRelatedResource : class, IIdentifiable;
         /// <summary>
         /// Gets a dictionary of all entities that have an affected relationship to type <paramref name="principalType"/>
         /// </summary>
-        Dictionary<RelationshipAttribute, HashSet<TDependentResource>> GetByRelationship(Type principalType);
+        Dictionary<RelationshipAttribute, HashSet<TResource>> GetByRelationship(Type relatedResourceType);
     }
 
     /// <summary>
@@ -82,7 +86,7 @@ namespace JsonApiDotNetCore.Hooks
         /// <inheritdoc />
         public Dictionary<RelationshipAttribute, HashSet<TResource>> GetByRelationship(Type relatedType)
         {
-            return this.Where(p => p.Key.PrincipalType == relatedType).ToDictionary(p => p.Key, p => p.Value);
+            return this.Where(p => p.Key.DependentType == relatedType).ToDictionary(p => p.Key, p => p.Value);
         }
     }
 }

--- a/src/JsonApiDotNetCore/Hooks/Execution/RelationshipsDictionary.cs
+++ b/src/JsonApiDotNetCore/Hooks/Execution/RelationshipsDictionary.cs
@@ -1,39 +1,45 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using JsonApiDotNetCore.Internal;
 using JsonApiDotNetCore.Models;
 
 namespace JsonApiDotNetCore.Hooks
 {
+
+
+
+    /// <summary>
+    /// A dummy interface used internally by the hook executor.
+    /// </summary>
     public interface IRelationshipsDictionary { }
+
 
     /// <summary>
     /// An interface that is implemented to expose a relationship dictionary on another class.
     /// </summary>
-    public interface IExposeRelationshipsDictionary<TDependentResource> : 
-        IRelationshipsDictionaryGetters<TDependentResource> where TDependentResource : class, IIdentifiable
+    public interface IByAffectedRelationships<TDependentResource> : 
+        IRelationshipGetters<TDependentResource> where TDependentResource : class, IIdentifiable
     {
         /// <summary>
         /// Gets a dictionary of affected resources grouped by affected relationships.
         /// </summary>
-        RelationshipsDictionary<TDependentResource> AffectedRelationships { get; }
+        Dictionary<RelationshipAttribute, HashSet<TDependentResource>> AffectedRelationships { get; }
     }
 
     /// <summary>
     /// A helper class that provides insights in which relationships have been updated for which entities.
     /// </summary>
     public interface IRelationshipsDictionary<TDependentResource> : 
-        IRelationshipsDictionaryGetters<TDependentResource>, 
+        IRelationshipGetters<TDependentResource>, 
         IReadOnlyDictionary<RelationshipAttribute, HashSet<TDependentResource>>, 
         IRelationshipsDictionary where TDependentResource : class, IIdentifiable { }
 
     /// <summary>
     /// A helper class that provides insights in which relationships have been updated for which entities.
     /// </summary>
-    public interface IRelationshipsDictionaryGetters<TDependentResource> where TDependentResource : class, IIdentifiable
+    public interface IRelationshipGetters<TDependentResource> where TDependentResource : class, IIdentifiable
     {
         /// <summary>
         /// Gets a dictionary of all entities that have an affected relationship to type <typeparamref name="TPrincipalResource"/>
@@ -51,38 +57,32 @@ namespace JsonApiDotNetCore.Hooks
     /// It is practically a ReadOnlyDictionary{RelationshipAttribute, HashSet{TDependentResource}} dictionary
     /// with the two helper methods defined on IAffectedRelationships{TDependentResource}.
     /// </summary>
-    public class RelationshipsDictionary<TDependentResource> : 
-        ReadOnlyDictionary<RelationshipAttribute, HashSet<TDependentResource>>, 
-        IRelationshipsDictionary<TDependentResource> where TDependentResource : class, IIdentifiable
+    public class RelationshipsDictionary<TResource> :
+        Dictionary<RelationshipAttribute, HashSet<TResource>>, 
+        IRelationshipsDictionary<TResource> where TResource : class, IIdentifiable
     {
         /// <summary>
-        /// a dictionary with affected relationships as keys and values being the corresponding resources
-        /// that were affected
+        /// Initializes a new instance of the <see cref="T:JsonApiDotNetCore.Hooks.RelationshipsDictionary`1"/> class.
         /// </summary>
-        private readonly Dictionary<RelationshipAttribute, HashSet<TDependentResource>> _groups;
-
-        /// <inheritdoc />
-        public RelationshipsDictionary(Dictionary<RelationshipAttribute, HashSet<TDependentResource>> relationships) : base(relationships)
-        {
-            _groups = relationships;
-        }
+        /// <param name="relationships">Relationships.</param>
+        public RelationshipsDictionary(Dictionary<RelationshipAttribute, HashSet<TResource>> relationships) : base(relationships) { }
 
         /// <summary>
         /// Used internally by the ResourceHookExecutor to make live a bit easier with generics
         /// </summary>
         internal RelationshipsDictionary(Dictionary<RelationshipAttribute, IEnumerable> relationships) 
-            : this(TypeHelper.ConvertRelationshipDictionary<TDependentResource>(relationships)) { }
+            : this(TypeHelper.ConvertRelationshipDictionary<TResource>(relationships)) { }
 
         /// <inheritdoc />
-        public Dictionary<RelationshipAttribute, HashSet<TDependentResource>> GetByRelationship<TPrincipalResource>() where TPrincipalResource : class, IIdentifiable
+        public Dictionary<RelationshipAttribute, HashSet<TResource>> GetByRelationship<TRelatedResource>() where TRelatedResource : class, IIdentifiable
         {
-            return GetByRelationship(typeof(TPrincipalResource));
+            return GetByRelationship(typeof(TRelatedResource));
         }
 
         /// <inheritdoc />
-        public Dictionary<RelationshipAttribute, HashSet<TDependentResource>> GetByRelationship(Type principalType)
+        public Dictionary<RelationshipAttribute, HashSet<TResource>> GetByRelationship(Type relatedType)
         {
-            return this.Where(p => p.Key.PrincipalType == principalType).ToDictionary(p => p.Key, p => p.Value);
+            return this.Where(p => p.Key.PrincipalType == relatedType).ToDictionary(p => p.Key, p => p.Value);
         }
     }
 }

--- a/src/JsonApiDotNetCore/Hooks/Execution/RelationshipsDictionary.cs
+++ b/src/JsonApiDotNetCore/Hooks/Execution/RelationshipsDictionary.cs
@@ -7,14 +7,10 @@ using JsonApiDotNetCore.Models;
 
 namespace JsonApiDotNetCore.Hooks
 {
-
-
-
     /// <summary>
     /// A dummy interface used internally by the hook executor.
     /// </summary>
     public interface IRelationshipsDictionary { }
-
 
     /// <summary>
     /// An interface that is implemented to expose a relationship dictionary on another class.

--- a/src/JsonApiDotNetCore/Hooks/Execution/RelationshipsDictionary.cs
+++ b/src/JsonApiDotNetCore/Hooks/Execution/RelationshipsDictionary.cs
@@ -13,7 +13,8 @@ namespace JsonApiDotNetCore.Hooks
     /// <summary>
     /// An interface that is implemented to expose a relationship dictionary on another class.
     /// </summary>
-    public interface IExposeRelationshipsDictionary<TDependentResource> : IRelationshipsDictionary<TDependentResource> where TDependentResource : class, IIdentifiable
+    public interface IExposeRelationshipsDictionary<TDependentResource> : 
+        IRelationshipsDictionaryGetters<TDependentResource> where TDependentResource : class, IIdentifiable
     {
         /// <summary>
         /// Gets a dictionary of affected resources grouped by affected relationships.
@@ -24,7 +25,15 @@ namespace JsonApiDotNetCore.Hooks
     /// <summary>
     /// A helper class that provides insights in which relationships have been updated for which entities.
     /// </summary>
-    public interface IRelationshipsDictionary<TDependentResource> : IRelationshipsDictionary where TDependentResource : class, IIdentifiable
+    public interface IRelationshipsDictionary<TDependentResource> : 
+        IRelationshipsDictionaryGetters<TDependentResource>, 
+        IReadOnlyDictionary<RelationshipAttribute, HashSet<TDependentResource>>, 
+        IRelationshipsDictionary where TDependentResource : class, IIdentifiable { }
+
+    /// <summary>
+    /// A helper class that provides insights in which relationships have been updated for which entities.
+    /// </summary>
+    public interface IRelationshipsDictionaryGetters<TDependentResource> where TDependentResource : class, IIdentifiable
     {
         /// <summary>
         /// Gets a dictionary of all entities that have an affected relationship to type <typeparamref name="TPrincipalResource"/>
@@ -42,7 +51,9 @@ namespace JsonApiDotNetCore.Hooks
     /// It is practically a ReadOnlyDictionary{RelationshipAttribute, HashSet{TDependentResource}} dictionary
     /// with the two helper methods defined on IAffectedRelationships{TDependentResource}.
     /// </summary>
-    public class RelationshipsDictionary<TDependentResource> : ReadOnlyDictionary<RelationshipAttribute, HashSet<TDependentResource>>, IRelationshipsDictionary<TDependentResource> where TDependentResource : class, IIdentifiable
+    public class RelationshipsDictionary<TDependentResource> : 
+        ReadOnlyDictionary<RelationshipAttribute, HashSet<TDependentResource>>, 
+        IRelationshipsDictionary<TDependentResource> where TDependentResource : class, IIdentifiable
     {
         /// <summary>
         /// a dictionary with affected relationships as keys and values being the corresponding resources
@@ -61,7 +72,6 @@ namespace JsonApiDotNetCore.Hooks
         /// </summary>
         internal RelationshipsDictionary(Dictionary<RelationshipAttribute, IEnumerable> relationships) 
             : this(TypeHelper.ConvertRelationshipDictionary<TDependentResource>(relationships)) { }
-
 
         /// <inheritdoc />
         public Dictionary<RelationshipAttribute, HashSet<TDependentResource>> GetByRelationship<TPrincipalResource>() where TPrincipalResource : class, IIdentifiable

--- a/src/JsonApiDotNetCore/Hooks/IResourceHookContainer.cs
+++ b/src/JsonApiDotNetCore/Hooks/IResourceHookContainer.cs
@@ -77,7 +77,7 @@ namespace JsonApiDotNetCore.Hooks
         /// <returns>The transformed entity set</returns>
         /// <param name="entityDiff">The entity diff.</param>
         /// <param name="pipeline">An enum indicating from where the hook was triggered.</param>
-        IEnumerable<TResource> BeforeUpdate(IEntityDiff<TResource> entityDiff, ResourcePipeline pipeline);
+        IEnumerable<TResource> BeforeUpdate(IEntityDiffs<TResource> entityDiff, ResourcePipeline pipeline);
 
         /// <summary>
         /// Implement this hook to run custom logic in the <see cref=" EntityResourceService{T}"/> 

--- a/src/JsonApiDotNetCore/Hooks/ResourceHookExecutor.cs
+++ b/src/JsonApiDotNetCore/Hooks/ResourceHookExecutor.cs
@@ -318,7 +318,6 @@ namespace JsonApiDotNetCore.Hooks
             PrincipalType principalType = dependentEntities.First().Key.PrincipalType;
             var byInverseRelationship = dependentEntities.Where(kvp => kvp.Key.InverseNavigation != null).ToDictionary(kvp => GetInverseRelationship(kvp.Key), kvp => kvp.Value);
             return (byInverseRelationship, principalType);
-
         }
 
         /// <summary>

--- a/src/JsonApiDotNetCore/Hooks/ResourceHookExecutor.cs
+++ b/src/JsonApiDotNetCore/Hooks/ResourceHookExecutor.cs
@@ -70,7 +70,6 @@ namespace JsonApiDotNetCore.Hooks
                 node.UpdateUnique(updated);
                 node.Reassign(entities);
             }
-
             FireNestedBeforeUpdateHooks(pipeline, _traversalHelper.CreateNextLayer(node));
             return entities;
         }
@@ -234,12 +233,15 @@ namespace JsonApiDotNetCore.Hooks
         }
 
         /// <summary>
-        /// Fires the nested before hooks. For example consider the case when
-        /// the owner of an article a1 (one-to-one) was updated from o1 to o2, where o2
-        /// was already related to a2. Then, the BeforeUpdateRelationship should be
-        /// fired for o2, and the BeforeImplicitUpdateRelationship hook should be fired for
-        /// o2 and then too for a2.
+        /// Fires the nested before hooks for entities in the current <paramref name="layer"/>
         /// </summary>
+        /// <remarks>
+        /// For example: consider the case when the owner of article1 (one-to-one) 
+        /// is being updated from owner_old to owner_new, where owner_new is currently already 
+        /// related to article2. Then, the following nested hooks need to be fired in the following order. 
+        /// First the BeforeUpdateRelationship should be for owner1, then the 
+        /// BeforeImplicitUpdateRelationship hook should be fired for
+        /// owner2, and lastely the BeforeImplicitUpdateRelationship for article2.</remarks>
         void FireNestedBeforeUpdateHooks(ResourcePipeline pipeline, EntityChildLayer layer)
         {
             foreach (IEntityNode node in layer)
@@ -247,8 +249,10 @@ namespace JsonApiDotNetCore.Hooks
                 var nestedHookcontainer = _executorHelper.GetResourceHookContainer(node.EntityType, ResourceHook.BeforeUpdateRelationship);
                 IEnumerable uniqueEntities = node.UniqueEntities;
                 DependentType entityType = node.EntityType;
+                Dictionary<RelationshipAttribute, IEnumerable> currenEntitiesGrouped;
+                Dictionary<RelationshipAttribute, IEnumerable> currentEntitiesGroupedInverse;
 
-                // fire the BeforeUpdateRelationship hook for o2
+                // fire the BeforeUpdateRelationship hook for owner_new
                 if (nestedHookcontainer != null)
                 {
                     if (uniqueEntities.Cast<IIdentifiable>().Any())
@@ -256,10 +260,17 @@ namespace JsonApiDotNetCore.Hooks
                         var relationships = node.RelationshipsToNextLayer.Select(p => p.Attribute).ToArray();
                         var dbValues = LoadDbValues(entityType, uniqueEntities, ResourceHook.BeforeUpdateRelationship, relationships);
 
-                        var dependentByPrevLayerRelationships = node.RelationshipsFromPreviousLayer.GetDependentEntities();
-                        var principalsByCurrentLayerRelationships = dependentByPrevLayerRelationships.ToDictionary(kvp => _graph.GetInverseRelationship(kvp.Key), kvp => kvp.Value);
+                        /// these are the entities of the current node grouped by 
+                        /// RelationshipAttributes that occured in the previous layer
+                        /// so it looks like { HasOneAttribute:owner  =>  owner_new }.
+                        /// Note that in the BeforeUpdateRelationship hook of Person, 
+                        /// we want want inverse relationship attribute:
+                        /// we now have the one pointing from article -> person, ]
+                        /// but we require the the one that points from person -> article             
+                        currenEntitiesGrouped = node.RelationshipsFromPreviousLayer.GetDependentEntities();
+                        currentEntitiesGroupedInverse = ReplaceKeysWithInverseRelationships(currenEntitiesGrouped);
 
-                        var resourcesByRelationship = CreateRelationshipHelper(entityType, principalsByCurrentLayerRelationships, dbValues);
+                        var resourcesByRelationship = CreateRelationshipHelper(entityType, currentEntitiesGroupedInverse, dbValues);
                         var allowedIds = CallHook(nestedHookcontainer, ResourceHook.BeforeUpdateRelationship, new object[] { GetIds(uniqueEntities), resourcesByRelationship, pipeline }).Cast<string>();
                         var updated = GetAllowedEntities(uniqueEntities, allowedIds);
                         node.UpdateUnique(updated);
@@ -267,24 +278,58 @@ namespace JsonApiDotNetCore.Hooks
                     }
                 }
 
-                // fire the BeforeImplicitUpdateRelationship hook for o1 
-                var implicitPrincipalTargets = node.RelationshipsFromPreviousLayer.GetPrincipalEntities();
-                if (pipeline != ResourcePipeline.Post && implicitPrincipalTargets.Any())
+                /// Fire the BeforeImplicitUpdateRelationship hook for owner_old.
+                /// Note: if the pipeline is Post it means we just created article1,
+                /// which means we are sure that it isn't related to any other entities yet.
+                if (pipeline != ResourcePipeline.Post)
                 {
-                    // value in implicitPrincipalTargets is a1 here.
-                    // we need to load the current value in db, which is o1.
-                    // then we need to inverse the relationship attribute 
-                    FireForAffectedImplicits(entityType, implicitPrincipalTargets, pipeline, uniqueEntities);
+                    /// To fire a hook for owner_old, we need to first get a reference to it.
+                    /// For this, we need to query the database for the  HasOneAttribute:owner 
+                    /// relationship of article1, which is referred to as the 
+                    /// principal side of the HasOneAttribute:owner relationship.
+                    var principalEntities = node.RelationshipsFromPreviousLayer.GetPrincipalEntities();
+                    if (principalEntities.Any())
+                    {
+                        /// owner_old is loaded, which is an "implicitly affected entity"
+                        FireForAffectedImplicits(entityType, principalEntities, pipeline, uniqueEntities);
+                    }
                 }
 
-                // fire the BeforeImplicitUpdateRelationship hook for a2 
-                var dependentEntities = node.RelationshipsFromPreviousLayer.GetDependentEntities();
-                if (dependentEntities.Any())
+                /// Fire the BeforeImplicitUpdateRelationship hook for article2
+                /// For this, we need to query the database for the current owner 
+                /// relationship value of owner_new.
+                currenEntitiesGrouped = node.RelationshipsFromPreviousLayer.GetDependentEntities();
+                if (currenEntitiesGrouped.Any())
                 {
-                    (var implicitDependentTargets, var principalEntityType) = GetDependentImplicitsTargets(dependentEntities);
-                    FireForAffectedImplicits(principalEntityType, implicitDependentTargets, pipeline);
+                    /// dependentEntities is grouped by relationships from previous 
+                    /// layer, ie { HasOneAttribute:owner  =>  owner_new }. But 
+                    /// to load article2 onto owner_new, we need to have the 
+                    /// RelationshipAttribute from owner to article, which is the
+                    /// inverse of HasOneAttribute:owner
+                    currentEntitiesGroupedInverse = ReplaceKeysWithInverseRelationships(currenEntitiesGrouped);
+                    /// Note that currently in the JADNC implementation of hooks, 
+                    /// the root layer is ALWAYS homogenous, so we safely assume 
+                    /// that for every relationship to the previous layer, the 
+                    /// principal type is the same.
+                    PrincipalType principalEntityType = currenEntitiesGrouped.First().Key.PrincipalType;
+                    FireForAffectedImplicits(principalEntityType, currentEntitiesGroupedInverse, pipeline);
                 }
             }
+        }
+
+        /// <summary>
+        /// replaces the keys of the <paramref name="entitiesByRelationship"/> dictionary
+        /// with its inverse relationship attribute.
+        /// </summary>
+        /// <param name="entitiesByRelationship">Entities grouped by relationship attribute</param>
+        Dictionary<RelationshipAttribute, IEnumerable> ReplaceKeysWithInverseRelationships(Dictionary<RelationshipAttribute, IEnumerable> entitiesByRelationship)
+        {
+            /// when Article has one Owner (HasOneAttribute:owner) is set, there is no guarantee
+            /// that the inverse attribute was also set (Owner has one Article: HasOneAttr:article).
+            /// If it isn't, JADNC currently knows nothing about this relationship pointing back, and it 
+            /// currently cannot fire hooks for entities resolved through inverse relationships.
+            var inversableRelationshipAttributes = entitiesByRelationship.Where(kvp => kvp.Key.InverseNavigation != null);
+            return inversableRelationshipAttributes.ToDictionary(kvp => _graph.GetInverseRelationship(kvp.Key), kvp => kvp.Value);
         }
 
         /// <summary>
@@ -317,16 +362,6 @@ namespace JsonApiDotNetCore.Hooks
             }
         }
 
-        /// <summary>
-        /// NOTE: in JADNC usage, the root layer is ALWAYS homogenous, so we can be sure that for every 
-        /// relationship to the previous layer, the principal type is the same.
-        /// </summary>
-        (Dictionary<RelationshipAttribute, IEnumerable>, PrincipalType) GetDependentImplicitsTargets(Dictionary<RelationshipAttribute, IEnumerable> dependentEntities)
-        {
-            PrincipalType principalType = dependentEntities.First().Key.PrincipalType;
-            var byInverseRelationship = dependentEntities.Where(kvp => kvp.Key.InverseNavigation != null).ToDictionary(kvp => GetInverseRelationship(kvp.Key), kvp => kvp.Value);
-            return (byInverseRelationship, principalType);
-        }
 
         /// <summary>
         /// A helper method to call a hook on <paramref name="container"/> reflectively.
@@ -389,26 +424,46 @@ namespace JsonApiDotNetCore.Hooks
             return new HashSet<IIdentifiable>(source.Cast<IIdentifiable>().Where(ue => allowedIds.Contains(ue.StringId)));
         }
 
+
         /// <summary>
-        /// Gets the inverse <see cref="RelationshipAttribute"/> for <paramref name="attribute"/>
+        /// given the set of <paramref name="uniqueEntities"/>, it will load all the 
+        /// values from the database of these entites.
         /// </summary>
-        RelationshipAttribute GetInverseRelationship(RelationshipAttribute attribute)
+        /// <returns>The db values.</returns>
+        /// <param name="entityType">type of the entities to be loaded</param>
+        /// <param name="uniqueEntities">The set of entities to load the db values for</param>
+        /// <param name="targetHook">The hook in which the db values will be displayed.</param>
+        /// <param name="relationshipsToNextLayer">Relationships from <paramref name="entityType"/> to the next layer: 
+        /// this indicates which relationships will be included on <paramref name="uniqueEntities"/>.</param>
+        IEnumerable LoadDbValues(Type entityType, IEnumerable uniqueEntities, ResourceHook targetHook, RelationshipAttribute[] relationshipsToNextLayer)
         {
-            return _graph.GetInverseRelationship(attribute);
+            /// We only need to load database values if the target hook of this hook execution
+            /// cycle is compatible with displaying database values and has this option enabled.
+            if (!_executorHelper.ShouldLoadDbValues(entityType, targetHook)) return null;
+            return _executorHelper.LoadDbValues(entityType, uniqueEntities, targetHook, relationshipsToNextLayer);
         }
 
-        IEnumerable LoadDbValues(Type containerEntityType, IEnumerable uniqueEntities, ResourceHook targetHook, RelationshipAttribute[] relationshipsToNextLayer)
-        {
-            if (!_executorHelper.ShouldLoadDbValues(containerEntityType, targetHook)) return null;
-            return _executorHelper.LoadDbValues(containerEntityType, uniqueEntities, targetHook, relationshipsToNextLayer);
-        }
 
+        /// <summary>
+        /// Fires the AfterUpdateRelationship hook
+        /// </summary>
         void FireAfterUpdateRelationship(IResourceHookContainer container, IEntityNode node, ResourcePipeline pipeline)
         {
-            var resourcesByRelationship = CreateRelationshipHelper(node.EntityType, node.RelationshipsFromPreviousLayer.GetDependentEntities());
+
+            Dictionary<RelationshipAttribute, IEnumerable> currenEntitiesGrouped = node.RelationshipsFromPreviousLayer.GetDependentEntities();
+            /// the relationships attributes in currenEntitiesGrouped will be pointing from a 
+            /// resource in the previouslayer to a resource in the current (nested) layer.
+            /// For the nested hook we need to replace these attributes with their inverse.
+            /// See the FireNestedBeforeUpdateHooks method for a more detailed example.
+            var resourcesByRelationship = CreateRelationshipHelper(node.EntityType, ReplaceKeysWithInverseRelationships(currenEntitiesGrouped));
             CallHook(container, ResourceHook.AfterUpdateRelationship, new object[] { resourcesByRelationship, pipeline });
         }
 
+        /// <summary>
+        /// Returns a list of StringIds from a list of IIdentifiables (<paramref name="entities"/>).
+        /// </summary>
+        /// <returns>The ids.</returns>
+        /// <param name="entities">iidentifiable entities.</param>
         HashSet<string> GetIds(IEnumerable entities)
         {
             return new HashSet<string>(entities.Cast<IIdentifiable>().Select(e => e.StringId));

--- a/src/JsonApiDotNetCore/Hooks/ResourceHookExecutor.cs
+++ b/src/JsonApiDotNetCore/Hooks/ResourceHookExecutor.cs
@@ -88,7 +88,11 @@ namespace JsonApiDotNetCore.Hooks
                 node.Reassign(entities);
             }
 
-            foreach (var entry in node.PrincipalsToNextLayerByType())
+            /// If we're deleting an article, we're implicitly affected any owners related to it.
+            /// Here we're loading all relations onto the to-be-deleted article
+            /// if for that relation the BeforeImplicitUpdateHook is implemented,
+            /// and this hook is then executed
+            foreach (var entry in node.PrincipalsToNextLayerByRelationships())
             {
                 var dependentType = entry.Key;
                 var implicitTargets = entry.Value;

--- a/src/JsonApiDotNetCore/Hooks/ResourceHookExecutor.cs
+++ b/src/JsonApiDotNetCore/Hooks/ResourceHookExecutor.cs
@@ -59,7 +59,6 @@ namespace JsonApiDotNetCore.Hooks
             return entities;
         }
 
-
         /// <inheritdoc/>
         public virtual IEnumerable<TEntity> BeforeCreate<TEntity>(IEnumerable<TEntity> entities, ResourcePipeline pipeline) where TEntity : class, IIdentifiable
         {
@@ -366,7 +365,6 @@ namespace JsonApiDotNetCore.Hooks
             }
         }
 
-
         /// <summary>
         /// A helper method to call a hook on <paramref name="container"/> reflectively.
         /// </summary>
@@ -428,7 +426,6 @@ namespace JsonApiDotNetCore.Hooks
             return new HashSet<IIdentifiable>(source.Cast<IIdentifiable>().Where(ue => allowedIds.Contains(ue.StringId)));
         }
 
-
         /// <summary>
         /// given the set of <paramref name="uniqueEntities"/>, it will load all the 
         /// values from the database of these entites.
@@ -446,7 +443,6 @@ namespace JsonApiDotNetCore.Hooks
             if (!_executorHelper.ShouldLoadDbValues(entityType, targetHook)) return null;
             return _executorHelper.LoadDbValues(entityType, uniqueEntities, targetHook, relationshipsToNextLayer);
         }
-
 
         /// <summary>
         /// Fires the AfterUpdateRelationship hook

--- a/src/JsonApiDotNetCore/Hooks/Traversal/RootNode.cs
+++ b/src/JsonApiDotNetCore/Hooks/Traversal/RootNode.cs
@@ -13,13 +13,15 @@ namespace JsonApiDotNetCore.Hooks
     /// </summary>
     internal class RootNode<TEntity> : IEntityNode where TEntity : class, IIdentifiable
     {
+        private readonly RelationshipProxy[] _allRelationshipsToNextLayer;
         private HashSet<TEntity> _uniqueEntities;
         public Type EntityType { get; internal set; }
         public IEnumerable UniqueEntities { get { return _uniqueEntities; } }
-        public RelationshipProxy[] RelationshipsToNextLayer { get; private set; }
-        public Dictionary<Type, Dictionary<RelationshipAttribute, IEnumerable>> PrincipalsToNextLayerByType()
+        public RelationshipProxy[] RelationshipsToNextLayer { get; }
+
+        public Dictionary<Type, Dictionary<RelationshipAttribute, IEnumerable>> PrincipalsToNextLayerByRelationships()
         {
-            return RelationshipsToNextLayer
+            return _allRelationshipsToNextLayer
                     .GroupBy(proxy => proxy.DependentType)
                     .ToDictionary(gdc => gdc.Key, gdc => gdc.ToDictionary(p => p.Attribute, p => UniqueEntities));
         }
@@ -37,11 +39,12 @@ namespace JsonApiDotNetCore.Hooks
         /// </summary>
         public IRelationshipsFromPreviousLayer RelationshipsFromPreviousLayer { get { return null; } }
 
-        public RootNode(IEnumerable<TEntity> uniqueEntities, RelationshipProxy[] relationships)
+        public RootNode(IEnumerable<TEntity> uniqueEntities, RelationshipProxy[] poplatedRelationships, RelationshipProxy[] allRelationships)
         {
             EntityType = typeof(TEntity);
             _uniqueEntities = new HashSet<TEntity>(uniqueEntities);
-            RelationshipsToNextLayer = relationships;
+            RelationshipsToNextLayer = poplatedRelationships;
+            _allRelationshipsToNextLayer = allRelationships;
         }
 
         /// <summary>

--- a/src/JsonApiDotNetCore/Hooks/Traversal/TraversalHelper.cs
+++ b/src/JsonApiDotNetCore/Hooks/Traversal/TraversalHelper.cs
@@ -193,6 +193,11 @@ namespace JsonApiDotNetCore.Hooks
             return newEntities;
         }
 
+        /// <summary>
+        /// Parses all relationships from <paramref name="type"/> to
+        /// other models in the resource graphs by constructing RelationshipProxies .
+        /// </summary>
+        /// <param name="type">The type to parse</param>
         void RegisterRelationshipProxies(DependentType type)
         {
             var contextEntity = _graph.GetContextEntity(type);

--- a/src/JsonApiDotNetCore/Hooks/Traversal/TraversalHelper.cs
+++ b/src/JsonApiDotNetCore/Hooks/Traversal/TraversalHelper.cs
@@ -57,8 +57,9 @@ namespace JsonApiDotNetCore.Hooks
             _processedEntities = new Dictionary<DependentType, HashSet<IIdentifiable>>();
             RegisterRelationshipProxies(typeof(TEntity));
             var uniqueEntities = ProcessEntities(rootEntities);
-            var relationshipsToNextLayer = GetPopulatedRelationships(typeof(TEntity), uniqueEntities.Cast<IIdentifiable>());
-            return new RootNode<TEntity>(uniqueEntities, relationshipsToNextLayer);
+            var populatedRelationshipsToNextLayer = GetPopulatedRelationships(typeof(TEntity), uniqueEntities.Cast<IIdentifiable>());
+            var allRelationshipsFromType = RelationshipProxies.Select(entry => entry.Value).Where(proxy => proxy.PrincipalType == typeof(TEntity)).ToArray();
+            return new RootNode<TEntity>(uniqueEntities, populatedRelationshipsToNextLayer, allRelationshipsFromType);
         }
 
         /// <summary>
@@ -107,7 +108,6 @@ namespace JsonApiDotNetCore.Hooks
             /// wrap the child nodes in a EntityChildLayer
             return new EntityChildLayer(nextNodes);
         }
-
 
         /// <summary>
         /// iterates throug the <paramref name="relationships"/> dictinary and groups the values 

--- a/src/JsonApiDotNetCore/Hooks/Traversal/TraversalHelper.cs
+++ b/src/JsonApiDotNetCore/Hooks/Traversal/TraversalHelper.cs
@@ -91,6 +91,8 @@ namespace JsonApiDotNetCore.Hooks
             var nextNodes = principalsGrouped.Select(entry =>
             {
                 var nextNodeType = entry.Key;
+                RegisterRelationshipProxies(nextNodeType);
+
                 var populatedRelationships = new List<RelationshipProxy>();
                 var relationshipsToPreviousLayer = entry.Value.Select(grouped =>
                 {
@@ -99,7 +101,6 @@ namespace JsonApiDotNetCore.Hooks
                     return CreateRelationshipGroupInstance(nextNodeType, proxy, grouped.Value, dependents[proxy]);
                 }).ToList();
 
-                RegisterRelationshipProxies(nextNodeType);
                 return CreateNodeInstance(nextNodeType, populatedRelationships.ToArray(), relationshipsToPreviousLayer);
             }).ToList();
 
@@ -201,7 +202,8 @@ namespace JsonApiDotNetCore.Hooks
                 if (!RelationshipProxies.TryGetValue(attr, out RelationshipProxy proxies))
                 {
                     DependentType dependentType = GetDependentTypeFromRelationship(attr);
-                    var isContextRelation = (_context.RelationshipsToUpdate?.ContainsKey(attr)) != null;
+                    bool isContextRelation = false;
+                    if (_context.RelationshipsToUpdate != null) isContextRelation = _context.RelationshipsToUpdate.ContainsKey(attr);
                     var proxy = new RelationshipProxy(attr, dependentType, isContextRelation);
                     RelationshipProxies[attr] = proxy;
                 }

--- a/src/JsonApiDotNetCore/Internal/TypeHelper.cs
+++ b/src/JsonApiDotNetCore/Internal/TypeHelper.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using JsonApiDotNetCore.Hooks;
 using JsonApiDotNetCore.Models;
 
 namespace JsonApiDotNetCore.Internal
@@ -113,9 +114,9 @@ namespace JsonApiDotNetCore.Internal
         /// <summary>
         /// Helper method that "unboxes" the TValue from the relationship dictionary into  
         /// </summary>
-        public static Dictionary<RelationshipAttribute, HashSet<TDependentResource>> ConvertRelationshipDictionary<TDependentResource>(Dictionary<RelationshipAttribute, IEnumerable> relationships)
+        public static Dictionary<RelationshipAttribute, HashSet<TValueOut>> ConvertRelationshipDictionary<TValueOut>(Dictionary<RelationshipAttribute, IEnumerable> relationships) 
         {
-            return relationships.ToDictionary(pair => pair.Key, pair => (HashSet<TDependentResource>)pair.Value);
+            return relationships.ToDictionary(pair => pair.Key, pair => (HashSet<TValueOut>)pair.Value);
         }
 
         /// <summary>

--- a/src/JsonApiDotNetCore/Internal/TypeHelper.cs
+++ b/src/JsonApiDotNetCore/Internal/TypeHelper.cs
@@ -181,5 +181,23 @@ namespace JsonApiDotNetCore.Internal
         {
             return list.GetType().GetGenericArguments()[0];
         }
+
+        /// <summary>
+        /// Gets the type (Guid or int) of the Id of a type that implements IIdentifiable
+        /// </summary>
+        public static Type GetIdentifierType(Type entityType)
+        {
+            var property = entityType.GetProperty("Id");
+            if (property == null) throw new ArgumentException("Type does not have a property Id");
+            return entityType.GetProperty("Id").PropertyType;
+        }
+
+        /// <summary>
+        /// Gets the type (Guid or int) of the Id of a type that implements IIdentifiable
+        /// </summary>
+        public static Type GetIdentifierType<T>() where T : IIdentifiable
+        {
+            return typeof(T).GetProperty("Id").PropertyType;
+        }
     }
 }

--- a/src/JsonApiDotNetCore/Models/ResourceDefinition.cs
+++ b/src/JsonApiDotNetCore/Models/ResourceDefinition.cs
@@ -179,7 +179,7 @@ namespace JsonApiDotNetCore.Models
         /// <inheritdoc/>
         public virtual void BeforeRead(ResourcePipeline pipeline, bool isIncluded = false, string stringId = null) { }
         /// <inheritdoc/>
-        public virtual IEnumerable<T> BeforeUpdate(IEntityDiff<T> entityDiff, ResourcePipeline pipeline) { return entityDiff.Entities; }
+        public virtual IEnumerable<T> BeforeUpdate(IEntityDiffs<T> entityDiff, ResourcePipeline pipeline) { return entityDiff.Entities; }
         /// <inheritdoc/>
         public virtual IEnumerable<T> BeforeDelete(IEntityHashSet<T> entities, ResourcePipeline pipeline) { return entities; }
         /// <inheritdoc/>

--- a/src/JsonApiDotNetCore/Models/ResourceDefinition.cs
+++ b/src/JsonApiDotNetCore/Models/ResourceDefinition.cs
@@ -173,19 +173,19 @@ namespace JsonApiDotNetCore.Models
         /// <inheritdoc/>
         public virtual void AfterDelete(HashSet<T> entities, ResourcePipeline pipeline, bool succeeded) { }
         /// <inheritdoc/>
-        public virtual void AfterUpdateRelationship(IRelationshipsDictionary<T> resourcesByRelationship, ResourcePipeline pipeline) { }
+        public virtual void AfterUpdateRelationship(IRelationshipsDictionary<T> entitiesByRelationship, ResourcePipeline pipeline) { }
         /// <inheritdoc/>
-        public virtual IEnumerable<T> BeforeCreate(IEntityHashSet<T> affected, ResourcePipeline pipeline) { return affected; }
+        public virtual IEnumerable<T> BeforeCreate(IEntityHashSet<T> entities, ResourcePipeline pipeline) { return entities; }
         /// <inheritdoc/>
         public virtual void BeforeRead(ResourcePipeline pipeline, bool isIncluded = false, string stringId = null) { }
         /// <inheritdoc/>
-        public virtual IEnumerable<T> BeforeUpdate(IEntityDiff<T> ResourceDiff, ResourcePipeline pipeline) { return ResourceDiff.Entities; }
+        public virtual IEnumerable<T> BeforeUpdate(IEntityDiff<T> entityDiff, ResourcePipeline pipeline) { return entityDiff.Entities; }
         /// <inheritdoc/>
-        public virtual IEnumerable<T> BeforeDelete(IEntityHashSet<T> affected, ResourcePipeline pipeline) { return affected; }
+        public virtual IEnumerable<T> BeforeDelete(IEntityHashSet<T> entities, ResourcePipeline pipeline) { return entities; }
         /// <inheritdoc/>
-        public virtual IEnumerable<string> BeforeUpdateRelationship(HashSet<string> ids, IRelationshipsDictionary<T> resourcesByRelationship, ResourcePipeline pipeline) { return ids; }
+        public virtual IEnumerable<string> BeforeUpdateRelationship(HashSet<string> ids, IRelationshipsDictionary<T> entitiesByRelationship, ResourcePipeline pipeline) { return ids; }
         /// <inheritdoc/>
-        public virtual void BeforeImplicitUpdateRelationship(IRelationshipsDictionary<T> resourcesByRelationship, ResourcePipeline pipeline) { }
+        public virtual void BeforeImplicitUpdateRelationship(IRelationshipsDictionary<T> entitiesByRelationship, ResourcePipeline pipeline) { }
         /// <inheritdoc/>
         public virtual IEnumerable<T> OnReturn(HashSet<T> entities, ResourcePipeline pipeline) { return entities; }
 

--- a/test/UnitTests/ResourceHooks/AffectedEntitiesHelperTests.cs
+++ b/test/UnitTests/ResourceHooks/AffectedEntitiesHelperTests.cs
@@ -1,166 +1,166 @@
-//using JsonApiDotNetCore.Models;
-//using JsonApiDotNetCore.Hooks;
-//using System.Collections.Generic;
-//using Xunit;
-//using System.Linq;
+using JsonApiDotNetCore.Models;
+using JsonApiDotNetCore.Hooks;
+using System.Collections.Generic;
+using Xunit;
+using System.Linq;
 
-//namespace UnitTests.ResourceHooks.AffectedEntities
-//{
-//    public class Dummy : Identifiable { }
-//    public class NotTargeted : Identifiable { }
-//    public class ToMany : Identifiable { }
-//    public class ToOne : Identifiable { }
+namespace UnitTests.ResourceHooks.AffectedEntities
+{
+    public class Dummy : Identifiable { }
+    public class NotTargeted : Identifiable { }
+    public class ToMany : Identifiable { }
+    public class ToOne : Identifiable { }
 
-//    public class AffectedEntitiesHelperTests
-//    {
+    public class AffectedEntitiesHelperTests
+    {
 
-//        public readonly HasOneAttribute FirstToOneAttr;
-//        public readonly HasOneAttribute SecondToOneAttr;
-//        public readonly HasManyAttribute ToManyAttr;
+        public readonly HasOneAttribute FirstToOneAttr;
+        public readonly HasOneAttribute SecondToOneAttr;
+        public readonly HasManyAttribute ToManyAttr;
 
 
-//        public readonly Dictionary<RelationshipAttribute, HashSet<Dummy>> Relationships = new Dictionary<RelationshipAttribute, HashSet<Dummy>>();
-//        public readonly HashSet<Dummy> FirstToOnesEntities = new HashSet<Dummy> { new Dummy() { Id = 1 }, new Dummy() { Id = 2 }, new Dummy() { Id = 3 } };
-//        public readonly HashSet<Dummy> SecondToOnesEntities = new HashSet<Dummy> { new Dummy() { Id = 4 }, new Dummy() { Id = 5 }, new Dummy() { Id = 6 } };
-//        public readonly HashSet<Dummy> ToManiesEntities = new HashSet<Dummy> { new Dummy() { Id = 7 }, new Dummy() { Id = 8 }, new Dummy() { Id = 9 } };
-//        public readonly HashSet<Dummy> NoRelationshipsEntities = new HashSet<Dummy> { new Dummy() { Id = 10 }, new Dummy() { Id = 11 }, new Dummy() { Id = 12 } };
-//        public readonly HashSet<Dummy> AllEntities;
-//        public AffectedEntitiesHelperTests()
-//        {
-//            FirstToOneAttr = new HasOneAttribute("first-to-one")
-//            {
-//                PrincipalType = typeof(Dummy),
-//                DependentType = typeof(ToOne)
-//            };
-//            SecondToOneAttr = new HasOneAttribute("second-to-one")
-//            {
-//                PrincipalType = typeof(Dummy),
-//                DependentType = typeof(ToOne)
-//            };
-//            ToManyAttr = new HasManyAttribute("to-manies")
-//            {
-//                PrincipalType = typeof(Dummy),
-//                DependentType = typeof(ToMany)
-//            };
-//            Relationships.Add(FirstToOneAttr, FirstToOnesEntities);
-//            Relationships.Add(SecondToOneAttr, SecondToOnesEntities);
-//            Relationships.Add(ToManyAttr, ToManiesEntities);
-//            AllEntities = new HashSet<Dummy>(FirstToOnesEntities.Union(SecondToOnesEntities).Union(ToManiesEntities).Union(NoRelationshipsEntities));
-//        }
+        public readonly Dictionary<RelationshipAttribute, HashSet<Dummy>> Relationships = new Dictionary<RelationshipAttribute, HashSet<Dummy>>();
+        public readonly HashSet<Dummy> FirstToOnesEntities = new HashSet<Dummy> { new Dummy() { Id = 1 }, new Dummy() { Id = 2 }, new Dummy() { Id = 3 } };
+        public readonly HashSet<Dummy> SecondToOnesEntities = new HashSet<Dummy> { new Dummy() { Id = 4 }, new Dummy() { Id = 5 }, new Dummy() { Id = 6 } };
+        public readonly HashSet<Dummy> ToManiesEntities = new HashSet<Dummy> { new Dummy() { Id = 7 }, new Dummy() { Id = 8 }, new Dummy() { Id = 9 } };
+        public readonly HashSet<Dummy> NoRelationshipsEntities = new HashSet<Dummy> { new Dummy() { Id = 10 }, new Dummy() { Id = 11 }, new Dummy() { Id = 12 } };
+        public readonly HashSet<Dummy> AllEntities;
+        public AffectedEntitiesHelperTests()
+        {
+            FirstToOneAttr = new HasOneAttribute("first-to-one")
+            {
+                PrincipalType = typeof(Dummy),
+                DependentType = typeof(ToOne)
+            };
+            SecondToOneAttr = new HasOneAttribute("second-to-one")
+            {
+                PrincipalType = typeof(Dummy),
+                DependentType = typeof(ToOne)
+            };
+            ToManyAttr = new HasManyAttribute("to-manies")
+            {
+                PrincipalType = typeof(Dummy),
+                DependentType = typeof(ToMany)
+            };
+            Relationships.Add(FirstToOneAttr, FirstToOnesEntities);
+            Relationships.Add(SecondToOneAttr, SecondToOnesEntities);
+            Relationships.Add(ToManyAttr, ToManiesEntities);
+            AllEntities = new HashSet<Dummy>(FirstToOnesEntities.Union(SecondToOnesEntities).Union(ToManiesEntities).Union(NoRelationshipsEntities));
+        }
 
-//        [Fact]
-//        public void RelationshipsDictionary_GetByRelationships()
-//        {
-//            // arrange 
-//            RelationshipsDictionary<Dummy> relationshipsDictionary = new RelationshipsDictionary<Dummy>(Relationships);
+        [Fact]
+        public void RelationshipsDictionary_GetByRelationships()
+        {
+            // arrange 
+            RelationshipsDictionary<Dummy> relationshipsDictionary = new RelationshipsDictionary<Dummy>(Relationships);
 
-//            // act
-//            Dictionary<RelationshipAttribute, HashSet<Dummy>> toOnes = relationshipsDictionary.GetByRelationship<ToOne>();
-//            Dictionary<RelationshipAttribute, HashSet<Dummy>> toManies = relationshipsDictionary.GetByRelationship<ToMany>();
-//            Dictionary<RelationshipAttribute, HashSet<Dummy>> notTargeted = relationshipsDictionary.GetByRelationship<NotTargeted>();
+            // act
+            Dictionary<RelationshipAttribute, HashSet<Dummy>> toOnes = relationshipsDictionary.GetByRelationship<ToOne>();
+            Dictionary<RelationshipAttribute, HashSet<Dummy>> toManies = relationshipsDictionary.GetByRelationship<ToMany>();
+            Dictionary<RelationshipAttribute, HashSet<Dummy>> notTargeted = relationshipsDictionary.GetByRelationship<NotTargeted>();
 
-//            // assert
-//            AssertRelationshipDictionaryGetters(relationshipsDictionary, toOnes, toManies, notTargeted);
-//        }
+            // assert
+            AssertRelationshipDictionaryGetters(relationshipsDictionary, toOnes, toManies, notTargeted);
+        }
 
-//        [Fact]
-//        public void EntityHashSet_GetByRelationships()
-//        {
-//            // arrange 
-//            EntityHashSet<Dummy> entities = new EntityHashSet<Dummy>(AllEntities, Relationships);
+        [Fact]
+        public void EntityHashSet_GetByRelationships()
+        {
+            // arrange 
+            EntityHashSet<Dummy> entities = new EntityHashSet<Dummy>(AllEntities, Relationships);
 
-//            // act
-//            Dictionary<RelationshipAttribute, HashSet<Dummy>> toOnes = entities.GetByRelationship<ToOne>();
-//            Dictionary<RelationshipAttribute, HashSet<Dummy>> toManies = entities.GetByRelationship<ToMany>();
-//            Dictionary<RelationshipAttribute, HashSet<Dummy>> notTargeted = entities.GetByRelationship<NotTargeted>();
-//            Dictionary<RelationshipAttribute, HashSet<Dummy>> allRelationships = entities.AffectedRelationships;
+            // act
+            Dictionary<RelationshipAttribute, HashSet<Dummy>> toOnes = entities.GetByRelationship<ToOne>();
+            Dictionary<RelationshipAttribute, HashSet<Dummy>> toManies = entities.GetByRelationship<ToMany>();
+            Dictionary<RelationshipAttribute, HashSet<Dummy>> notTargeted = entities.GetByRelationship<NotTargeted>();
+            Dictionary<RelationshipAttribute, HashSet<Dummy>> allRelationships = entities.AffectedRelationships;
 
-//            // Assert
-//            AssertRelationshipDictionaryGetters(allRelationships, toOnes, toManies, notTargeted);
-//            var allEntitiesWithAffectedRelationships = allRelationships.SelectMany(kvp => kvp.Value).ToList();
-//            NoRelationshipsEntities.ToList().ForEach(e =>
-//            {
-//                Assert.DoesNotContain(e, allEntitiesWithAffectedRelationships);
-//            });
-//        }
+            // Assert
+            AssertRelationshipDictionaryGetters(allRelationships, toOnes, toManies, notTargeted);
+            var allEntitiesWithAffectedRelationships = allRelationships.SelectMany(kvp => kvp.Value).ToList();
+            NoRelationshipsEntities.ToList().ForEach(e =>
+            {
+                Assert.DoesNotContain(e, allEntitiesWithAffectedRelationships);
+            });
+        }
 
-//        [Fact]
-//        public void EntityDiff_GetByRelationships()
-//        {
-//            // arrange 
-//            var dbEntities = new HashSet<Dummy>(AllEntities.Select(e => new Dummy { Id = e.Id }).ToList());
-//            EntityDiffs<Dummy> diffs = new EntityDiffs<Dummy>(AllEntities, dbEntities, Relationships);
+        [Fact]
+        public void EntityDiff_GetByRelationships()
+        {
+            // arrange 
+            var dbEntities = new HashSet<Dummy>(AllEntities.Select(e => new Dummy { Id = e.Id }).ToList());
+            EntityDiffs<Dummy> diffs = new EntityDiffs<Dummy>(AllEntities, dbEntities, Relationships);
 
-//            // act
-//            Dictionary<RelationshipAttribute, HashSet<Dummy>> toOnes = diffs.Entities.GetByRelationship<ToOne>();
-//            Dictionary<RelationshipAttribute, HashSet<Dummy>> toManies = diffs.Entities.GetByRelationship<ToMany>();
-//            Dictionary<RelationshipAttribute, HashSet<Dummy>> notTargeted = diffs.Entities.GetByRelationship<NotTargeted>();
-//            Dictionary<RelationshipAttribute, HashSet<Dummy>> allRelationships = diffs.Entities.AffectedRelationships;
+            // act
+            Dictionary<RelationshipAttribute, HashSet<Dummy>> toOnes = diffs.Entities.GetByRelationship<ToOne>();
+            Dictionary<RelationshipAttribute, HashSet<Dummy>> toManies = diffs.Entities.GetByRelationship<ToMany>();
+            Dictionary<RelationshipAttribute, HashSet<Dummy>> notTargeted = diffs.Entities.GetByRelationship<NotTargeted>();
+            Dictionary<RelationshipAttribute, HashSet<Dummy>> allRelationships = diffs.Entities.AffectedRelationships;
 
-//            // Assert
-//            AssertRelationshipDictionaryGetters(allRelationships, toOnes, toManies, notTargeted);
-//            var allEntitiesWithAffectedRelationships = allRelationships.SelectMany(kvp => kvp.Value).ToList();
-//            NoRelationshipsEntities.ToList().ForEach(e =>
-//            {
-//                Assert.DoesNotContain(e, allEntitiesWithAffectedRelationships);
-//            });
+            // Assert
+            AssertRelationshipDictionaryGetters(allRelationships, toOnes, toManies, notTargeted);
+            var allEntitiesWithAffectedRelationships = allRelationships.SelectMany(kvp => kvp.Value).ToList();
+            NoRelationshipsEntities.ToList().ForEach(e =>
+            {
+                Assert.DoesNotContain(e, allEntitiesWithAffectedRelationships);
+            });
 
-//            var requestEntitiesFromDiff = diffs.Entities;
-//            requestEntitiesFromDiff.ToList().ForEach(e =>
-//            {
-//                Assert.Contains(e, AllEntities);
-//            });
-//            var databaseEntitiesFromDiff = diffs.DatabaseValues;
-//            databaseEntitiesFromDiff.ToList().ForEach(e =>
-//            {
-//                Assert.Contains(e, dbEntities);
-//            });
-//        }
+            var requestEntitiesFromDiff = diffs.Entities;
+            requestEntitiesFromDiff.ToList().ForEach(e =>
+            {
+                Assert.Contains(e, AllEntities);
+            });
+            var databaseEntitiesFromDiff = diffs.DatabaseValues;
+            databaseEntitiesFromDiff.ToList().ForEach(e =>
+            {
+                Assert.Contains(e, dbEntities);
+            });
+        }
 
-//        [Fact]
-//        public void EntityDiff_Loops_Over_Diffs()
-//        {
-//            // arrange 
-//            var dbEntities = new HashSet<Dummy>(AllEntities.Select(e => new Dummy { Id = e.Id }));
-//            EntityDiffs<Dummy> diffs = new EntityDiffs<Dummy>(AllEntities, dbEntities, Relationships);
+        [Fact]
+        public void EntityDiff_Loops_Over_Diffs()
+        {
+            // arrange 
+            var dbEntities = new HashSet<Dummy>(AllEntities.Select(e => new Dummy { Id = e.Id }));
+            EntityDiffs<Dummy> diffs = new EntityDiffs<Dummy>(AllEntities, dbEntities, Relationships);
 
-//            // Assert & act
-//            foreach (EntityDiffPair<Dummy> diff in diffs)
-//            {
-//                Assert.Equal(diff.Entity.Id, diff.DatabaseValue.Id);
-//                Assert.NotEqual(diff.Entity, diff.DatabaseValue);
-//                Assert.Contains(diff.Entity, AllEntities);
-//                Assert.Contains(diff.DatabaseValue, dbEntities);
-//            }
+            // Assert & act
+            foreach (EntityDiffPair<Dummy> diff in diffs)
+            {
+                Assert.Equal(diff.Entity.Id, diff.DatabaseValue.Id);
+                Assert.NotEqual(diff.Entity, diff.DatabaseValue);
+                Assert.Contains(diff.Entity, AllEntities);
+                Assert.Contains(diff.DatabaseValue, dbEntities);
+            }
  
-//        }
+        }
 
-//        private void AssertRelationshipDictionaryGetters(Dictionary<RelationshipAttribute, HashSet<Dummy>> relationshipsDictionary,
-//        Dictionary<RelationshipAttribute, HashSet<Dummy>> toOnes,
-//        Dictionary<RelationshipAttribute, HashSet<Dummy>> toManies,
-//        Dictionary<RelationshipAttribute, HashSet<Dummy>> notTargeted)
-//        {
-//            Assert.Contains(FirstToOneAttr, toOnes.Keys);
-//            Assert.Contains(SecondToOneAttr, toOnes.Keys);
-//            Assert.Contains(ToManyAttr, toManies.Keys);
-//            Assert.Equal(relationshipsDictionary.Keys.Count, toOnes.Keys.Count + toManies.Keys.Count + notTargeted.Keys.Count);
+        private void AssertRelationshipDictionaryGetters(Dictionary<RelationshipAttribute, HashSet<Dummy>> relationshipsDictionary,
+        Dictionary<RelationshipAttribute, HashSet<Dummy>> toOnes,
+        Dictionary<RelationshipAttribute, HashSet<Dummy>> toManies,
+        Dictionary<RelationshipAttribute, HashSet<Dummy>> notTargeted)
+        {
+            Assert.Contains(FirstToOneAttr, toOnes.Keys);
+            Assert.Contains(SecondToOneAttr, toOnes.Keys);
+            Assert.Contains(ToManyAttr, toManies.Keys);
+            Assert.Equal(relationshipsDictionary.Keys.Count, toOnes.Keys.Count + toManies.Keys.Count + notTargeted.Keys.Count);
 
-//            toOnes[FirstToOneAttr].ToList().ForEach((entitiy) =>
-//            {
-//                Assert.Contains(entitiy, FirstToOnesEntities);
-//            });
+            toOnes[FirstToOneAttr].ToList().ForEach((entitiy) =>
+            {
+                Assert.Contains(entitiy, FirstToOnesEntities);
+            });
 
-//            toOnes[SecondToOneAttr].ToList().ForEach((entity) =>
-//            {
-//                Assert.Contains(entity, SecondToOnesEntities);
-//            });
+            toOnes[SecondToOneAttr].ToList().ForEach((entity) =>
+            {
+                Assert.Contains(entity, SecondToOnesEntities);
+            });
 
-//            toManies[ToManyAttr].ToList().ForEach((entitiy) =>
-//            {
-//                Assert.Contains(entitiy, ToManiesEntities);
-//            });
-//            Assert.Empty(notTargeted);
-//        }
+            toManies[ToManyAttr].ToList().ForEach((entitiy) =>
+            {
+                Assert.Contains(entitiy, ToManiesEntities);
+            });
+            Assert.Empty(notTargeted);
+        }
 
-//    }
-//}
+    }
+}

--- a/test/UnitTests/ResourceHooks/AffectedEntitiesHelperTests.cs
+++ b/test/UnitTests/ResourceHooks/AffectedEntitiesHelperTests.cs
@@ -13,11 +13,9 @@ namespace UnitTests.ResourceHooks.AffectedEntities
 
     public class AffectedEntitiesHelperTests
     {
-
         public readonly HasOneAttribute FirstToOneAttr;
         public readonly HasOneAttribute SecondToOneAttr;
         public readonly HasManyAttribute ToManyAttr;
-
 
         public readonly Dictionary<RelationshipAttribute, HashSet<Dummy>> Relationships = new Dictionary<RelationshipAttribute, HashSet<Dummy>>();
         public readonly HashSet<Dummy> FirstToOnesEntities = new HashSet<Dummy> { new Dummy() { Id = 1 }, new Dummy() { Id = 2 }, new Dummy() { Id = 3 } };
@@ -132,7 +130,6 @@ namespace UnitTests.ResourceHooks.AffectedEntities
                 Assert.Contains(diff.Entity, AllEntities);
                 Assert.Contains(diff.DatabaseValue, dbEntities);
             }
- 
         }
 
         private void AssertRelationshipDictionaryGetters(Dictionary<RelationshipAttribute, HashSet<Dummy>> relationshipsDictionary,
@@ -161,6 +158,5 @@ namespace UnitTests.ResourceHooks.AffectedEntities
             });
             Assert.Empty(notTargeted);
         }
-
     }
 }

--- a/test/UnitTests/ResourceHooks/AffectedEntitiesHelperTests.cs
+++ b/test/UnitTests/ResourceHooks/AffectedEntitiesHelperTests.cs
@@ -1,0 +1,166 @@
+//using JsonApiDotNetCore.Models;
+//using JsonApiDotNetCore.Hooks;
+//using System.Collections.Generic;
+//using Xunit;
+//using System.Linq;
+
+//namespace UnitTests.ResourceHooks.AffectedEntities
+//{
+//    public class Dummy : Identifiable { }
+//    public class NotTargeted : Identifiable { }
+//    public class ToMany : Identifiable { }
+//    public class ToOne : Identifiable { }
+
+//    public class AffectedEntitiesHelperTests
+//    {
+
+//        public readonly HasOneAttribute FirstToOneAttr;
+//        public readonly HasOneAttribute SecondToOneAttr;
+//        public readonly HasManyAttribute ToManyAttr;
+
+
+//        public readonly Dictionary<RelationshipAttribute, HashSet<Dummy>> Relationships = new Dictionary<RelationshipAttribute, HashSet<Dummy>>();
+//        public readonly HashSet<Dummy> FirstToOnesEntities = new HashSet<Dummy> { new Dummy() { Id = 1 }, new Dummy() { Id = 2 }, new Dummy() { Id = 3 } };
+//        public readonly HashSet<Dummy> SecondToOnesEntities = new HashSet<Dummy> { new Dummy() { Id = 4 }, new Dummy() { Id = 5 }, new Dummy() { Id = 6 } };
+//        public readonly HashSet<Dummy> ToManiesEntities = new HashSet<Dummy> { new Dummy() { Id = 7 }, new Dummy() { Id = 8 }, new Dummy() { Id = 9 } };
+//        public readonly HashSet<Dummy> NoRelationshipsEntities = new HashSet<Dummy> { new Dummy() { Id = 10 }, new Dummy() { Id = 11 }, new Dummy() { Id = 12 } };
+//        public readonly HashSet<Dummy> AllEntities;
+//        public AffectedEntitiesHelperTests()
+//        {
+//            FirstToOneAttr = new HasOneAttribute("first-to-one")
+//            {
+//                PrincipalType = typeof(Dummy),
+//                DependentType = typeof(ToOne)
+//            };
+//            SecondToOneAttr = new HasOneAttribute("second-to-one")
+//            {
+//                PrincipalType = typeof(Dummy),
+//                DependentType = typeof(ToOne)
+//            };
+//            ToManyAttr = new HasManyAttribute("to-manies")
+//            {
+//                PrincipalType = typeof(Dummy),
+//                DependentType = typeof(ToMany)
+//            };
+//            Relationships.Add(FirstToOneAttr, FirstToOnesEntities);
+//            Relationships.Add(SecondToOneAttr, SecondToOnesEntities);
+//            Relationships.Add(ToManyAttr, ToManiesEntities);
+//            AllEntities = new HashSet<Dummy>(FirstToOnesEntities.Union(SecondToOnesEntities).Union(ToManiesEntities).Union(NoRelationshipsEntities));
+//        }
+
+//        [Fact]
+//        public void RelationshipsDictionary_GetByRelationships()
+//        {
+//            // arrange 
+//            RelationshipsDictionary<Dummy> relationshipsDictionary = new RelationshipsDictionary<Dummy>(Relationships);
+
+//            // act
+//            Dictionary<RelationshipAttribute, HashSet<Dummy>> toOnes = relationshipsDictionary.GetByRelationship<ToOne>();
+//            Dictionary<RelationshipAttribute, HashSet<Dummy>> toManies = relationshipsDictionary.GetByRelationship<ToMany>();
+//            Dictionary<RelationshipAttribute, HashSet<Dummy>> notTargeted = relationshipsDictionary.GetByRelationship<NotTargeted>();
+
+//            // assert
+//            AssertRelationshipDictionaryGetters(relationshipsDictionary, toOnes, toManies, notTargeted);
+//        }
+
+//        [Fact]
+//        public void EntityHashSet_GetByRelationships()
+//        {
+//            // arrange 
+//            EntityHashSet<Dummy> entities = new EntityHashSet<Dummy>(AllEntities, Relationships);
+
+//            // act
+//            Dictionary<RelationshipAttribute, HashSet<Dummy>> toOnes = entities.GetByRelationship<ToOne>();
+//            Dictionary<RelationshipAttribute, HashSet<Dummy>> toManies = entities.GetByRelationship<ToMany>();
+//            Dictionary<RelationshipAttribute, HashSet<Dummy>> notTargeted = entities.GetByRelationship<NotTargeted>();
+//            Dictionary<RelationshipAttribute, HashSet<Dummy>> allRelationships = entities.AffectedRelationships;
+
+//            // Assert
+//            AssertRelationshipDictionaryGetters(allRelationships, toOnes, toManies, notTargeted);
+//            var allEntitiesWithAffectedRelationships = allRelationships.SelectMany(kvp => kvp.Value).ToList();
+//            NoRelationshipsEntities.ToList().ForEach(e =>
+//            {
+//                Assert.DoesNotContain(e, allEntitiesWithAffectedRelationships);
+//            });
+//        }
+
+//        [Fact]
+//        public void EntityDiff_GetByRelationships()
+//        {
+//            // arrange 
+//            var dbEntities = new HashSet<Dummy>(AllEntities.Select(e => new Dummy { Id = e.Id }).ToList());
+//            EntityDiffs<Dummy> diffs = new EntityDiffs<Dummy>(AllEntities, dbEntities, Relationships);
+
+//            // act
+//            Dictionary<RelationshipAttribute, HashSet<Dummy>> toOnes = diffs.Entities.GetByRelationship<ToOne>();
+//            Dictionary<RelationshipAttribute, HashSet<Dummy>> toManies = diffs.Entities.GetByRelationship<ToMany>();
+//            Dictionary<RelationshipAttribute, HashSet<Dummy>> notTargeted = diffs.Entities.GetByRelationship<NotTargeted>();
+//            Dictionary<RelationshipAttribute, HashSet<Dummy>> allRelationships = diffs.Entities.AffectedRelationships;
+
+//            // Assert
+//            AssertRelationshipDictionaryGetters(allRelationships, toOnes, toManies, notTargeted);
+//            var allEntitiesWithAffectedRelationships = allRelationships.SelectMany(kvp => kvp.Value).ToList();
+//            NoRelationshipsEntities.ToList().ForEach(e =>
+//            {
+//                Assert.DoesNotContain(e, allEntitiesWithAffectedRelationships);
+//            });
+
+//            var requestEntitiesFromDiff = diffs.Entities;
+//            requestEntitiesFromDiff.ToList().ForEach(e =>
+//            {
+//                Assert.Contains(e, AllEntities);
+//            });
+//            var databaseEntitiesFromDiff = diffs.DatabaseValues;
+//            databaseEntitiesFromDiff.ToList().ForEach(e =>
+//            {
+//                Assert.Contains(e, dbEntities);
+//            });
+//        }
+
+//        [Fact]
+//        public void EntityDiff_Loops_Over_Diffs()
+//        {
+//            // arrange 
+//            var dbEntities = new HashSet<Dummy>(AllEntities.Select(e => new Dummy { Id = e.Id }));
+//            EntityDiffs<Dummy> diffs = new EntityDiffs<Dummy>(AllEntities, dbEntities, Relationships);
+
+//            // Assert & act
+//            foreach (EntityDiffPair<Dummy> diff in diffs)
+//            {
+//                Assert.Equal(diff.Entity.Id, diff.DatabaseValue.Id);
+//                Assert.NotEqual(diff.Entity, diff.DatabaseValue);
+//                Assert.Contains(diff.Entity, AllEntities);
+//                Assert.Contains(diff.DatabaseValue, dbEntities);
+//            }
+ 
+//        }
+
+//        private void AssertRelationshipDictionaryGetters(Dictionary<RelationshipAttribute, HashSet<Dummy>> relationshipsDictionary,
+//        Dictionary<RelationshipAttribute, HashSet<Dummy>> toOnes,
+//        Dictionary<RelationshipAttribute, HashSet<Dummy>> toManies,
+//        Dictionary<RelationshipAttribute, HashSet<Dummy>> notTargeted)
+//        {
+//            Assert.Contains(FirstToOneAttr, toOnes.Keys);
+//            Assert.Contains(SecondToOneAttr, toOnes.Keys);
+//            Assert.Contains(ToManyAttr, toManies.Keys);
+//            Assert.Equal(relationshipsDictionary.Keys.Count, toOnes.Keys.Count + toManies.Keys.Count + notTargeted.Keys.Count);
+
+//            toOnes[FirstToOneAttr].ToList().ForEach((entitiy) =>
+//            {
+//                Assert.Contains(entitiy, FirstToOnesEntities);
+//            });
+
+//            toOnes[SecondToOneAttr].ToList().ForEach((entity) =>
+//            {
+//                Assert.Contains(entity, SecondToOnesEntities);
+//            });
+
+//            toManies[ToManyAttr].ToList().ForEach((entitiy) =>
+//            {
+//                Assert.Contains(entitiy, ToManiesEntities);
+//            });
+//            Assert.Empty(notTargeted);
+//        }
+
+//    }
+//}

--- a/test/UnitTests/ResourceHooks/ResourceHookExecutor/Update/BeforeUpdateTests.cs
+++ b/test/UnitTests/ResourceHooks/ResourceHookExecutor/Update/BeforeUpdateTests.cs
@@ -24,7 +24,7 @@ namespace UnitTests.ResourceHooks
             hookExecutor.BeforeUpdate(todoList, ResourcePipeline.Patch);
 
             // assert
-            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.IsAny<IEntityDiff<TodoItem>>(), ResourcePipeline.Patch), Times.Once());
+            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.IsAny<IEntityDiffs<TodoItem>>(), ResourcePipeline.Patch), Times.Once());
             ownerResourceMock.Verify(rd => rd.BeforeUpdateRelationship(It.IsAny<HashSet<string>>(), It.IsAny<IRelationshipsDictionary<Person>>(), ResourcePipeline.Patch), Times.Once());
             VerifyNoOtherCalls(todoResourceMock, ownerResourceMock);
         }
@@ -62,7 +62,7 @@ namespace UnitTests.ResourceHooks
             hookExecutor.BeforeUpdate(todoList, ResourcePipeline.Patch);
 
             // assert
-            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.IsAny<IEntityDiff<TodoItem>>(), ResourcePipeline.Patch), Times.Once());
+            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.IsAny<IEntityDiffs<TodoItem>>(), ResourcePipeline.Patch), Times.Once());
             VerifyNoOtherCalls(todoResourceMock, ownerResourceMock);
         }
 

--- a/test/UnitTests/ResourceHooks/ResourceHookExecutor/Update/BeforeUpdate_WithDbValues_Tests.cs
+++ b/test/UnitTests/ResourceHooks/ResourceHookExecutor/Update/BeforeUpdate_WithDbValues_Tests.cs
@@ -59,7 +59,7 @@ namespace UnitTests.ResourceHooks
             hookExecutor.BeforeUpdate(todoList, ResourcePipeline.Patch);
 
             // assert
-            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
+            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheckDiff(diff, description)), ResourcePipeline.Patch), Times.Once());
             ownerResourceMock.Verify(rd => rd.BeforeUpdateRelationship(
                 It.Is<HashSet<string>>(ids => PersonIdCheck(ids, personId)),
                 It.Is<IRelationshipsDictionary<Person>>(rh => PersonCheck(lastName, rh)),
@@ -93,7 +93,7 @@ namespace UnitTests.ResourceHooks
             hookExecutor.BeforeUpdate(_todoList, ResourcePipeline.Patch);
 
             // assert
-            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
+            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheckDiff(diff, description)), ResourcePipeline.Patch), Times.Once());
             ownerResourceMock.Verify(rd => rd.BeforeImplicitUpdateRelationship(
                 It.Is<IRelationshipsDictionary<Person>>(rh => PersonCheck(lastName + lastName, rh)),
                 ResourcePipeline.Patch),
@@ -140,7 +140,7 @@ namespace UnitTests.ResourceHooks
             hookExecutor.BeforeUpdate(todoList, ResourcePipeline.Patch);
 
             // assert
-            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
+            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheckDiff(diff, description)), ResourcePipeline.Patch), Times.Once());
             todoResourceMock.Verify(rd => rd.BeforeImplicitUpdateRelationship(
                 It.Is<IRelationshipsDictionary<TodoItem>>(rh => TodoCheck(rh, description + description)),
                 ResourcePipeline.Patch),
@@ -161,7 +161,7 @@ namespace UnitTests.ResourceHooks
             hookExecutor.BeforeUpdate(todoList, ResourcePipeline.Patch);
 
             // assert
-            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
+            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheckDiff(diff, description)), ResourcePipeline.Patch), Times.Once());
             ownerResourceMock.Verify(rd => rd.BeforeUpdateRelationship(
                 It.Is<HashSet<string>>(ids => PersonIdCheck(ids, personId)),
                 It.IsAny<IRelationshipsDictionary<Person>>(),
@@ -204,16 +204,21 @@ namespace UnitTests.ResourceHooks
             hookExecutor.BeforeUpdate(todoList, ResourcePipeline.Patch);
 
             // assert
-            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
+            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheckDiff(diff, description)), ResourcePipeline.Patch), Times.Once());
             VerifyNoOtherCalls(todoResourceMock, ownerResourceMock);
         }
 
-        private bool TodoCheck(IEntityDiffs<TodoItem> diff, string checksum)
+        private bool TodoCheckDiff(IEntityDiffs<TodoItem> diff, string checksum)
         {
             var diffPair = diff.Single();
             var dbCheck = diffPair.DatabaseValue.Description == checksum;
             var reqCheck = diffPair.Entity.Description == null;
-            return (dbCheck && reqCheck);
+            var diffPairCheck = (dbCheck && reqCheck);
+
+            var updatedRelationship = diff.Entities.GetByRelationship<Person>().Single();
+            var diffcheck = updatedRelationship.Key.PublicRelationshipName == "one-to-one-person";
+
+            return (dbCheck && reqCheck && diffcheck);
         }
 
         private bool TodoCheck(IRelationshipsDictionary<TodoItem> rh, string checksum)

--- a/test/UnitTests/ResourceHooks/ResourceHookExecutor/Update/BeforeUpdate_WithDbValues_Tests.cs
+++ b/test/UnitTests/ResourceHooks/ResourceHookExecutor/Update/BeforeUpdate_WithDbValues_Tests.cs
@@ -59,7 +59,7 @@ namespace UnitTests.ResourceHooks
             hookExecutor.BeforeUpdate(todoList, ResourcePipeline.Patch);
 
             // assert
-            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiff<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
+            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
             ownerResourceMock.Verify(rd => rd.BeforeUpdateRelationship(
                 It.Is<HashSet<string>>(ids => PersonIdCheck(ids, personId)),
                 It.Is<IRelationshipsDictionary<Person>>(rh => PersonCheck(lastName, rh)),
@@ -93,7 +93,7 @@ namespace UnitTests.ResourceHooks
             hookExecutor.BeforeUpdate(_todoList, ResourcePipeline.Patch);
 
             // assert
-            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiff<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
+            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
             ownerResourceMock.Verify(rd => rd.BeforeImplicitUpdateRelationship(
                 It.Is<IRelationshipsDictionary<Person>>(rh => PersonCheck(lastName + lastName, rh)),
                 ResourcePipeline.Patch),
@@ -140,7 +140,7 @@ namespace UnitTests.ResourceHooks
             hookExecutor.BeforeUpdate(todoList, ResourcePipeline.Patch);
 
             // assert
-            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiff<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
+            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
             todoResourceMock.Verify(rd => rd.BeforeImplicitUpdateRelationship(
                 It.Is<IRelationshipsDictionary<TodoItem>>(rh => TodoCheck(rh, description + description)),
                 ResourcePipeline.Patch),
@@ -161,7 +161,7 @@ namespace UnitTests.ResourceHooks
             hookExecutor.BeforeUpdate(todoList, ResourcePipeline.Patch);
 
             // assert
-            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiff<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
+            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
             ownerResourceMock.Verify(rd => rd.BeforeUpdateRelationship(
                 It.Is<HashSet<string>>(ids => PersonIdCheck(ids, personId)),
                 It.IsAny<IRelationshipsDictionary<Person>>(),
@@ -204,11 +204,11 @@ namespace UnitTests.ResourceHooks
             hookExecutor.BeforeUpdate(todoList, ResourcePipeline.Patch);
 
             // assert
-            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiff<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
+            todoResourceMock.Verify(rd => rd.BeforeUpdate(It.Is<IEntityDiffs<TodoItem>>((diff) => TodoCheck(diff, description)), ResourcePipeline.Patch), Times.Once());
             VerifyNoOtherCalls(todoResourceMock, ownerResourceMock);
         }
 
-        private bool TodoCheck(IEntityDiff<TodoItem> diff, string checksum)
+        private bool TodoCheck(IEntityDiffs<TodoItem> diff, string checksum)
         {
             var diffPair = diff.Single();
             var dbCheck = diffPair.DatabaseValue.Description == checksum;

--- a/test/UnitTests/ResourceHooks/ResourceHooksTestsSetup.cs
+++ b/test/UnitTests/ResourceHooks/ResourceHooksTestsSetup.cs
@@ -39,6 +39,7 @@ namespace UnitTests.ResourceHooks
                 .AddResource<Article>()
                 .AddResource<IdentifiableArticleTag>()
                 .AddResource<Tag>()
+                .AddResource<TodoItemCollection, Guid>()
                 .Build();
 
             _todoFaker = new Faker<TodoItem>().Rules((f, i) => i.Id = f.UniqueIndex + 1);
@@ -325,8 +326,16 @@ namespace UnitTests.ResourceHooks
 
             if (dbContext != null)
             {
-                IEntityReadRepository<TModel, int> repo = CreateTestRepository<TModel>(dbContext, apiContext);
-                processorFactory.Setup(c => c.GetProcessor<IEntityReadRepository<TModel, int>>(typeof(IEntityReadRepository<,>), typeof(TModel), typeof(int))).Returns(repo);
+                var idType = TypeHelper.GetIdentifierType<TModel>();
+                if (idType == typeof(int))
+                {
+                    IEntityReadRepository<TModel, int> repo = CreateTestRepository<TModel>(dbContext, apiContext);
+                    processorFactory.Setup(c => c.GetProcessor<IEntityReadRepository<TModel, int>>(typeof(IEntityReadRepository<,>), typeof(TModel), typeof(int))).Returns(repo);
+                } else
+                {
+                    throw new TypeLoadException("Test not set up properly");
+                }
+
             }
         }
 

--- a/test/UnitTests/ResourceHooks/ResourceHooksTestsSetup.cs
+++ b/test/UnitTests/ResourceHooks/ResourceHooksTestsSetup.cs
@@ -130,7 +130,6 @@ namespace UnitTests.ResourceHooks
             var articles = new List<Article>() { articleTagsSubset, articleWithAllTags };
             return (articles, allJoins, allTags);
         }
-
     }
 
     public class HooksTestsSetup : HooksDummyData
@@ -168,7 +167,6 @@ namespace UnitTests.ResourceHooks
 
             // mocking the GenericProcessorFactory and JsonApiContext and wiring them up.
             (var context, var processorFactory) = CreateContextAndProcessorMocks();
-
 
             var dbContext = repoDbContextOptions != null ? new AppDbContext(repoDbContextOptions) : null;
 
@@ -276,12 +274,10 @@ namespace UnitTests.ResourceHooks
             resourceDefinition
             .Setup(rd => rd.BeforeImplicitUpdateRelationship(It.IsAny<IRelationshipsDictionary<TModel>>(), It.IsAny<ResourcePipeline>()))
             .Verifiable();
-
             resourceDefinition
             .Setup(rd => rd.OnReturn(It.IsAny<HashSet<TModel>>(), It.IsAny<ResourcePipeline>()))
             .Returns<IEnumerable<TModel>, ResourcePipeline>((entities, context) => entities)
             .Verifiable();
-
             resourceDefinition
             .Setup(rd => rd.AfterCreate(It.IsAny<HashSet<TModel>>(), It.IsAny<ResourcePipeline>()))
             .Verifiable();
@@ -294,8 +290,6 @@ namespace UnitTests.ResourceHooks
             resourceDefinition
             .Setup(rd => rd.AfterDelete(It.IsAny<HashSet<TModel>>(), It.IsAny<ResourcePipeline>(), It.IsAny<bool>()))
             .Verifiable();
-
-
         }
 
         (Mock<IJsonApiContext>, Mock<IGenericProcessorFactory>) CreateContextAndProcessorMocks()

--- a/test/UnitTests/ResourceHooks/ResourceHooksTestsSetup.cs
+++ b/test/UnitTests/ResourceHooks/ResourceHooksTestsSetup.cs
@@ -261,7 +261,7 @@ namespace UnitTests.ResourceHooks
             .Setup(rd => rd.BeforeRead(It.IsAny<ResourcePipeline>(), It.IsAny<bool>(), It.IsAny<string>()))
             .Verifiable();
             resourceDefinition
-            .Setup(rd => rd.BeforeUpdate(It.IsAny<IEntityDiff<TModel>>(), It.IsAny<ResourcePipeline>()))
+            .Setup(rd => rd.BeforeUpdate(It.IsAny<IEntityDiffs<TModel>>(), It.IsAny<ResourcePipeline>()))
             .Returns<EntityDiffs<TModel>, ResourcePipeline>((entityDiff, context) => entityDiff.Entities)
             .Verifiable();
             resourceDefinition


### PR DESCRIPTION
This PR contains the following

*  `IRelationshipsDictionary<T>` did not implement `IReadOnlyDictionary<RelationshipAttribute, HashSet<T>>` interface (introduced in #529),  and as a result the common dictionary-like methods weren't exposed on `IRelationshipsDictionary<T>`. 
* unit tests for the implementations of `IRelationshipsDictionary<T>`, `IEntityHashSet<T>` and `IEntityDiffs<T>`
* these unit tests pointed me to a serious bug in how `RelationshipsDictionary<T>` was instantiated internally which caused unexpected relationship data wherever `IRelationshipsDictionary<T>` was used. This has been fixed
* in the meanwhile, added loads of comments internally in the `HookExecutor` 
