### PR TITLE
Simplify DefaultResourceService constructor

### DIFF
--- a/src/Examples/JsonApiDotNetCoreExample/Services/CustomArticleService.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Services/CustomArticleService.cs
@@ -7,26 +7,20 @@ using JsonApiDotNetCore.Query;
 using JsonApiDotNetCore.Services;
 using JsonApiDotNetCoreExample.Models;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace JsonApiDotNetCoreExample.Services
 {
     public class CustomArticleService : DefaultResourceService<Article>
     {
-        public CustomArticleService(ISortService sortService,
-                                    IFilterService filterService,
-                                    IResourceRepository<Article, int> repository,
+        public CustomArticleService(IEnumerable<IQueryParameterService> queryParameters,
                                     IJsonApiOptions options,
-                                    IIncludeService includeService,
-                                    ISparseFieldsService sparseFieldsService,
-                                    IPageService pageService,
+                                    IResourceRepository<Article, int> repository,
                                     IResourceContextProvider provider,
                                     IResourceHookExecutor hookExecutor = null,
                                     ILoggerFactory loggerFactory = null)
-            : base(sortService, filterService, repository, options, includeService, sparseFieldsService,
-                   pageService, provider, hookExecutor, loggerFactory)
-        {
-        }
+            : base(queryParameters, options, repository, provider, hookExecutor, loggerFactory) { }
 
         public override async Task<Article> GetAsync(int id)
         {

--- a/src/JsonApiDotNetCore/Extensions/IEnumerableExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IEnumerableExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using JsonApiDotNetCore.Query;
+
+namespace JsonApiDotNetCore.Extensions
+{
+    public static class IEnumerableExtensions
+    {
+        /// <summary>
+        /// gets the first element of type <typeparamref name="TImplementedService"/> if it exists and casts the result to that.
+        /// Returns null otherwise.
+        /// </summary>
+        public static TImplementedService FirstOrDefault<TImplementedService>(this IEnumerable<IQueryParameterService> data) where TImplementedService : class, IQueryParameterService
+        {
+            return data.FirstOrDefault(qp => qp is TImplementedService) as TImplementedService;
+        }
+    }
+}

--- a/src/JsonApiDotNetCore/Extensions/IQueryableExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IQueryableExtensions.cs
@@ -10,7 +10,6 @@ using JsonApiDotNetCore.Models;
 
 namespace JsonApiDotNetCore.Extensions
 {
-
     // ReSharper disable once InconsistentNaming
     public static class IQueryableExtensions
     {

--- a/src/JsonApiDotNetCore/Extensions/IQueryableExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IQueryableExtensions.cs
@@ -10,6 +10,7 @@ using JsonApiDotNetCore.Models;
 
 namespace JsonApiDotNetCore.Extensions
 {
+
     // ReSharper disable once InconsistentNaming
     public static class IQueryableExtensions
     {

--- a/src/JsonApiDotNetCore/Services/DefaultResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/DefaultResourceService.cs
@@ -34,23 +34,19 @@ namespace JsonApiDotNetCore.Services
         private readonly ResourceContext _currentRequestResource;
 
         public DefaultResourceService(
-                ISortService sortService,
-                IFilterService filterService,
+                IEnumerable<IQueryParameterService> queryParameters,
                 IJsonApiOptions options,
-                IIncludeService includeService,
-                ISparseFieldsService sparseFieldsService,
-                IPageService pageManager,
                 IResourceRepository<TResource, TId> repository,
                 IResourceContextProvider provider,
                 IResourceHookExecutor hookExecutor = null,
                 ILoggerFactory loggerFactory = null)
         {
-            _includeService = includeService;
-            _sparseFieldsService = sparseFieldsService;
-            _pageManager = pageManager;
+            _includeService = queryParameters.FirstOrDefault(qp => qp is IIncludeService) as IIncludeService;
+            _sparseFieldsService = queryParameters.FirstOrDefault(qp => qp is ISparseFieldsService) as ISparseFieldsService;
+            _pageManager = queryParameters.FirstOrDefault(qp => qp is IPageService) as IPageService;
+            _sortService = queryParameters.FirstOrDefault(qp => qp is ISortService) as ISortService;
+            _filterService = queryParameters.FirstOrDefault(qp => qp is IFilterService) as IFilterService;
             _options = options;
-            _sortService = sortService;
-            _filterService = filterService;
             _repository = repository;
             _hookExecutor = hookExecutor;
             _logger = loggerFactory?.CreateLogger<DefaultResourceService<TResource, TId>>();
@@ -323,12 +319,12 @@ namespace JsonApiDotNetCore.Services
         IResourceService<TResource>
         where TResource : class, IIdentifiable<int>
     {
-        public DefaultResourceService(ISortService sortService, IFilterService filterService, IResourceRepository<TResource, int> repository,
-                                     IJsonApiOptions options, IIncludeService includeService, ISparseFieldsService sparseFieldsService,
-                                     IPageService pageManager, IResourceContextProvider provider,
-                                     IResourceHookExecutor hookExecutor = null, ILoggerFactory loggerFactory = null)
-            : base(sortService, filterService, options, includeService, sparseFieldsService, pageManager, repository, provider, hookExecutor, loggerFactory)
-        {
-        }
+        public DefaultResourceService(IEnumerable<IQueryParameterService> queryParameters,
+                                      IJsonApiOptions options,
+                                      IResourceRepository<TResource, int> repository,
+                                      IResourceContextProvider provider,
+                                      IResourceHookExecutor hookExecutor = null,
+                                      ILoggerFactory loggerFactory = null)
+            : base(queryParameters, options, repository, provider, hookExecutor, loggerFactory) { }
     }
 }

--- a/src/JsonApiDotNetCore/Services/DefaultResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/DefaultResourceService.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using JsonApiDotNetCore.Internal.Contracts;
 using JsonApiDotNetCore.Query;
+using JsonApiDotNetCore.Extensions;
 
 namespace JsonApiDotNetCore.Services
 {
@@ -41,17 +42,18 @@ namespace JsonApiDotNetCore.Services
                 IResourceHookExecutor hookExecutor = null,
                 ILoggerFactory loggerFactory = null)
         {
-            _includeService = queryParameters.FirstOrDefault(qp => qp is IIncludeService) as IIncludeService;
-            _sparseFieldsService = queryParameters.FirstOrDefault(qp => qp is ISparseFieldsService) as ISparseFieldsService;
-            _pageManager = queryParameters.FirstOrDefault(qp => qp is IPageService) as IPageService;
-            _sortService = queryParameters.FirstOrDefault(qp => qp is ISortService) as ISortService;
-            _filterService = queryParameters.FirstOrDefault(qp => qp is IFilterService) as IFilterService;
+            _includeService = queryParameters.FirstOrDefault<IIncludeService>();
+            _sparseFieldsService = queryParameters.FirstOrDefault<ISparseFieldsService>();
+            _pageManager = queryParameters.FirstOrDefault<IPageService>();
+            _sortService = queryParameters.FirstOrDefault<ISortService>();
+            _filterService = queryParameters.FirstOrDefault<IFilterService>();
             _options = options;
             _repository = repository;
             _hookExecutor = hookExecutor;
             _logger = loggerFactory?.CreateLogger<DefaultResourceService<TResource, TId>>();
             _currentRequestResource = provider.GetResourceContext<TResource>();
         }
+
 
         public virtual async Task<TResource> CreateAsync(TResource entity)
         {

--- a/test/UnitTests/Services/EntityResourceService_Tests.cs
+++ b/test/UnitTests/Services/EntityResourceService_Tests.cs
@@ -97,7 +97,7 @@ namespace UnitTests.Services
 
         private DefaultResourceService<TodoItem> GetService()
         {
-            return new DefaultResourceService<TodoItem>(null, null, _repositoryMock.Object, new JsonApiOptions(), null, null, _pgsMock.Object, _resourceGraph);
+            return new DefaultResourceService<TodoItem>(new List<IQueryParameterService>(), new JsonApiOptions(), _repositoryMock.Object, _resourceGraph);
         }
     }
 }


### PR DESCRIPTION
Usage of `IEnumerable<IQueryParameterService>` in `DefaultResourceService` constructor as opposed to individually injecting every member of that `IEnumerable`

Closes #568
