### PR TITLE
feat: added new overload in query controllers

### DIFF
--- a/src/JsonApiDotNetCore/Controllers/JsonApiQueryController.cs
+++ b/src/JsonApiDotNetCore/Controllers/JsonApiQueryController.cs
@@ -12,18 +12,22 @@ namespace JsonApiDotNetCore.Controllers
         public JsonApiQueryController(
             IJsonApiOptions jsonApiOptions,
             IResourceService<T, int> resourceService)
-            : base(jsonApiOptions, resourceService)
-        { }
+            : base(jsonApiOptions, resourceService) { }
     }
 
     public class JsonApiQueryController<T, TId>
     : BaseJsonApiController<T, TId> where T : class, IIdentifiable<TId>
     {
         public JsonApiQueryController(
+            IJsonApiOptions jsonApiContext,
+            IResourceQueryService<T, TId> resourceQueryService)
+            : base(jsonApiContext, resourceQueryService) { }
+
+
+        public JsonApiQueryController(
             IJsonApiOptions jsonApiOptions,
             IResourceService<T, TId> resourceService)
-        : base(jsonApiOptions, resourceService)
-        { }
+            : base(jsonApiOptions, resourceService) { }
 
         [HttpGet]
         public override async Task<IActionResult> GetAsync() => await base.GetAsync();


### PR DESCRIPTION
Adds an extra overload to the `JsonApiQueryController` class.

Closes #537. See that issue for description.
