### PR TITLE
Support query param operations on nested resources

### DIFF
--- a/src/Examples/JsonApiDotNetCoreExample/Models/TodoItem.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Models/TodoItem.cs
@@ -38,7 +38,9 @@ namespace JsonApiDotNetCoreExample.Models
         public DateTimeOffset? OffsetDate { get; set; }
  
         public int? OwnerId { get; set; }
+
         public int? AssigneeId { get; set; }
+
         public Guid? CollectionId { get; set; }
 
         [HasOne]
@@ -49,6 +51,7 @@ namespace JsonApiDotNetCoreExample.Models
 
         [HasOne]
         public virtual Person OneToOnePerson { get; set; }
+
         public virtual int? OneToOnePersonId { get; set; }
 
         [HasMany]
@@ -59,13 +62,16 @@ namespace JsonApiDotNetCoreExample.Models
 
         // cyclical to-one structure
         public virtual int? DependentOnTodoId { get; set; }
+
         [HasOne]
         public virtual TodoItem DependentOnTodo { get; set; }
 
         // cyclical to-many structure
         public virtual int? ParentTodoId {get; set;}
+
         [HasOne]
         public virtual TodoItem ParentTodo { get; set; }
+
         [HasMany]
         public virtual List<TodoItem> ChildrenTodos { get; set; }
     }

--- a/src/JsonApiDotNetCore/Controllers/JsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/JsonApiController.cs
@@ -9,7 +9,6 @@ namespace JsonApiDotNetCore.Controllers
 {
     public class JsonApiController<T, TId> : BaseJsonApiController<T, TId> where T : class, IIdentifiable<TId>
     {
-
         /// <param name="jsonApiOptions"></param>
         /// <param name="resourceService"></param>
         /// <param name="loggerFactory"></param>

--- a/src/JsonApiDotNetCore/QueryParameterServices/Common/QueryParameterService.cs
+++ b/src/JsonApiDotNetCore/QueryParameterServices/Common/QueryParameterService.cs
@@ -20,7 +20,14 @@ namespace JsonApiDotNetCore.Query
         protected QueryParameterService(IResourceGraph resourceGraph, ICurrentRequest currentRequest)
         {
             _resourceGraph = resourceGraph;
-            _requestResource = currentRequest.GetRequestResource();
+            if (currentRequest.RequestRelationship != null)
+            {
+                _requestResource= resourceGraph.GetResourceContext(currentRequest.RequestRelationship.RightType);
+            }
+            else
+            {
+                _requestResource = currentRequest.GetRequestResource();
+            }
         }
 
         protected QueryParameterService() { }

--- a/src/JsonApiDotNetCore/QueryParameterServices/FilterService.cs
+++ b/src/JsonApiDotNetCore/QueryParameterServices/FilterService.cs
@@ -31,6 +31,7 @@ namespace JsonApiDotNetCore.Query
         /// <inheritdoc/>
         public virtual void Parse(KeyValuePair<string, StringValues> queryParameter)
         {
+            EnsureNoNestedResourceRoute();
             var queries = GetFilterQueries(queryParameter);
             _filters.AddRange(queries.Select(GetQueryContexts));
         }

--- a/src/JsonApiDotNetCore/QueryParameterServices/PageService.cs
+++ b/src/JsonApiDotNetCore/QueryParameterServices/PageService.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Internal;
+using JsonApiDotNetCore.Internal.Contracts;
 using JsonApiDotNetCore.Internal.Query;
+using JsonApiDotNetCore.Managers.Contracts;
 using Microsoft.Extensions.Primitives;
 
 namespace JsonApiDotNetCore.Query
@@ -12,7 +14,16 @@ namespace JsonApiDotNetCore.Query
     {
         private readonly IJsonApiOptions _options;
 
-        public PageService(IJsonApiOptions options)
+        public PageService(IJsonApiOptions options, IResourceGraph resourceGraph, ICurrentRequest currentRequest) : base(resourceGraph, currentRequest)
+        {
+            _options = options;
+            PageSize = _options.DefaultPageSize;
+        }
+
+        /// <summary>
+        /// constructor used for unit testing
+        /// </summary>
+        internal PageService(IJsonApiOptions options)
         {
             _options = options;
             PageSize = _options.DefaultPageSize;
@@ -39,6 +50,7 @@ namespace JsonApiDotNetCore.Query
         /// <inheritdoc/>
         public virtual void Parse(KeyValuePair<string, StringValues> queryParameter)
         {
+            EnsureNoNestedResourceRoute();
             // expected input = page[size]=<integer>
             //                  page[number]=<integer > 0>
             var propertyName = queryParameter.Key.Split(QueryConstants.OPEN_BRACKET, QueryConstants.CLOSE_BRACKET)[1];

--- a/src/JsonApiDotNetCore/QueryParameterServices/SortService.cs
+++ b/src/JsonApiDotNetCore/QueryParameterServices/SortService.cs
@@ -28,6 +28,7 @@ namespace JsonApiDotNetCore.Query
         /// <inheritdoc/>
         public virtual void Parse(KeyValuePair<string, StringValues> queryParameter)
         {
+            EnsureNoNestedResourceRoute();
             CheckIfProcessed(); // disallow multiple sort parameters.
             var queries = BuildQueries(queryParameter.Value);
 

--- a/src/JsonApiDotNetCore/QueryParameterServices/SparseFieldsService.cs
+++ b/src/JsonApiDotNetCore/QueryParameterServices/SparseFieldsService.cs
@@ -45,6 +45,7 @@ namespace JsonApiDotNetCore.Query
         {   // expected: articles?fields=prop1,prop2
             //           articles?fields[articles]=prop1,prop2  <-- this form in invalid UNLESS "articles" is actually a relationship on Article
             //           articles?fields[relationship]=prop1,prop2
+            EnsureNoNestedResourceRoute();
             var fields = new List<string> { nameof(Identifiable.Id) };
             fields.AddRange(((string)queryParameter.Value).Split(QueryConstants.COMMA));
 

--- a/src/JsonApiDotNetCore/Services/DefaultResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/DefaultResourceService.cs
@@ -274,7 +274,10 @@ namespace JsonApiDotNetCore.Services
             {
                 foreach (var inclusionChain in chains)
                 {
-                    inclusionChain.InsertRange(0, chainPrefix);
+                    if (chainPrefix != null)
+                    {
+                        inclusionChain.InsertRange(0, chainPrefix);
+                    }
                     entities = _repository.Include(entities, inclusionChain.ToArray());
                 }
             }

--- a/src/JsonApiDotNetCore/Services/DefaultResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/DefaultResourceService.cs
@@ -80,7 +80,7 @@ namespace JsonApiDotNetCore.Services
             if (!IsNull(_hookExecutor, entity)) _hookExecutor.AfterDelete(AsList(entity), ResourcePipeline.Delete, succeeded);
             return succeeded;
         }
-        g
+        
         public virtual async Task<IEnumerable<TResource>> GetAsync()
         {
             _hookExecutor?.BeforeRead<TResource>(ResourcePipeline.Get);

--- a/src/JsonApiDotNetCore/Services/DefaultResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/DefaultResourceService.cs
@@ -134,8 +134,10 @@ namespace JsonApiDotNetCore.Services
 
             // TODO: it would be better if we could distinguish whether or not the relationship was not found,
             // vs the relationship not being set on the instance of T
-            var entityQuery = _repository.Include(_repository.Get(id), new RelationshipAttribute[] { relationship });
-            var entity = await _repository.FirstOrDefaultAsync(entityQuery);
+
+            var query = _repository.Get(id);
+            query = ApplyInclude(query, chainPrefix: new List<RelationshipAttribute> { relationship });
+            var entity = await _repository.FirstOrDefaultAsync(query);
             if (entity == null) // this does not make sense. If the parent entity is not found, this error is thrown?
                 throw new JsonApiException(404, $"Relationship '{relationshipName}' not found.");
 
@@ -251,12 +253,31 @@ namespace JsonApiDotNetCore.Services
         /// </summary>
         /// <param name="entities"></param>
         /// <returns></returns>
-        protected virtual IQueryable<TResource> ApplyInclude(IQueryable<TResource> entities)
+        protected virtual IQueryable<TResource> ApplyInclude(IQueryable<TResource> entities, IEnumerable<RelationshipAttribute> chainPrefix = null)
         {
             var chains = _includeService.Get();
-            if (chains != null && chains.Any())
-                foreach (var r in chains)
-                    entities = _repository.Include(entities, r.ToArray());
+            bool hasInclusionChain = chains.Any();
+
+            if (chains == null)
+            {
+                throw new Exception();
+            }
+
+            if (chainPrefix != null && !hasInclusionChain)
+            {
+               hasInclusionChain = true;
+               chains.Add(new List<RelationshipAttribute>());
+            }
+
+
+            if (hasInclusionChain)
+            {
+                foreach (var inclusionChain in chains)
+                {
+                    inclusionChain.InsertRange(0, chainPrefix);
+                    entities = _repository.Include(entities, inclusionChain.ToArray());
+                }
+            }
 
             return entities;
         }

--- a/src/JsonApiDotNetCore/Services/DefaultResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/DefaultResourceService.cs
@@ -80,7 +80,7 @@ namespace JsonApiDotNetCore.Services
             if (!IsNull(_hookExecutor, entity)) _hookExecutor.AfterDelete(AsList(entity), ResourcePipeline.Delete, succeeded);
             return succeeded;
         }
-
+        g
         public virtual async Task<IEnumerable<TResource>> GetAsync()
         {
             _hookExecutor?.BeforeRead<TResource>(ResourcePipeline.Get);
@@ -135,13 +135,7 @@ namespace JsonApiDotNetCore.Services
             // TODO: it would be better if we could distinguish whether or not the relationship was not found,
             // vs the relationship not being set on the instance of T
 
-            var entityQuery = _repository.Get(id);
-
-            entityQuery = ApplyFilter(entityQuery);
-            entityQuery = ApplySort(entityQuery);
-            entityQuery = ApplyInclude(entityQuery, chainPrefix: new List<RelationshipAttribute> { relationship });
-            entityQuery = ApplySelect(entityQuery);
-
+            var entityQuery = ApplyInclude(_repository.Get(id), chainPrefix: new List<RelationshipAttribute> { relationship });
             var entity = await _repository.FirstOrDefaultAsync(entityQuery);
             if (entity == null)
             {

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/CreatingDataTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/CreatingDataTests.cs
@@ -14,6 +14,7 @@ using Person = JsonApiDotNetCoreExample.Models.Person;
 
 namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
 {
+
     public class CreatingDataTests : FunctionalTestCollection<StandardApplicationFactory>
     {
         private readonly Faker<TodoItem> _todoItemFaker;

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/CreatingDataTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/CreatingDataTests.cs
@@ -14,7 +14,6 @@ using Person = JsonApiDotNetCoreExample.Models.Person;
 
 namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
 {
-
     public class CreatingDataTests : FunctionalTestCollection<StandardApplicationFactory>
     {
         private readonly Faker<TodoItem> _todoItemFaker;

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/NestedResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/NestedResourceTests.cs
@@ -29,7 +29,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
         }
 
         [Fact]
-        public async Task NestedResourceRoute_IncludeDeeplyNestedRelationship_ReturnsRequestedRelationships()
+        public async Task NestedResourceRoute_RequestWithIncludeQueryParam_ReturnsRequestedRelationships()
         {
             // Arrange
             var assignee = _dbContext.Add(_personFaker.Generate()).Entity;
@@ -51,6 +51,22 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             Assert.Equal(todo.Id, resultTodoItem.Id);
             Assert.Equal(todo.Owner.Id, resultTodoItem.Owner.Id);
             Assert.Equal(todo.Owner.Passport.Id, resultTodoItem.Owner.Passport.Id);
+        }
+
+        [Theory]
+        [InlineData("filter[ordinal]=1")]
+        [InlineData("fields=ordinal")]
+        [InlineData("sort=ordinal")]
+        [InlineData("page[number]=1")]
+        [InlineData("page[size]=10")]
+        public async Task NestedResourceRoute_RequestWithUnsupportedQueryParam_ReturnsBadRequest(string queryParam)
+        {
+            // Act
+            var (body, response) = await Get($"/api/v1/people/1/assignedTodoItems?{queryParam}");
+
+            // Assert
+            AssertEqualStatusCode(HttpStatusCode.BadRequest, response);
+            Assert.Contains("currently not supported", body);
         }
     }
 }

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/NestedResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/NestedResourceTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Bogus;
+using JsonApiDotNetCoreExample.Models;
+using JsonApiDotNetCoreExampleTests.Helpers.Models;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using Person = JsonApiDotNetCoreExample.Models.Person;
+
+namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
+{
+    public class NestedResourceTests : FunctionalTestCollection<StandardApplicationFactory>
+    {
+        private readonly Faker<TodoItem> _todoItemFaker;
+        private readonly Faker<Person> _personFaker;
+        private readonly Faker<Passport> _passportFaker;
+
+        public NestedResourceTests(StandardApplicationFactory factory) : base(factory)
+        {
+            _todoItemFaker = new Faker<TodoItem>()
+                    .RuleFor(t => t.Description, f => f.Lorem.Sentence())
+                    .RuleFor(t => t.Ordinal, f => f.Random.Number())
+                    .RuleFor(t => t.CreatedDate, f => f.Date.Past());
+            _personFaker = new Faker<Person>()
+                    .RuleFor(t => t.FirstName, f => f.Name.FirstName())
+                    .RuleFor(t => t.LastName, f => f.Name.LastName());
+            _passportFaker = new Faker<Passport>()
+                    .RuleFor(t => t.SocialSecurityNumber, f => f.Random.Number());
+        }
+
+        [Fact]
+        public async Task Include_NestedResource_CanInclude()
+        {
+            // Arrange
+            var assignee = _dbContext.Add(_personFaker.Generate()).Entity;
+            var todo = _dbContext.Add(_todoItemFaker.Generate()).Entity;
+            var owner = _dbContext.Add(_personFaker.Generate()).Entity;
+            var passport = _dbContext.Add(_passportFaker.Generate()).Entity;
+            _dbContext.SaveChanges();
+            todo.AssigneeId = assignee.Id;
+            todo.OwnerId = owner.Id;
+            owner.PassportId = passport.Id;
+            _dbContext.SaveChanges();
+
+            // Act
+            var (body, response) = await Get($"/api/v1/people/{assignee.Id}/assignedTodoItems?include=owner.passport");
+
+            // Assert
+            AssertEqualStatusCode(HttpStatusCode.OK, response);
+            var resultTodoItem = _deserializer.DeserializeList<TodoItemClient>(body).Data.SingleOrDefault();
+            Assert.Equal(todo.Id, resultTodoItem.Id);
+            Assert.Equal(todo.Owner.Id, resultTodoItem.Owner.Id);
+            Assert.Equal(todo.Owner.Passport.Id, resultTodoItem.Owner.Passport.Id);
+        }
+    }
+}

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/NestedResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/NestedResourceTests.cs
@@ -52,26 +52,5 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             Assert.Equal(todo.Owner.Id, resultTodoItem.Owner.Id);
             Assert.Equal(todo.Owner.Passport.Id, resultTodoItem.Owner.Passport.Id);
         }
-
-        [Fact]
-        public async Task NestedResourceRoute_Filter_ReturnsFilteredResources()
-        {
-            // Arrange
-            var assignee = _personFaker.Generate();
-            //var assignee = _dbContext.Add(_personFaker.Generate()).Entity;
-            //var todos = _todoItemFaker.Generate(10).ToList();
-            assignee.AssignedTodoItems = _todoItemFaker.Generate(10).ToList();
-            //assignee.AssignedTodoItems = todos;
-            _dbContext.Add(assignee);
-            var ordinal = assignee.AssignedTodoItems.First().Ordinal;
-
-            // Act
-            var (body, response) = await Get($"/api/v1/people/{assignee.Id}/assignedTodoItems?filter[ordinal]={ordinal}");
-
-            // Assert
-            AssertEqualStatusCode(HttpStatusCode.OK, response);
-            var resultTodoItem = _deserializer.DeserializeList<TodoItemClient>(body).Data.SingleOrDefault();
-            Assert.Equal(assignee.AssignedTodoItems.First().Id, resultTodoItem.Id);
-        }
     }
 }

--- a/test/UnitTests/Services/EntityResourceService_Tests.cs
+++ b/test/UnitTests/Services/EntityResourceService_Tests.cs
@@ -87,7 +87,9 @@ namespace UnitTests.Services
 
         private DefaultResourceService<TodoItem> GetService()
         {
-            return new DefaultResourceService<TodoItem>(new List<IQueryParameterService>(), new JsonApiOptions(), _repositoryMock.Object, _resourceGraph);
+            var includeService = new Mock<IIncludeService>();
+            includeService.Setup(m => m.Get()).Returns(new List<List<RelationshipAttribute>>());
+            return new DefaultResourceService<TodoItem>(new List<IQueryParameterService>() { includeService.Object }, new JsonApiOptions(), _repositoryMock.Object, _resourceGraph);
         }
     }
 }

--- a/test/UnitTests/Services/EntityResourceService_Tests.cs
+++ b/test/UnitTests/Services/EntityResourceService_Tests.cs
@@ -19,9 +19,21 @@ namespace UnitTests.Services
     {
         private readonly Mock<IResourceRepository<TodoItem>> _repositoryMock = new Mock<IResourceRepository<TodoItem>>();
         private readonly IResourceGraph _resourceGraph;
+        private readonly Mock<IIncludeService> _includeService;
+        private readonly Mock<ISparseFieldsService> _sparseFieldsService;
+        private readonly Mock<IPageService> _pageService;
+
+        public Mock<ISortService> _sortService { get; }
+        public Mock<IFilterService> _filterService { get; }
 
         public EntityResourceService_Tests()
         {
+            _includeService = new Mock<IIncludeService>();
+            _includeService.Setup(m => m.Get()).Returns(new List<List<RelationshipAttribute>>());
+            _sparseFieldsService = new Mock<ISparseFieldsService>();
+            _pageService = new Mock<IPageService>();
+            _sortService = new Mock<ISortService>();
+            _filterService = new Mock<IFilterService>();
             _resourceGraph = new ResourceGraphBuilder()
                                 .AddResource<TodoItem>()
                                 .AddResource<TodoItemCollection, Guid>()
@@ -87,9 +99,13 @@ namespace UnitTests.Services
 
         private DefaultResourceService<TodoItem> GetService()
         {
-            var includeService = new Mock<IIncludeService>();
-            includeService.Setup(m => m.Get()).Returns(new List<List<RelationshipAttribute>>());
-            return new DefaultResourceService<TodoItem>(new List<IQueryParameterService>() { includeService.Object }, new JsonApiOptions(), _repositoryMock.Object, _resourceGraph);
+            var queryParamServices = new List<IQueryParameterService>
+            {
+                _includeService.Object, _pageService.Object, _filterService.Object,
+                _sortService.Object, _sparseFieldsService.Object
+            };
+
+            return new DefaultResourceService<TodoItem>(queryParamServices, new JsonApiOptions(), _repositoryMock.Object, _resourceGraph);
         }
     }
 }


### PR DESCRIPTION
This closed  #628 and partially addresses  #627

Please see #627 for a the relevant discussion about this

- [x] Support includes on nested route
~- [ ] Support filter on nested route~
~- [ ] Support sparse field selection on nested route~
~- [ ] Support paging on nested route~
- [x] Throw HTTP 400 when unsupported query params are used in nested resource routes