### PR TITLE
Use relationships as navigations in sparse field queries

### DIFF
--- a/src/JsonApiDotNetCore/QueryParameterServices/SparseFieldsService.cs
+++ b/src/JsonApiDotNetCore/QueryParameterServices/SparseFieldsService.cs
@@ -39,12 +39,11 @@ namespace JsonApiDotNetCore.Query
             _selectedRelationshipFields.TryGetValue(relationship, out var fields);
             return fields;
         }
-
         
         /// <inheritdoc/>
         public virtual void Parse(KeyValuePair<string, StringValues> queryParameter)
         {   // expected: articles?fields=prop1,prop2
-            //           articles?fields[articles]=prop1,prop2
+            //           articles?fields[articles]=prop1,prop2  <-- this form in invalid UNLESS "articles" is actually a relationship on Article
             //           articles?fields[relationship]=prop1,prop2
             var fields = new List<string> { nameof(Identifiable.Id) };
             fields.AddRange(((string)queryParameter.Value).Split(QueryConstants.COMMA));

--- a/src/JsonApiDotNetCore/QueryParameterServices/SparseFieldsService.cs
+++ b/src/JsonApiDotNetCore/QueryParameterServices/SparseFieldsService.cs
@@ -51,9 +51,11 @@ namespace JsonApiDotNetCore.Query
 
             var keySplitted = queryParameter.Key.Split(QueryConstants.OPEN_BRACKET, QueryConstants.CLOSE_BRACKET);
 
-            if (keySplitted.Count() == 1) // input format: fields=prop1,prop2
+            if (keySplitted.Count() == 1)
+            {   // input format: fields=prop1,prop2
                 foreach (var field in fields)
                     RegisterRequestResourceField(field);
+            }
             else
             {  // input format: fields[articles]=prop1,prop2
                 string navigation = keySplitted[1];
@@ -64,6 +66,9 @@ namespace JsonApiDotNetCore.Query
                     throw new JsonApiException(400, $"Use \"?fields=...\" instead of \"fields[{navigation}]\":" +
                         $" the square bracket navigations is now reserved " +
                         $"for relationships only. See https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/555#issuecomment-543100865");
+
+                if (navigation.Contains(QueryConstants.DOT))
+                    throw new JsonApiException(400, $"fields[{navigation}] is not valid: deeply nested sparse field selection is not yet supported.");
 
                 var relationship = _requestResource.Relationships.SingleOrDefault(a => a.Is(navigation));
                 if (relationship == null)

--- a/src/JsonApiDotNetCore/QueryParameterServices/SparseFieldsService.cs
+++ b/src/JsonApiDotNetCore/QueryParameterServices/SparseFieldsService.cs
@@ -40,40 +40,66 @@ namespace JsonApiDotNetCore.Query
             return fields;
         }
 
+        
         /// <inheritdoc/>
         public virtual void Parse(KeyValuePair<string, StringValues> queryParameter)
-        {
-            // expected: fields[TYPE]=prop1,prop2
-            var typeName = queryParameter.Key.Split(QueryConstants.OPEN_BRACKET, QueryConstants.CLOSE_BRACKET)[1];
+        {   // expected: articles?fields=prop1,prop2
+            //           articles?fields[articles]=prop1,prop2
+            //           articles?fields[relationship]=prop1,prop2
             var fields = new List<string> { nameof(Identifiable.Id) };
-
-            var relationship = _requestResource.Relationships.SingleOrDefault(a => a.Is(typeName));
-            if (relationship == null && string.Equals(typeName, _requestResource.EntityName, StringComparison.OrdinalIgnoreCase) == false)
-                throw new JsonApiException(400, $"fields[{typeName}] is invalid");
-
             fields.AddRange(((string)queryParameter.Value).Split(QueryConstants.COMMA));
-            foreach (var field in fields)
-            {
-                if (relationship != default)
-                {
-                    var relationProperty = _contextEntityProvider.GetContextEntity(relationship.DependentType);
-                    var attr = relationProperty.Attributes.SingleOrDefault(a => a.Is(field));
-                    if (attr == null)
-                        throw new JsonApiException(400, $"'{relationship.DependentType.Name}' does not contain '{field}'.");
 
-                    if (!_selectedRelationshipFields.TryGetValue(relationship, out var registeredFields))
-                        _selectedRelationshipFields.Add(relationship, registeredFields = new List<AttrAttribute>());
-                    registeredFields.Add(attr);
-                }
-                else
-                {
-                    var attr = _requestResource.Attributes.SingleOrDefault(a => a.Is(field));
-                    if (attr == null)
-                        throw new JsonApiException(400, $"'{_requestResource.EntityName}' does not contain '{field}'.");
+            var keySplitted = queryParameter.Key.Split(QueryConstants.OPEN_BRACKET, QueryConstants.CLOSE_BRACKET);
 
-                    (_selectedFields = _selectedFields ?? new List<AttrAttribute>()).Add(attr);
-                }
+            if (keySplitted.Count() == 1) // input format: fields=prop1,prop2
+                foreach (var field in fields)
+                    RegisterRequestResourceField(field);
+            else
+            {  // input format: fields[articles]=prop1,prop2
+                string navigation = keySplitted[1];
+                // it is possible that the request resource has a relationship
+                // that is equal to the resource name, like with self-referering data types (eg directory structures)
+                // if not, no longer support this type of sparse field selection.
+                if (navigation == _requestResource.EntityName && !_requestResource.Relationships.Any(a => a.Is(navigation)))
+                    throw new JsonApiException(400, $"Use \"?fields=...\" instead of \"fields[{navigation}]\":" +
+                        $" the square bracket navigations is now reserved " +
+                        $"for relationships only. See https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/555#issuecomment-543100865");
+
+                var relationship = _requestResource.Relationships.SingleOrDefault(a => a.Is(navigation));
+                if (relationship == null)
+                    throw new JsonApiException(400, $"\"{navigation}\" in \"fields[{navigation}]\" is not a valid relationship of {_requestResource.EntityName}");
+
+                foreach (var field in fields)
+                    RegisterRelatedResourceField(field, relationship);
+
             }
+        }
+
+        /// <summary>
+        /// Registers field selection queries of the form articles?fields[author]=first-name
+        /// </summary>
+        private void RegisterRelatedResourceField(string field, RelationshipAttribute relationship)
+        {
+            var relationProperty = _contextEntityProvider.GetContextEntity(relationship.DependentType);
+            var attr = relationProperty.Attributes.SingleOrDefault(a => a.Is(field));
+            if (attr == null)
+                throw new JsonApiException(400, $"'{relationship.DependentType.Name}' does not contain '{field}'.");
+
+            if (!_selectedRelationshipFields.TryGetValue(relationship, out var registeredFields))
+                _selectedRelationshipFields.Add(relationship, registeredFields = new List<AttrAttribute>());
+            registeredFields.Add(attr);
+        }
+
+        /// <summary>
+        /// Registers field selection queries of the form articles?fields=title
+        /// </summary>
+        private void RegisterRequestResourceField(string field)
+        {
+            var attr = _requestResource.Attributes.SingleOrDefault(a => a.Is(field));
+            if (attr == null)
+                throw new JsonApiException(400, $"'{_requestResource.EntityName}' does not contain '{field}'.");
+
+            (_selectedFields = _selectedFields ?? new List<AttrAttribute>()).Add(attr);
         }
     }
 }

--- a/test/UnitTests/QueryParameters/SparseFieldsServiceTests.cs
+++ b/test/UnitTests/QueryParameters/SparseFieldsServiceTests.cs
@@ -38,7 +38,7 @@ namespace UnitTests.QueryParameters
             var attribute = new AttrAttribute(attrName) { InternalAttributeName = internalAttrName };
             var idAttribute = new AttrAttribute("id") { InternalAttributeName = "Id" };
 
-            var query = new KeyValuePair<string, StringValues>($"fields[{type}]", new StringValues(attrName));
+            var query = new KeyValuePair<string, StringValues>($"fields", new StringValues(attrName));
 
             var contextEntity = new ContextEntity
             {
@@ -56,6 +56,31 @@ namespace UnitTests.QueryParameters
             Assert.NotEmpty(result);
             Assert.Equal(idAttribute, result.First());
             Assert.Equal(attribute, result[1]);
+        }
+
+        [Fact]
+        public void Parse_TypeNameAsNavigation_ThrowsJsonApiException()
+        {
+            // arrange
+            const string type = "articles";
+            const string attrName = "some-field";
+            const string internalAttrName = "SomeField";
+            var attribute = new AttrAttribute(attrName) { InternalAttributeName = internalAttrName };
+            var idAttribute = new AttrAttribute("id") { InternalAttributeName = "Id" };
+
+            var query = new KeyValuePair<string, StringValues>($"fields[{type}]", new StringValues(attrName));
+
+            var contextEntity = new ContextEntity
+            {
+                EntityName = type,
+                Attributes = new List<AttrAttribute> { attribute, idAttribute },
+                Relationships = new List<RelationshipAttribute>()
+            };
+            var service = GetService(contextEntity);
+
+            // act, assert
+            var ex = Assert.Throws<JsonApiException>(() => service.Parse(query));
+            Assert.Contains("relationships only", ex.Message);
         }
 
         [Fact]

--- a/test/UnitTests/QueryParameters/SparseFieldsServiceTests.cs
+++ b/test/UnitTests/QueryParameters/SparseFieldsServiceTests.cs
@@ -59,7 +59,7 @@ namespace UnitTests.QueryParameters
         }
 
         [Fact]
-        public void Parse_TypeNameAsNavigation_ThrowsJsonApiException()
+        public void Parse_TypeNameAsNavigation_Throws400ErrorWithRelationshipsOnlyMessage()
         {
             // arrange
             const string type = "articles";
@@ -84,7 +84,7 @@ namespace UnitTests.QueryParameters
         }
 
         [Fact]
-        public void Parse_DeeplyNestedSelection_ThrowsJsonApiException()
+        public void Parse_DeeplyNestedSelection_Throws400ErrorWithDeeplyNestedMessage()
         {
             // arrange
             const string type = "articles";

--- a/test/UnitTests/QueryParameters/SparseFieldsServiceTests.cs
+++ b/test/UnitTests/QueryParameters/SparseFieldsServiceTests.cs
@@ -84,6 +84,32 @@ namespace UnitTests.QueryParameters
         }
 
         [Fact]
+        public void Parse_DeeplyNestedSelection_ThrowsJsonApiException()
+        {
+            // arrange
+            const string type = "articles";
+            const string relationship = "author.employer";
+            const string attrName = "some-field";
+            const string internalAttrName = "SomeField";
+            var attribute = new AttrAttribute(attrName) { InternalAttributeName = internalAttrName };
+            var idAttribute = new AttrAttribute("id") { InternalAttributeName = "Id" };
+
+            var query = new KeyValuePair<string, StringValues>($"fields[{relationship}]", new StringValues(attrName));
+
+            var contextEntity = new ContextEntity
+            {
+                EntityName = type,
+                Attributes = new List<AttrAttribute> { attribute, idAttribute },
+                Relationships = new List<RelationshipAttribute>()
+            };
+            var service = GetService(contextEntity);
+
+            // act, assert
+            var ex = Assert.Throws<JsonApiException>(() => service.Parse(query));
+            Assert.Contains("deeply nested", ex.Message);
+        }
+
+        [Fact]
         public void Parse_InvalidField_ThrowsJsonApiException()
         {
             // arrange


### PR DESCRIPTION
This PR makes the sparse field selection syntax consistent. Only `articles?fields[ RELATIONHIP_PATH ]` is now allowed. See #583. 


When the old syntax is used, eg `articles?fields[articles]=title`, a constructive error message is generated: `Should be "articles?fields=title"`. 

Closes #583


