### PR TITLE
Improve usability RequestSerializer

### DIFF
--- a/src/JsonApiDotNetCore/Builders/JsonApiApplicationBuilder.cs
+++ b/src/JsonApiDotNetCore/Builders/JsonApiApplicationBuilder.cs
@@ -150,6 +150,9 @@ namespace JsonApiDotNetCore.Builders
             _services.AddScoped(typeof(IResourceService<>), typeof(DefaultResourceService<>));
             _services.AddScoped(typeof(IResourceService<,>), typeof(DefaultResourceService<,>));
 
+            _services.AddScoped(typeof(IResourceQueryService<,>), typeof(DefaultResourceService<,>));
+            _services.AddScoped(typeof(IResourceCmdService<,>), typeof(DefaultResourceService<,>));
+
             _services.AddSingleton<ILinksConfiguration>(JsonApiOptions);
             _services.AddSingleton(resourceGraph);
             _services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -27,7 +27,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftLoggingVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.ValueTuple" Version="$(TuplesVersion)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- 

--- a/src/JsonApiDotNetCore/RequestServices/Contracts/IUpdatedFields.cs
+++ b/src/JsonApiDotNetCore/RequestServices/Contracts/IUpdatedFields.cs
@@ -17,5 +17,4 @@ namespace JsonApiDotNetCore.Serialization
         /// </summary>
         List<RelationshipAttribute> Relationships { get; set; }
     }
-
 }

--- a/src/JsonApiDotNetCore/Serialization/Client/IRequestSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/Client/IRequestSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using JsonApiDotNetCore.Models;
 
@@ -22,20 +23,26 @@ namespace JsonApiDotNetCore.Serialization.Client
         /// <param name="entities">Entities to serialize</param>
         /// <returns>The serialized content</returns>
         string Serialize(IEnumerable entities);
-        /// <summary>
-        /// Sets the <see cref="AttrAttribute"/>s to serialize for resources of type <typeparamref name="TResource"/>.
-        /// If no <see cref="AttrAttribute"/>s are specified, by default all attributes are included in the serialized result.
-        /// </summary>
-        /// <typeparam name="TResource">Type of the resource to serialize</typeparam>
-        /// <param name="filter">Should be of the form: (TResource e) => new { e.Attr1, e.Attr2 }</param>
-        void SetAttributesToSerialize<TResource>(Expression<System.Func<TResource, dynamic>> filter) where TResource : class, IIdentifiable;
-        /// <summary>
-        /// Sets the <see cref="RelationshipAttribute"/>s to serialize for resources of type <typeparamref name="TResource"/>.
-        /// If no <see cref="RelationshipAttribute"/>s are specified, by default no relationships are included in the serialization result.
-        /// The <paramref name="filter"/>should be of the form: (TResource e) => new { e.Attr1, e.Attr2 }
-        /// </summary>
-        /// <typeparam name="TResource">Type of the resource to serialize</typeparam>
-        /// <param name="filter">Should be of the form: (TResource e) => new { e.Attr1, e.Attr2 }</param>
-        void SetRelationshipsToSerialize<TResource>(Expression<System.Func<TResource, dynamic>> filter) where TResource : class, IIdentifiable;
+        ///// <summary>
+        ///// Sets the <see cref="AttrAttribute"/>s to serialize for resources of type <typeparamref name="TResource"/>.
+        ///// If no <see cref="AttrAttribute"/>s are specified, by default all attributes are included in the serialized result.
+        ///// </summary>
+        ///// <typeparam name="TResource">Type of the resource to serialize</typeparam>
+        ///// <param name="filter">Should be of the form: (TResource e) => new { e.Attr1, e.Attr2 }</param>
+        //void  AAttributesToSerialize(IEnumerable<AttrAttribute> attributes);
+        ///// <summary>
+        ///// Sets the <see cref="RelationshipAttribute"/>s to serialize for resources of type <typeparamref name="TResource"/>.
+        ///// If no <see cref="RelationshipAttribute"/>s are specified, by default no relationships are included in the serialization result.
+        ///// The <paramref name="filter"/>should be of the form: (TResource e) => new { e.Attr1, e.Attr2 }
+        ///// </summary>
+        ///// <typeparam name="TResource">Type of the resource to serialize</typeparam>
+        ///// <param name="filter">Should be of the form: (TResource e) => new { e.Attr1, e.Attr2 }</param>
+        //void SetRelationshipsToSerialize(IEnumerable<RelationshipAttribute> attributes);
+
+        /// <inheritdoc/>
+        public IEnumerable<AttrAttribute> AttributesToSerialize { set; }
+
+        /// <inheritdoc/>
+        public IEnumerable<RelationshipAttribute> RelationshipsToSerialize { set; }
     }
 }

--- a/src/JsonApiDotNetCore/Serialization/Client/IRequestSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/Client/IRequestSerializer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using JsonApiDotNetCore.Models;
+using JsonApiDotNetCore.Internal.Contracts;
 
 namespace JsonApiDotNetCore.Serialization.Client
 {
@@ -23,11 +24,17 @@ namespace JsonApiDotNetCore.Serialization.Client
         /// <param name="entities">Entities to serialize</param>
         /// <returns>The serialized content</returns>
         string Serialize(IEnumerable entities);
-
-        /// <inheritdoc/>
+        /// <summary>
+        /// Sets the attributes that will be included in the serialized payload.
+        /// You can use <see cref="IResourceGraph.GetAttributes{TResource}(Expression{System.Func{TResource, dynamic}})"/>
+        /// to conveniently access the desired <see cref="AttrAttribute"/> instances
+        /// </summary>
         public IEnumerable<AttrAttribute> AttributesToSerialize { set; }
-
-        /// <inheritdoc/>
+        /// <summary>
+        /// Sets the relationships that will be included in the serialized payload.
+        /// You can use <see cref="IResourceGraph.GetRelationships{TResource}(Expression{System.Func{TResource, dynamic}})"/>
+        /// to conveniently access the desired <see cref="RelationshipAttribute"/> instances
+        /// </summary>
         public IEnumerable<RelationshipAttribute> RelationshipsToSerialize { set; }
     }
 }

--- a/src/JsonApiDotNetCore/Serialization/Client/IRequestSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/Client/IRequestSerializer.cs
@@ -23,21 +23,6 @@ namespace JsonApiDotNetCore.Serialization.Client
         /// <param name="entities">Entities to serialize</param>
         /// <returns>The serialized content</returns>
         string Serialize(IEnumerable entities);
-        ///// <summary>
-        ///// Sets the <see cref="AttrAttribute"/>s to serialize for resources of type <typeparamref name="TResource"/>.
-        ///// If no <see cref="AttrAttribute"/>s are specified, by default all attributes are included in the serialized result.
-        ///// </summary>
-        ///// <typeparam name="TResource">Type of the resource to serialize</typeparam>
-        ///// <param name="filter">Should be of the form: (TResource e) => new { e.Attr1, e.Attr2 }</param>
-        //void  AAttributesToSerialize(IEnumerable<AttrAttribute> attributes);
-        ///// <summary>
-        ///// Sets the <see cref="RelationshipAttribute"/>s to serialize for resources of type <typeparamref name="TResource"/>.
-        ///// If no <see cref="RelationshipAttribute"/>s are specified, by default no relationships are included in the serialization result.
-        ///// The <paramref name="filter"/>should be of the form: (TResource e) => new { e.Attr1, e.Attr2 }
-        ///// </summary>
-        ///// <typeparam name="TResource">Type of the resource to serialize</typeparam>
-        ///// <param name="filter">Should be of the form: (TResource e) => new { e.Attr1, e.Attr2 }</param>
-        //void SetRelationshipsToSerialize(IEnumerable<RelationshipAttribute> attributes);
 
         /// <inheritdoc/>
         public IEnumerable<AttrAttribute> AttributesToSerialize { set; }

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/ResourceDefinitions/ResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/ResourceDefinitions/ResourceDefinitionTests.cs
@@ -72,6 +72,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
         {
             // Arrange
             var user = _userFaker.Generate();
+
             var serializer = _fixture.GetSerializer<User>(p => new { p.Password, p.Username });
 
             

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/TestFixture.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/TestFixture.cs
@@ -38,8 +38,10 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
         {
             var serializer =  GetService<IRequestSerializer>();
             var graph =  GetService<IResourceGraph>();
-            serializer.AttributesToSerialize = graph.GetAttributes(attributes);
-            serializer.RelationshipsToSerialize = graph.GetRelationships(attributes);
+            if (attributes != null)
+                serializer.AttributesToSerialize = graph.GetAttributes(attributes);
+            if (relationships != null)
+                serializer.RelationshipsToSerialize = graph.GetRelationships(relationships);
             return serializer;
         }
         public IResponseDeserializer GetDeserializer()

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/TestFixture.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/TestFixture.cs
@@ -11,6 +11,7 @@ using JsonApiDotNetCore.Models;
 using JsonApiDotNetCore.Builders;
 using JsonApiDotNetCoreExampleTests.Helpers.Models;
 using JsonApiDotNetCoreExample.Models;
+using JsonApiDotNetCore.Internal.Contracts;
 
 namespace JsonApiDotNetCoreExampleTests.Acceptance
 {
@@ -31,17 +32,14 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
 
         public HttpClient Client { get; set; }
         public AppDbContext Context { get; private set; }
+
+
         public IRequestSerializer GetSerializer<TResource>(Expression<Func<TResource, dynamic>> attributes = null, Expression<Func<TResource, dynamic>> relationships = null) where TResource : class, IIdentifiable
         {
             var serializer =  GetService<IRequestSerializer>();
-            if (attributes != null)
-            {
-                serializer.SetAttributesToSerialize(attributes);
-            }
-            if (relationships != null)
-            {
-                serializer.SetRelationshipsToSerialize(relationships);
-            }
+            var graph =  GetService<IResourceGraph>();
+            serializer.AttributesToSerialize = graph.GetAttributes(attributes);
+            serializer.RelationshipsToSerialize = graph.GetRelationships(attributes);
             return serializer;
         }
         public IResponseDeserializer GetDeserializer()

--- a/test/NoEntityFrameworkTests/TestFixture.cs
+++ b/test/NoEntityFrameworkTests/TestFixture.cs
@@ -1,4 +1,5 @@
 using JsonApiDotNetCore.Builders;
+using JsonApiDotNetCore.Internal.Contracts;
 using JsonApiDotNetCore.Models;
 using JsonApiDotNetCore.Serialization.Client;
 using Microsoft.AspNetCore.Hosting;
@@ -28,10 +29,9 @@ namespace NoEntityFrameworkTests
         public IRequestSerializer GetSerializer<TResource>(Expression<Func<TResource, dynamic>> attributes = null, Expression<Func<TResource, dynamic>> relationships = null) where TResource : class, IIdentifiable
         {
             var serializer = GetService<IRequestSerializer>();
-            if (attributes != null)
-                serializer.SetAttributesToSerialize(attributes);
-            if (relationships != null)
-                serializer.SetRelationshipsToSerialize(relationships);
+            var graph = GetService<IResourceGraph>();
+            serializer.AttributesToSerialize = graph.GetAttributes(attributes);
+            serializer.RelationshipsToSerialize = graph.GetRelationships(attributes);
             return serializer;
         }
         public IResponseDeserializer GetDeserializer()

--- a/test/NoEntityFrameworkTests/TestFixture.cs
+++ b/test/NoEntityFrameworkTests/TestFixture.cs
@@ -30,10 +30,13 @@ namespace NoEntityFrameworkTests
         {
             var serializer = GetService<IRequestSerializer>();
             var graph = GetService<IResourceGraph>();
-            serializer.AttributesToSerialize = graph.GetAttributes(attributes);
-            serializer.RelationshipsToSerialize = graph.GetRelationships(attributes);
+            if (attributes != null)
+                serializer.AttributesToSerialize = graph.GetAttributes(attributes);
+            if (relationships != null)
+                serializer.RelationshipsToSerialize = graph.GetRelationships(relationships);
             return serializer;
         }
+
         public IResponseDeserializer GetDeserializer()
         {
             var resourceGraph = new ResourceGraphBuilder().AddResource<TodoItem>("todo-items").Build();

--- a/test/UnitTests/Serialization/Client/RequestSerializerTests.cs
+++ b/test/UnitTests/Serialization/Client/RequestSerializerTests.cs
@@ -56,7 +56,7 @@ namespace UnitTests.Serialization.Client
         {
             // Arrange
             var entity = new TestResource() { Id = 1, StringField = "value", NullableIntField = 123 };
-            _serializer.SetAttributesToSerialize<TestResource>(tr => tr.StringField);
+            _serializer.AttributesToSerialize = _resourceGraph.GetAttributes<TestResource>(tr => tr.StringField);
 
             // Act
             string serialized = _serializer.Serialize(entity);
@@ -81,7 +81,7 @@ namespace UnitTests.Serialization.Client
         {
             // Arrange
             var entityNoId = new TestResource() { Id = 0, StringField = "value", NullableIntField = 123 };
-            _serializer.SetAttributesToSerialize<TestResource>(tr => tr.StringField);
+            _serializer.AttributesToSerialize = _resourceGraph.GetAttributes<TestResource>(tr => tr.StringField);
 
             // Act
             string serialized = _serializer.Serialize(entityNoId);
@@ -106,7 +106,7 @@ namespace UnitTests.Serialization.Client
         {
             // Arrange
             var entity = new TestResource() { Id = 1, StringField = "value", NullableIntField = 123 };
-            _serializer.SetAttributesToSerialize<TestResource>(tr => new { });
+            _serializer.AttributesToSerialize = _resourceGraph.GetAttributes<TestResource>(tr => new { });
 
             // Act
             string serialized = _serializer.Serialize(entity);
@@ -133,7 +133,7 @@ namespace UnitTests.Serialization.Client
                 PopulatedToOne = new OneToOneDependent { Id = 10 },
                 PopulatedToManies = new List<OneToManyDependent> { new OneToManyDependent { Id = 20 } }
             };
-            _serializer.SetRelationshipsToSerialize<MultipleRelationshipsPrincipalPart>(tr => new { tr.EmptyToOne, tr.EmptyToManies, tr.PopulatedToOne, tr.PopulatedToManies });
+            _serializer.RelationshipsToSerialize = _resourceGraph.GetRelationships<MultipleRelationshipsPrincipalPart>(tr => new { tr.EmptyToOne, tr.EmptyToManies, tr.PopulatedToOne, tr.PopulatedToManies });
 
             // Act
             string serialized = _serializer.Serialize(entityWithRelationships);
@@ -182,7 +182,7 @@ namespace UnitTests.Serialization.Client
                 new TestResource() { Id = 1, StringField = "value1", NullableIntField = 123 },
                 new TestResource() { Id = 2, StringField = "value2", NullableIntField = 123 }
             };
-            _serializer.SetAttributesToSerialize<TestResource>(tr => tr.StringField);
+            _serializer.AttributesToSerialize = _resourceGraph.GetAttributes<TestResource>(tr => tr.StringField);
 
             // Act
             string serialized = _serializer.Serialize(entities);
@@ -215,7 +215,7 @@ namespace UnitTests.Serialization.Client
         public void SerializeSingle_Null_CanBuild()
         {
             // Arrange
-            _serializer.SetAttributesToSerialize<TestResource>(tr => tr.StringField);
+            _serializer.AttributesToSerialize = _resourceGraph.GetAttributes<TestResource>(tr => tr.StringField);
 
             // Act
             IIdentifiable obj = null;
@@ -235,7 +235,7 @@ namespace UnitTests.Serialization.Client
         {
             // Arrange
             var entities = new List<TestResource> { };
-            _serializer.SetAttributesToSerialize<TestResource>(tr => tr.StringField);
+            _serializer.AttributesToSerialize = _resourceGraph.GetAttributes<TestResource>(tr => tr.StringField);
 
             // Act
             string serialized = _serializer.Serialize(entities);


### PR DESCRIPTION
Replaced

```c#
void SetAttributesToSerialize<TResource>(Expression<Func<TResource, dynamic>> filter) where TResource : class, IIdentifiable;
```
with 
```c#
public IEnumerable<AttrAttribute> AttributesToSerialize { set; }
```

And similar for `RelationshipAttribute`.

Closes #611. See that issue for more detail
