### PR TITLE
Fix/#620

### DIFF
--- a/src/Examples/JsonApiDotNetCoreExample/Startups/Startup.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Startups/Startup.cs
@@ -58,6 +58,7 @@ namespace JsonApiDotNetCoreExample
             AppDbContext context)
         {
             context.Database.EnsureCreated();
+            app.EnableDetailedErrors();
             app.UseJsonApi();
         }
 

--- a/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
@@ -32,12 +32,12 @@ namespace JsonApiDotNetCore.Configuration
         /// <summary>
         /// Whether or not stack traces should be serialized in Error objects
         /// </summary>
-        public static bool DisableErrorStackTraces { get; set; }
+        public static bool DisableErrorStackTraces { get; set; } = true;
 
         /// <summary>
         /// Whether or not source URLs should be serialized in Error objects
         /// </summary>
-        public static bool DisableErrorSource { get; set; }
+        public static bool DisableErrorSource { get; set; } = true;
 
         /// <summary>
         /// Whether or not ResourceHooks are enabled. 

--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
@@ -141,7 +141,7 @@ namespace JsonApiDotNetCore.Controllers
                 return Forbidden();
 
             if (_jsonApiOptions.ValidateModelState && !ModelState.IsValid)
-                return UnprocessableEntity(ModelState.ConvertToErrorCollection<T>(GetAssociatedResource()));
+                return UnprocessableEntity(ModelState.ConvertToErrorCollection<T>());
 
             entity = await _create.CreateAsync(entity);
 
@@ -155,7 +155,7 @@ namespace JsonApiDotNetCore.Controllers
                 return UnprocessableEntity();
 
             if (_jsonApiOptions.ValidateModelState && !ModelState.IsValid)
-                return UnprocessableEntity(ModelState.ConvertToErrorCollection<T>(GetAssociatedResource()));
+                return UnprocessableEntity(ModelState.ConvertToErrorCollection<T>());
 
             var updatedEntity = await _update.UpdateAsync(id, entity);
 
@@ -181,12 +181,12 @@ namespace JsonApiDotNetCore.Controllers
             return NoContent();
         }
 
-        internal Type GetAssociatedResource()
-        {
-            return GetType().GetMethod(nameof(GetAssociatedResource), BindingFlags.Instance | BindingFlags.NonPublic)
-                            .DeclaringType
-                            .GetGenericArguments()[0];
-        }
+        //internal Type GetAssociatedResource()
+        //{
+        //    return GetType().GetMethod(nameof(GetAssociatedResource), BindingFlags.Instance | BindingFlags.NonPublic)
+        //                    .DeclaringType
+        //                    .GetGenericArguments()[0];
+        //}
     }
     public class BaseJsonApiController<T>
     : BaseJsonApiController<T, int>

--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Reflection;
 using System.Threading.Tasks;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Extensions;
@@ -106,7 +104,11 @@ namespace JsonApiDotNetCore.Controllers
             if (_getById == null) throw Exceptions.UnSupportedRequestMethod;
             var entity = await _getById.GetAsync(id);
             if (entity == null)
-                return NotFound();
+            {
+                // remove the null argument as soon as this has been resolved:
+                // https://github.com/aspnet/AspNetCore/issues/16969
+                return NotFound(null);
+            }
 
             return Ok(entity);
         }
@@ -117,7 +119,11 @@ namespace JsonApiDotNetCore.Controllers
                 throw Exceptions.UnSupportedRequestMethod;
             var relationship = await _getRelationships.GetRelationshipsAsync(id, relationshipName);
             if (relationship == null)
-                return NotFound();
+            {
+                // remove the null argument as soon as this has been resolved:
+                // https://github.com/aspnet/AspNetCore/issues/16969
+                return NotFound(null);
+            }
 
             return Ok(relationship);
         }
@@ -160,7 +166,12 @@ namespace JsonApiDotNetCore.Controllers
             var updatedEntity = await _update.UpdateAsync(id, entity);
 
             if (updatedEntity == null)
-                return NotFound();
+            {
+                // remove the null argument as soon as this has been resolved:
+                // https://github.com/aspnet/AspNetCore/issues/16969
+                return NotFound(null);
+            }
+
 
             return Ok(updatedEntity);
         }
@@ -180,14 +191,8 @@ namespace JsonApiDotNetCore.Controllers
                 return NotFound();
             return NoContent();
         }
-
-        //internal Type GetAssociatedResource()
-        //{
-        //    return GetType().GetMethod(nameof(GetAssociatedResource), BindingFlags.Instance | BindingFlags.NonPublic)
-        //                    .DeclaringType
-        //                    .GetGenericArguments()[0];
-        //}
     }
+
     public class BaseJsonApiController<T>
     : BaseJsonApiController<T, int>
     where T : class, IIdentifiable<int>

--- a/src/JsonApiDotNetCore/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IApplicationBuilderExtensions.cs
@@ -38,6 +38,10 @@ namespace JsonApiDotNetCore.Extensions
             app.UseEndpoints(endpoints => endpoints.MapControllers());
         }
 
+        /// <summary>
+        /// Configures your application to return stack traces in error results.
+        /// </summary>
+        /// <param name="app"></param>
         public static void EnableDetailedErrors(this IApplicationBuilder app)
         {
             JsonApiOptions.DisableErrorStackTraces = false;

--- a/src/JsonApiDotNetCore/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/IApplicationBuilderExtensions.cs
@@ -6,6 +6,7 @@ using JsonApiDotNetCore.Middleware;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace JsonApiDotNetCore.Extensions
@@ -20,7 +21,6 @@ namespace JsonApiDotNetCore.Extensions
         /// <returns></returns>
         public static void UseJsonApi(this IApplicationBuilder app)
         {
-            DisableDetailedErrorsIfProduction(app);
             LogResourceGraphValidations(app);
             using (var scope = app.ApplicationServices.CreateScope())
             {
@@ -38,14 +38,10 @@ namespace JsonApiDotNetCore.Extensions
             app.UseEndpoints(endpoints => endpoints.MapControllers());
         }
 
-        private static void DisableDetailedErrorsIfProduction(IApplicationBuilder app)
+        public static void EnableDetailedErrors(this IApplicationBuilder app)
         {
-            var webHostEnvironment = (IWebHostEnvironment) app.ApplicationServices.GetService(typeof(IWebHostEnvironment));
-            if (webHostEnvironment.EnvironmentName == "Production")
-            {
-                JsonApiOptions.DisableErrorStackTraces = true;
-                JsonApiOptions.DisableErrorSource = true;
-            }
+            JsonApiOptions.DisableErrorStackTraces = false;
+            JsonApiOptions.DisableErrorSource = false;
         }
 
         private static void LogResourceGraphValidations(IApplicationBuilder app)

--- a/src/JsonApiDotNetCore/Extensions/ModelStateExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/ModelStateExtensions.cs
@@ -9,7 +9,7 @@ namespace JsonApiDotNetCore.Extensions
 {
     public static class ModelStateExtensions
     {
-        public static ErrorCollection ConvertToErrorCollection<T>(this ModelStateDictionary modelState, Type resourceType)
+        public static ErrorCollection ConvertToErrorCollection<T>(this ModelStateDictionary modelState) where T : class, IIdentifiable
         {
             ErrorCollection collection = new ErrorCollection();
             foreach (var entry in modelState)
@@ -19,7 +19,7 @@ namespace JsonApiDotNetCore.Extensions
                     continue;
                 }
 
-                var targetedProperty = resourceType.GetProperty(entry.Key);
+                var targetedProperty = typeof(T).GetProperty(entry.Key);
                 var attrName = targetedProperty.GetCustomAttribute<AttrAttribute>().PublicAttributeName;
 
                 foreach (var modelError in entry.Value.Errors)

--- a/src/JsonApiDotNetCore/Models/JsonApiDocuments/ExposableData.cs
+++ b/src/JsonApiDotNetCore/Models/JsonApiDocuments/ExposableData.cs
@@ -31,11 +31,13 @@ namespace JsonApiDotNetCore.Models
         /// <summary>
         /// Internally used for "single" primary data.
         /// </summary>
+        [JsonIgnore]
         public T SingleData { get; private set; }
 
         /// <summary>
         /// Internally used for "many" primary data.
         /// </summary>
+        [JsonIgnore]
         public List<T> ManyData { get; private set; }
 
         /// <summary>

--- a/src/JsonApiDotNetCore/Models/JsonApiDocuments/ExposableData.cs
+++ b/src/JsonApiDotNetCore/Models/JsonApiDocuments/ExposableData.cs
@@ -31,12 +31,12 @@ namespace JsonApiDotNetCore.Models
         /// <summary>
         /// Internally used for "single" primary data.
         /// </summary>
-        internal T SingleData { get; private set; }
+        public T SingleData { get; private set; }
 
         /// <summary>
         /// Internally used for "many" primary data.
         /// </summary>
-        internal List<T> ManyData { get; private set; }
+        public List<T> ManyData { get; private set; }
 
         /// <summary>
         /// Internally used to indicate if the document's primary data is


### PR DESCRIPTION
- Fixes #620 by exposing better configurability to disable stack traces in error result
- Fixes #620 by ensuring our custom `IOutputFormatter`s are executed with a workaround for [this issue](https://github.com/aspnet/AspNetCore/issues/16969) in .net core 3
- Exposes the getters of `Document.SingleData` and `Document.ManyData` which allows for easier testability.

Closes #620 