### PR TITLE
Hooks discovery detection of implemented hooks issue

### DIFF
--- a/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
@@ -42,7 +42,7 @@ namespace JsonApiDotNetCore.Configuration
         /// <summary>
         /// Whether or not ResourceHooks are enabled. 
         /// 
-        /// Default is set to <see langword="false"/> for backward compatibility.
+        /// Default is set to <see langword="true"/>
         /// </summary>
         public bool EnableResourceHooks { get; set; } = true;
 

--- a/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
@@ -44,7 +44,7 @@ namespace JsonApiDotNetCore.Configuration
         /// 
         /// Default is set to <see langword="false"/> for backward compatibility.
         /// </summary>
-        public bool EnableResourceHooks { get; set; } = false;
+        public bool EnableResourceHooks { get; set; } = true;
 
         /// <summary>
         /// Whether or not database values should be included by default

--- a/src/JsonApiDotNetCore/Hooks/Discovery/HooksDiscovery.cs
+++ b/src/JsonApiDotNetCore/Hooks/Discovery/HooksDiscovery.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JsonApiDotNetCore.Internal;
 using JsonApiDotNetCore.Models;
-using JsonApiDotNetCore.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace JsonApiDotNetCore.Hooks
 {
@@ -26,13 +26,14 @@ namespace JsonApiDotNetCore.Hooks
         public ResourceHook[] DatabaseValuesEnabledHooks { get; private set; }
         public ResourceHook[] DatabaseValuesDisabledHooks { get; private set; }
 
-        public HooksDiscovery(IScopedServiceProvider provider)
+        public HooksDiscovery(IServiceProvider provider)
         {
             _allHooks = Enum.GetValues(typeof(ResourceHook))
                             .Cast<ResourceHook>()
                             .Where(h => h != ResourceHook.None)
                             .ToArray();
-            var containerType = provider.GetService(_boundResourceDefinitionType)?.GetType();
+            using var scope = provider.CreateScope();
+            var containerType = scope.ServiceProvider.GetService(_boundResourceDefinitionType)?.GetType();
             if (containerType == null || containerType == _boundResourceDefinitionType)
                 return;
             DiscoverImplementedHooksForModel(containerType);

--- a/src/JsonApiDotNetCore/Hooks/Discovery/HooksDiscovery.cs
+++ b/src/JsonApiDotNetCore/Hooks/Discovery/HooksDiscovery.cs
@@ -32,19 +32,27 @@ namespace JsonApiDotNetCore.Hooks
                             .Cast<ResourceHook>()
                             .Where(h => h != ResourceHook.None)
                             .ToArray();
-            using var scope = provider.CreateScope();
-            var containerType = scope.ServiceProvider.GetService(_boundResourceDefinitionType)?.GetType();
-            if (containerType == null || containerType == _boundResourceDefinitionType)
-                return;
-            DiscoverImplementedHooksForModel(containerType);
+
+            Type containerType;
+            using (var scope = provider.CreateScope())
+            {
+                containerType = scope.ServiceProvider.GetService(_boundResourceDefinitionType)?.GetType();
+            }
+
+            DiscoverImplementedHooks(containerType);
         }
 
         /// <summary>
         /// Discovers the implemented hooks for a model.
         /// </summary>
         /// <returns>The implemented hooks for model.</returns>
-        void DiscoverImplementedHooksForModel(Type containerType)
+        void DiscoverImplementedHooks(Type containerType)
         {
+            if (containerType == null || containerType == _boundResourceDefinitionType)
+            {
+                return;
+            }
+
             var implementedHooks = new List<ResourceHook>();
             var databaseValuesEnabledHooks = new List<ResourceHook> { ResourceHook.BeforeImplicitUpdateRelationship }; // this hook can only be used with enabled database values
             var databaseValuesDisabledHooks = new List<ResourceHook>();

--- a/src/JsonApiDotNetCore/Hooks/Discovery/HooksDiscovery.cs
+++ b/src/JsonApiDotNetCore/Hooks/Discovery/HooksDiscovery.cs
@@ -54,7 +54,8 @@ namespace JsonApiDotNetCore.Hooks
             }
 
             var implementedHooks = new List<ResourceHook>();
-            var databaseValuesEnabledHooks = new List<ResourceHook> { ResourceHook.BeforeImplicitUpdateRelationship }; // this hook can only be used with enabled database values
+            // this hook can only be used with enabled database values
+            var databaseValuesEnabledHooks = new List<ResourceHook> { ResourceHook.BeforeImplicitUpdateRelationship };
             var databaseValuesDisabledHooks = new List<ResourceHook>();
             foreach (var hook in _allHooks)
             {

--- a/src/JsonApiDotNetCore/Hooks/Discovery/HooksDiscovery.cs
+++ b/src/JsonApiDotNetCore/Hooks/Discovery/HooksDiscovery.cs
@@ -45,8 +45,8 @@ namespace JsonApiDotNetCore.Hooks
         void DiscoverImplementedHooksForModel(Type containerType)
         {
             var implementedHooks = new List<ResourceHook>();
-            var enabledHooks = new List<ResourceHook> { ResourceHook.BeforeImplicitUpdateRelationship };
-            var disabledHooks = new List<ResourceHook>();
+            var databaseValuesEnabledHooks = new List<ResourceHook> { ResourceHook.BeforeImplicitUpdateRelationship }; // this hook can only be used with enabled database values
+            var databaseValuesDisabledHooks = new List<ResourceHook>();
             foreach (var hook in _allHooks)
             {
                 var method = containerType.GetMethod(hook.ToString("G"));
@@ -62,14 +62,14 @@ namespace JsonApiDotNetCore.Hooks
                         throw new JsonApiSetupException($"DatabaseValuesAttribute cannot be used on hook" +
                             $"{hook.ToString("G")} in resource definition  {containerType.Name}");
                     }
-                    var targetList = attr.value ? enabledHooks : disabledHooks;
+                    var targetList = attr.value ? databaseValuesEnabledHooks : databaseValuesDisabledHooks;
                     targetList.Add(hook);
                 }
             }
 
             ImplementedHooks = implementedHooks.ToArray();
-            DatabaseValuesDisabledHooks = disabledHooks.ToArray();
-            DatabaseValuesEnabledHooks = enabledHooks.ToArray();
+            DatabaseValuesDisabledHooks = databaseValuesDisabledHooks.ToArray();
+            DatabaseValuesEnabledHooks = databaseValuesEnabledHooks.ToArray();
         }
     }
 }

--- a/src/JsonApiDotNetCore/Hooks/Discovery/HooksDiscovery.cs
+++ b/src/JsonApiDotNetCore/Hooks/Discovery/HooksDiscovery.cs
@@ -10,9 +10,9 @@ namespace JsonApiDotNetCore.Hooks
     /// <summary>
     /// The default implementation for IHooksDiscovery
     /// </summary>
-    public class HooksDiscovery<TEntity> : IHooksDiscovery<TEntity> where TEntity : class, IIdentifiable
+    public class HooksDiscovery<TResource> : IHooksDiscovery<TResource> where TResource : class, IIdentifiable
     {
-        private readonly Type _boundResourceDefinitionType = typeof(ResourceDefinition<TEntity>);
+        private readonly Type _boundResourceDefinitionType = typeof(ResourceDefinition<TResource>);
         private readonly ResourceHook[] _allHooks;
         private readonly ResourceHook[] _databaseValuesAttributeAllowed =
         {

--- a/src/JsonApiDotNetCore/Hooks/Discovery/LoadDatabaseValuesAttribute.cs
+++ b/src/JsonApiDotNetCore/Hooks/Discovery/LoadDatabaseValuesAttribute.cs
@@ -1,10 +1,10 @@
 using System;
 namespace JsonApiDotNetCore.Hooks
 {
-    public class LoaDatabaseValues : Attribute
+    public class LoadDatabaseValues : Attribute
     {
         public readonly bool value;
-        public LoaDatabaseValues(bool mode = true)
+        public LoadDatabaseValues(bool mode = true)
         {
             value = mode;
         }

--- a/src/JsonApiDotNetCore/Hooks/Execution/DiffableEntityHashSet.cs
+++ b/src/JsonApiDotNetCore/Hooks/Execution/DiffableEntityHashSet.cs
@@ -90,7 +90,7 @@ namespace JsonApiDotNetCore.Hooks
 
         private HashSet<TResource> ThrowNoDbValuesError()
         {
-            throw new MemberAccessException("Cannot iterate over the diffs if the LoaDatabaseValues option is set to false");
+            throw new MemberAccessException("Cannot iterate over the diffs if the LoadDatabaseValues option is set to false");
         }
     }
 

--- a/src/JsonApiDotNetCore/Hooks/Execution/DiffableEntityHashSet.cs
+++ b/src/JsonApiDotNetCore/Hooks/Execution/DiffableEntityHashSet.cs
@@ -90,7 +90,7 @@ namespace JsonApiDotNetCore.Hooks
 
         private HashSet<TResource> ThrowNoDbValuesError()
         {
-            throw new MemberAccessException("Cannot iterate over the diffs if the LoadDatabaseValues option is set to false");
+            throw new MemberAccessException($"Cannot iterate over the diffs if the ${nameof(LoadDatabaseValues)} option is set to false");
         }
     }
 

--- a/test/UnitTests/Graph/TypeLocator_Tests.cs
+++ b/test/UnitTests/Graph/TypeLocator_Tests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using JsonApiDotNetCore.Graph;
 using JsonApiDotNetCore.Models;
 using Xunit;

--- a/test/UnitTests/ResourceHooks/DiscoveryTests.cs
+++ b/test/UnitTests/ResourceHooks/DiscoveryTests.cs
@@ -22,9 +22,9 @@ namespace UnitTests.ResourceHooks
             public override void AfterDelete(HashSet<Dummy> entities, ResourcePipeline pipeline, bool succeeded) { }
         }
 
-        private IScopedServiceProvider MockProvider(object service)
+        private IServiceProvider MockProvider(object service)
         {
-            var mock = new Mock<IScopedServiceProvider>();
+            var mock = new Mock<IServiceProvider>();
             mock.Setup(m => m.GetService(It.IsAny<Type>())).Returns(service);
             return mock.Object;
         }
@@ -88,30 +88,5 @@ namespace UnitTests.ResourceHooks
             });
 
         }
-
-        //public class DoubleDummy : Identifiable { }
-        //public class DoubleDummyResourceDefinition1 : ResourceDefinition<DoubleDummy>
-        //{
-        //    public DoubleDummyResourceDefinition1() : base(new ResourceGraphBuilder().AddResource<DoubleDummy>().Build()) { }
-
-        //    public override IEnumerable<DoubleDummy> BeforeDelete(IEntityHashSet<DoubleDummy> affected, ResourcePipeline pipeline) { return affected; }
-        //}
-        //public class DoubleDummyResourceDefinition2 : ResourceDefinition<DoubleDummy>
-        //{
-        //    public DoubleDummyResourceDefinition2() : base(new ResourceGraphBuilder().AddResource<DoubleDummy>().Build()) { }
-
-        //    public override void AfterDelete(HashSet<DoubleDummy> entities, ResourcePipeline pipeline, bool succeeded) { }
-        //}
-        //[Fact]
-        //public void Multiple_Implementations_Of_ResourceDefinitions()
-        //{
-        //    //  assert
-        //    Assert.Throws<JsonApiSetupException>(() =>
-        //    {
-        //        // Arrange & act
-        //        new List<> { new DoubleDummyResourceDefinition1(), new DoubleDummyResourceDefinition2() };
-        //        var hookConfig = new HooksDiscovery<DoubleDummy>(MockProvider( ));
-        //    });
-        //}
     }
 }

--- a/test/UnitTests/ResourceHooks/DiscoveryTests.cs
+++ b/test/UnitTests/ResourceHooks/DiscoveryTests.cs
@@ -6,8 +6,7 @@ using JsonApiDotNetCore.Builders;
 using JsonApiDotNetCore.Internal;
 using JsonApiDotNetCore.Internal.Contracts;
 using System;
-using Moq;
-using JsonApiDotNetCore.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace UnitTests.ResourceHooks
 {
@@ -22,32 +21,27 @@ namespace UnitTests.ResourceHooks
             public override void AfterDelete(HashSet<Dummy> entities, ResourcePipeline pipeline, bool succeeded) { }
         }
 
-        private IServiceProvider MockProvider(object service)
+        private IServiceProvider MockProvider<TResource>(object service) where TResource : class, IIdentifiable
         {
-            var mock = new Mock<IServiceProvider>();
-            mock.Setup(m => m.GetService(It.IsAny<Type>())).Returns(service);
-            return mock.Object;
+            var services = new ServiceCollection();
+            services.AddScoped((_) => (ResourceDefinition<TResource>)service);
+            return services.BuildServiceProvider();
         }
-
 
         [Fact]
         public void Hook_Discovery()
         {
             // Arrange & act
-            var hookConfig = new HooksDiscovery<Dummy>(MockProvider(new DummyResourceDefinition()));
+            var hookConfig = new HooksDiscovery<Dummy>(MockProvider<Dummy>(new DummyResourceDefinition()));
             // Assert
             Assert.Contains(ResourceHook.BeforeDelete, hookConfig.ImplementedHooks);
             Assert.Contains(ResourceHook.AfterDelete, hookConfig.ImplementedHooks);
-
         }
 
         public class AnotherDummy : Identifiable { }
         public abstract class ResourceDefintionBase<T> : ResourceDefinition<T> where T : class, IIdentifiable
         {
-            public ResourceDefintionBase(IResourceGraph resourceGraph) : base(resourceGraph)
-            {
-            }
-
+            public ResourceDefintionBase(IResourceGraph resourceGraph) : base(resourceGraph) { }
             public override IEnumerable<T> BeforeDelete(IEntityHashSet<T> affected, ResourcePipeline pipeline) { return affected; }
             public override void AfterDelete(HashSet<T> entities, ResourcePipeline pipeline, bool succeeded) { }
         }
@@ -56,16 +50,16 @@ namespace UnitTests.ResourceHooks
         {
             public AnotherDummyResourceDefinition() : base(new ResourceGraphBuilder().AddResource<AnotherDummy>().Build()) { }
         }
+
         [Fact]
         public void Hook_Discovery_With_Inheritance()
         {
             // Arrange & act
-            var hookConfig = new HooksDiscovery<AnotherDummy>(MockProvider(new AnotherDummyResourceDefinition()));
+            var hookConfig = new HooksDiscovery<AnotherDummy>(MockProvider<AnotherDummy>(new AnotherDummyResourceDefinition()));
             // Assert
             Assert.Contains(ResourceHook.BeforeDelete, hookConfig.ImplementedHooks);
             Assert.Contains(ResourceHook.AfterDelete, hookConfig.ImplementedHooks);
         }
-
 
         public class YetAnotherDummy : Identifiable { }
         public class YetAnotherDummyResourceDefinition : ResourceDefinition<YetAnotherDummy>
@@ -77,6 +71,7 @@ namespace UnitTests.ResourceHooks
             [LoadDatabaseValues(false)]
             public override void AfterDelete(HashSet<YetAnotherDummy> entities, ResourcePipeline pipeline, bool succeeded) { }
         }
+
         [Fact]
         public void LoadDatabaseValues_Attribute_Not_Allowed()
         {
@@ -84,7 +79,7 @@ namespace UnitTests.ResourceHooks
             Assert.Throws<JsonApiSetupException>(() =>
             {
                 // Arrange & act
-                var hookConfig = new HooksDiscovery<YetAnotherDummy>(MockProvider(new YetAnotherDummyResourceDefinition()));
+                var hookConfig = new HooksDiscovery<YetAnotherDummy>(MockProvider<YetAnotherDummy>(new YetAnotherDummyResourceDefinition()));
             });
 
         }


### PR DESCRIPTION
Closes #615

There was a problem with detecting which hooks have been implemented for a particular resource when that resource and its associated resource definition were defined in different assemblies.

This PR:
- contains a fix for that issue: we're no longer expecting assemblies but instead relying on the fact that the hooks container *must* be registered with the DI container anyway, so we might as well resolve it from there
- fixed more occurrences of the `LoaDatabaseValue` typo
- sets the default value of `EnableResourceHooks` to true on `JsonApiOptions`.