### PR TITLE
Unit test hook discovery, fix typo in hooks docs

### DIFF
--- a/src/JsonApiDotNetCore/Hooks/IResourceHookExecutor.cs
+++ b/src/JsonApiDotNetCore/Hooks/IResourceHookExecutor.cs
@@ -19,7 +19,7 @@ namespace JsonApiDotNetCore.Hooks
     public interface ICreateHookExecutor
     {
         /// <summary>
-        /// Executes the Before Cycle by firing the appropiate hooks if they are implemented. 
+        /// Executes the Before Cycle by firing the appropriate hooks if they are implemented. 
         /// The returned set will be used in the actual operation in <see cref="DefaultResourceService{T}"/>.
         /// <para />
         /// Fires the <see cref="ResourceDefinition{T}.BeforeCreate"/>
@@ -34,7 +34,7 @@ namespace JsonApiDotNetCore.Hooks
         /// <typeparam name="TResource">The type of the root entities</typeparam>
         IEnumerable<TResource> BeforeCreate<TResource>(IEnumerable<TResource> entities, ResourcePipeline pipeline) where TResource : class, IIdentifiable;
         /// <summary>
-        /// Executes the After Cycle by firing the appropiate hooks if they are implemented. 
+        /// Executes the After Cycle by firing the appropriate hooks if they are implemented. 
         /// <para />
         /// Fires the <see cref="ResourceDefinition{T}.AfterCreate"/>
         /// hook where T = <typeparamref name="TResource"/> for values in parameter <paramref name="entities"/>.
@@ -51,7 +51,7 @@ namespace JsonApiDotNetCore.Hooks
     public interface IDeleteHookExecutor
     {
         /// <summary>
-        /// Executes the Before Cycle by firing the appropiate hooks if they are implemented. 
+        /// Executes the Before Cycle by firing the appropriate hooks if they are implemented. 
         /// The returned set will be used in the actual operation in <see cref="DefaultResourceService{T}"/>.
         /// <para />
         /// Fires the <see cref="ResourceDefinition{T}.BeforeDelete"/>
@@ -68,7 +68,7 @@ namespace JsonApiDotNetCore.Hooks
         /// <typeparam name="TResource">The type of the root entities</typeparam>
         IEnumerable<TResource> BeforeDelete<TResource>(IEnumerable<TResource> entities, ResourcePipeline pipeline) where TResource : class, IIdentifiable;
         /// <summary>
-        /// Executes the After Cycle by firing the appropiate hooks if they are implemented. 
+        /// Executes the After Cycle by firing the appropriate hooks if they are implemented. 
         /// <para />
         /// Fires the <see cref="ResourceDefinition{T}.AfterDelete"/>
         /// hook where T = <typeparamref name="TResource"/> for values in parameter <paramref name="entities"/>.
@@ -85,7 +85,7 @@ namespace JsonApiDotNetCore.Hooks
     public interface IReadHookExecutor
     {
         /// <summary>
-        /// Executes the Before Cycle by firing the appropiate hooks if they are implemented. 
+        /// Executes the Before Cycle by firing the appropriate hooks if they are implemented. 
         /// <para />
         /// Fires the <see cref="ResourceDefinition{T}.BeforeRead"/>
         /// hook where T = <typeparamref name="TResource"/> for the requested 
@@ -97,7 +97,7 @@ namespace JsonApiDotNetCore.Hooks
         /// <typeparam name="TResource">The type of the request entity</typeparam>
         void BeforeRead<TResource>(ResourcePipeline pipeline, string stringId = null) where TResource : class, IIdentifiable;
         /// <summary>
-        /// Executes the After Cycle by firing the appropiate hooks if they are implemented. 
+        /// Executes the After Cycle by firing the appropriate hooks if they are implemented. 
         /// <para />
         /// Fires the <see cref="ResourceDefinition{T}.AfterRead"/> for every unique
         /// entity type occuring in parameter <paramref name="entities"/>.
@@ -114,7 +114,7 @@ namespace JsonApiDotNetCore.Hooks
     public interface IUpdateHookExecutor
     {
         /// <summary>
-        /// Executes the Before Cycle by firing the appropiate hooks if they are implemented. 
+        /// Executes the Before Cycle by firing the appropriate hooks if they are implemented. 
         /// The returned set will be used in the actual operation in <see cref="DefaultResourceService{T}"/>.
         /// <para />
         /// Fires the <see cref="ResourceDefinition{T}.BeforeUpdate(IDiffableEntityHashSet{T}, ResourcePipeline)"/>
@@ -135,7 +135,7 @@ namespace JsonApiDotNetCore.Hooks
         /// <typeparam name="TResource">The type of the root entities</typeparam>
         IEnumerable<TResource> BeforeUpdate<TResource>(IEnumerable<TResource> entities, ResourcePipeline pipeline) where TResource : class, IIdentifiable;
         /// <summary>
-        /// Executes the After Cycle by firing the appropiate hooks if they are implemented. 
+        /// Executes the After Cycle by firing the appropriate hooks if they are implemented. 
         /// <para />
         /// Fires the <see cref="ResourceDefinition{T}.AfterUpdate"/>
         /// hook where T = <typeparamref name="TResource"/> for values in parameter <paramref name="entities"/>.
@@ -155,7 +155,7 @@ namespace JsonApiDotNetCore.Hooks
     public interface IOnReturnHookExecutor
     {
         /// <summary>
-        /// Executes the On Cycle by firing the appropiate hooks if they are implemented. 
+        /// Executes the On Cycle by firing the appropriate hooks if they are implemented. 
         /// <para />
         /// Fires the <see cref="ResourceDefinition{T}.OnReturn"/> for every unique
         /// entity type occuring in parameter <paramref name="entities"/>.

--- a/test/UnitTests/ResourceHooks/DiscoveryTests.cs
+++ b/test/UnitTests/ResourceHooks/DiscoveryTests.cs
@@ -29,7 +29,7 @@ namespace UnitTests.ResourceHooks
         }
 
         [Fact]
-        public void Hook_Discovery()
+        public void HookDiscovery_StandardResourceDefinition_CanDiscover()
         {
             // Arrange & act
             var hookConfig = new HooksDiscovery<Dummy>(MockProvider<Dummy>(new DummyResourceDefinition()));
@@ -73,7 +73,7 @@ namespace UnitTests.ResourceHooks
         }
 
         [Fact]
-        public void LoadDatabaseValues_Attribute_Not_Allowed()
+        public void HookDiscovery_WronglyUsedLoadDatabaseValueAttribute_ThrowsJsonApiSetupException()
         {
             //  assert
             Assert.Throws<JsonApiSetupException>(() =>

--- a/test/UnitTests/ResourceHooks/DiscoveryTests.cs
+++ b/test/UnitTests/ResourceHooks/DiscoveryTests.cs
@@ -42,7 +42,7 @@ namespace UnitTests.ResourceHooks
         public abstract class ResourceDefintionBase<T> : ResourceDefinition<T> where T : class, IIdentifiable
         {
             public ResourceDefintionBase(IResourceGraph resourceGraph) : base(resourceGraph) { }
-            public override IEnumerable<T> BeforeDelete(IEntityHashSet<T> affected, ResourcePipeline pipeline) { return affected; }
+            public override IEnumerable<T> BeforeDelete(IEntityHashSet<T> entities, ResourcePipeline pipeline) { return entities; }
             public override void AfterDelete(HashSet<T> entities, ResourcePipeline pipeline, bool succeeded) { }
         }
 
@@ -52,7 +52,7 @@ namespace UnitTests.ResourceHooks
         }
 
         [Fact]
-        public void Hook_Discovery_With_Inheritance()
+        public void HookDiscovery_InheritanceSubclass_CanDiscover()
         {
             // Arrange & act
             var hookConfig = new HooksDiscovery<AnotherDummy>(MockProvider<AnotherDummy>(new AnotherDummyResourceDefinition()));
@@ -81,7 +81,25 @@ namespace UnitTests.ResourceHooks
                 // Arrange & act
                 var hookConfig = new HooksDiscovery<YetAnotherDummy>(MockProvider<YetAnotherDummy>(new YetAnotherDummyResourceDefinition()));
             });
+        }
 
+        [Fact]
+        public void HookDiscovery_InheritanceWithGenericSubclass_CanDiscover()
+        {
+            // Arrange & act
+            var hookConfig = new HooksDiscovery<AnotherDummy>(MockProvider<AnotherDummy>(new GenericDummyResourceDefinition<AnotherDummy>()));
+
+            // Assert
+            Assert.Contains(ResourceHook.BeforeDelete, hookConfig.ImplementedHooks);
+            Assert.Contains(ResourceHook.AfterDelete, hookConfig.ImplementedHooks);
+        }
+
+        public class GenericDummyResourceDefinition<TResource> : ResourceDefinition<TResource> where TResource : class, IIdentifiable<int>
+        {
+            public GenericDummyResourceDefinition() : base(new ResourceGraphBuilder().AddResource<TResource>().Build()) { }
+
+            public override IEnumerable<TResource> BeforeDelete(IEntityHashSet<TResource> entities, ResourcePipeline pipeline) { return entities; }
+            public override void AfterDelete(HashSet<TResource> entities, ResourcePipeline pipeline, bool succeeded) { }
         }
     }
 }


### PR DESCRIPTION
- Replaced all occurrences of `appropiate` with `appropriate`
- Cleaned up hook discovery tests
