### PR TITLE
Return 404 or 200 on error/non existent resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,24 @@
 <img src ="https://raw.githubusercontent.com/json-api-dotnet/JsonApiDotnetCore/master/logo.png" />
 </p>
 
-# JSON API .Net Core
+# JSON API .Net Core <!-- omit in toc -->
 
-[![Build status](https://ci.appveyor.com/api/projects/status/9fvgeoxdikwkom10?svg=true)](https://ci.appveyor.com/project/jaredcnance/jsonapidotnetcore)
-[![Travis](https://travis-ci.org/json-api-dotnet/JsonApiDotNetCore.svg?branch=master)](https://travis-ci.org/json-api-dotnet/JsonApiDotNetCore)
-[![NuGet](https://img.shields.io/nuget/v/JsonApiDotNetCore.svg)](https://www.nuget.org/packages/JsonApiDotNetCore/)
-[![Join the chat at https://gitter.im/json-api-dotnet-core/Lobby](https://badges.gitter.im/json-api-dotnet-core/Lobby.svg)](https://gitter.im/json-api-dotnet-core/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![FIRST-TIMERS](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](http://www.firsttimersonly.com/)
+[![Build status](https://ci.appveyor.com/api/projects/status/9fvgeoxdikwkom10?svg=true)](https://ci.appveyor.com/project/jaredcnance/jsonapidotnetcore) [![Travis](https://travis-ci.org/json-api-dotnet/JsonApiDotNetCore.svg?branch=master)](https://travis-ci.org/json-api-dotnet/JsonApiDotNetCore) [![NuGet](https://img.shields.io/nuget/v/JsonApiDotNetCore.svg)](https://www.nuget.org/packages/JsonApiDotNetCore/) [![Join the chat at https://gitter.im/json-api-dotnet-core/Lobby](https://badges.gitter.im/json-api-dotnet-core/Lobby.svg)](https://gitter.im/json-api-dotnet-core/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![FIRST-TIMERS](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](http://www.firsttimersonly.com/)
 
 A framework for building [json:api](http://jsonapi.org/) compliant web APIs. The ultimate goal of this library is to eliminate as much boilerplate as possible by offering out-of-the-box features such as sorting, filtering and pagination. You just need to focus on defining the resources and implementing your custom business logic. This library has been designed around dependency injection making extensibility incredibly easy.
+
+## Table of Contents <!-- omit in toc -->
+- [Getting Started](#getting-started)
+- [Related Projects](#related-projects)
+- [Examples](#examples)
+- [Compatibility](#compatibility)
+- [Installation And Usage](#installation-and-usage)
+  - [Models](#models)
+  - [Controllers](#controllers)
+  - [Middleware](#middleware)
+- [Development](#development)
+    - [Testing](#testing)
+    - [Cleaning](#cleaning)
 
 ## Getting Started
 
@@ -33,6 +42,15 @@ These are some steps you can take to help you understand what this project is an
 ## Examples
 
 See the [examples](https://github.com/json-api-dotnet/JsonApiDotNetCore/tree/master/src/Examples) directory for up-to-date sample applications. There is also a [Todo List App](https://github.com/json-api-dotnet/TodoListExample) that includes a JADNC API and an EmberJs client.
+
+## Compatibility
+
+A lot of changes were introduced in v4.0.0, the following chart should help you with compatibility issues between .NET Core versions
+
+| .NET Core Version | JADNC Version |
+| ----------------- | ------------- |
+| 2.*               | v3.*          |
+| 3.*               | v4.*          |
 
 ## Installation And Usage
 
@@ -79,7 +97,7 @@ public class Startup
 }
 ```
 
-### Development
+## Development
 
 Restore all NuGet packages with:
 
@@ -109,13 +127,5 @@ Sometimes the compiled files can be dirty / corrupt from other branches / failed
 dotnet clean
 ```
 
-## Compatibility
-
-A lot of changes were introduced in v4.0.0, the following chart should help you with compatibility issues between .NET Core versions
-
-| .NET Core Version | JADNC Version |
-| ----------------- | ------------- |
-| 2.*               | v3.*          |
-| 3.*               | v4.*          |
 
 

--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
@@ -101,16 +101,23 @@ namespace JsonApiDotNetCore.Controllers
 
         public virtual async Task<IActionResult> GetAsync(TId id)
         {
-            if (_getById == null) throw Exceptions.UnSupportedRequestMethod;
+            if (_getById == null) {
+                throw Exceptions.UnSupportedRequestMethod;
+            }
             var entity = await _getById.GetAsync(id);
             if (entity == null)
             {
-                // remove the null argument as soon as this has been resolved:
-                // https://github.com/aspnet/AspNetCore/issues/16969
-                return NotFound(null);
+                return NoResultFound();
             }
 
             return Ok(entity);
+        }
+
+        private NotFoundObjectResult NoResultFound()
+        {
+            // remove the null argument as soon as this has been resolved:
+            // https://github.com/aspnet/AspNetCore/issues/16969
+            return NotFound(null);
         }
 
         public virtual async Task<IActionResult> GetRelationshipsAsync(TId id, string relationshipName)
@@ -120,9 +127,7 @@ namespace JsonApiDotNetCore.Controllers
             var relationship = await _getRelationships.GetRelationshipsAsync(id, relationshipName);
             if (relationship == null)
             {
-                // remove the null argument as soon as this has been resolved:
-                // https://github.com/aspnet/AspNetCore/issues/16969
-                return NotFound(null);
+                return NoResultFound();
             }
 
             return Ok(relationship);

--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
@@ -135,26 +135,35 @@ namespace JsonApiDotNetCore.Controllers
 
         protected virtual async Task<IActionResult> GetRelationshipInternal(TId id, string relationshipName, bool relationshipInUrl)
         {
-            if (_getRelationship == null)
-            {
-                throw Exceptions.UnSupportedRequestMethod;
-            }
+
             object relationship;
             if (relationshipInUrl)
             {
-                relationship = await _getRelationship.GetRelationshipAsync(id, relationshipName);
+                if (_getRelationships == null)
+                {
+                    throw Exceptions.UnSupportedRequestMethod;
+                }
+                relationship = await _getRelationships.GetRelationshipsAsync(id, relationshipName);
             }
             else
             {
+                if (_getRelationship == null)
+                {
+                    throw Exceptions.UnSupportedRequestMethod;
+                }
                 relationship = await _getRelationship.GetRelationshipAsync(id, relationshipName);
             }
-            if(relationship == null)
+            if (relationship == null)
             {
                 return Ok(null);
             }
-            if (((IEnumerable<object>)relationship).Count() == 0)
+
+            if (relationship.GetType() != typeof(T))
             {
-                return Ok(null);
+                if (((IEnumerable<object>)relationship).Count() == 0)
+                {
+                    return Ok(null);
+                }
             }
             return Ok(relationship);
         }

--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
@@ -155,7 +155,7 @@ namespace JsonApiDotNetCore.Controllers
             }
             if (relationship == null)
             {
-                return Ok(null);
+                return Ok(relationship);
             }
 
             if (relationship.GetType() != typeof(T))

--- a/src/JsonApiDotNetCore/Formatters/JsonApiWriter.cs
+++ b/src/JsonApiDotNetCore/Formatters/JsonApiWriter.cs
@@ -47,13 +47,12 @@ namespace JsonApiDotNetCore.Formatters
             {
                 var requestedModel = _currentRequest.GetRequestResource();
                 var errors = new ErrorCollection();
-                errors.Add(new Error(404, $"The resource with type '{requestedModel.ResourceName}' and id 'unknown' could not be found"));
+                errors.Add(new Error(404, $"The resource with type '{requestedModel.ResourceName}' and id '{_currentRequest.BaseId}' could not be found"));
                 responseContent = _serializer.Serialize(errors);
                 response.StatusCode = 404;
             }
             else
             {
-
                 if (_serializer == null)
                 {
                     responseContent = JsonConvert.SerializeObject(context.Object);
@@ -68,7 +67,6 @@ namespace JsonApiDotNetCore.Formatters
                             var errors = new ErrorCollection();
                             errors.Add(new Error(pd.Status.Value, pd.Title, pd.Detail));
                             responseContent = _serializer.Serialize(errors);
-
                         }
                         else
                         {

--- a/src/JsonApiDotNetCore/Internal/Exceptions/ResourceNotFoundException.cs
+++ b/src/JsonApiDotNetCore/Internal/Exceptions/ResourceNotFoundException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace JsonApiDotNetCore.Internal
+{
+    public class ResourceNotFoundException : Exception
+    {
+        private readonly ErrorCollection _errors = new ErrorCollection();
+
+        public ResourceNotFoundException()
+        { }
+
+    }
+}

--- a/src/JsonApiDotNetCore/Middleware/DefaultExceptionFilter.cs
+++ b/src/JsonApiDotNetCore/Middleware/DefaultExceptionFilter.cs
@@ -1,7 +1,9 @@
-﻿using JsonApiDotNetCore.Internal;
+using JsonApiDotNetCore.Internal;
+using JsonApiDotNetCore.Managers.Contracts;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 
 namespace JsonApiDotNetCore.Middleware
 {
@@ -10,19 +12,19 @@ namespace JsonApiDotNetCore.Middleware
     /// </summary>
     public class DefaultExceptionFilter : ActionFilterAttribute, IExceptionFilter
     {
+        private readonly ICurrentRequest _currentRequest;
         private readonly ILogger _logger;
 
-        public DefaultExceptionFilter(ILoggerFactory loggerFactory)
+        public DefaultExceptionFilter(ILoggerFactory loggerFactory, ICurrentRequest currentRequest)
         {
+            _currentRequest = currentRequest;
             _logger = loggerFactory.CreateLogger<DefaultExceptionFilter>();
         }
 
         public void OnException(ExceptionContext context)
         {
             _logger?.LogError(new EventId(), context.Exception, "An unhandled exception occurred during the request");
-
             var jsonApiException = JsonApiExceptionFactory.GetException(context.Exception);
-
             var error = jsonApiException.GetError();
             var result = new ObjectResult(error)
             {

--- a/src/JsonApiDotNetCore/Serialization/Server/Builders/LinkBuilder.cs
+++ b/src/JsonApiDotNetCore/Serialization/Server/Builders/LinkBuilder.cs
@@ -110,6 +110,10 @@ namespace JsonApiDotNetCore.Serialization.Server.Builders
         /// <inheritdoc/>
         public RelationshipLinks GetRelationshipLinks(RelationshipAttribute relationship, IIdentifiable parent)
         {
+            if(parent == null)
+            {
+                return null;
+            }
             var parentResourceContext = _provider.GetResourceContext(parent.GetType());
             var childNavigation = relationship.PublicRelationshipName;
             RelationshipLinks links = null;

--- a/src/JsonApiDotNetCore/index.md
+++ b/src/JsonApiDotNetCore/index.md
@@ -1,4 +1,0 @@
-# This is the **HOMEPAGE**.
-Refer to [Markdown](http://daringfireball.net/projects/markdown/) for how to write markdown files.
-## Quick Start Notes:
-1. Add images to the *images* folder if the file is referencing an image.

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/EndToEndTest.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/EndToEndTest.cs
@@ -36,7 +36,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             ClearDbContext();
         }
 
-        protected Task<(string, HttpResponseMessage)> Get(string route)
+        protected Task<(string Body, HttpResponseMessage Response)> Get(string route)
         {
             return SendRequest("GET", route);
         }
@@ -109,7 +109,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             _dbContext.SaveChanges();
         }
 
-        private async Task<(string, HttpResponseMessage)> SendRequest(string method, string route, string content = null)
+        private async Task<(string body, HttpResponseMessage response)> SendRequest(string method, string route, string content = null)
         {
             var request = new HttpRequestMessage(new HttpMethod(method), route);
             if (content != null)

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/NonExistentResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/NonExistentResourceTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Bogus;
+using JsonApiDotNetCore.Models;
+using JsonApiDotNetCoreExample;
+using JsonApiDotNetCoreExample.Data;
+using JsonApiDotNetCoreExample.Models;
+using Newtonsoft.Json;
+using Xunit;
+using Person = JsonApiDotNetCoreExample.Models.Person;
+
+namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
+{
+    [Collection("WebHostCollection")]
+    public class NonExistentResourceTests
+    {
+        private TestFixture<Startup> _fixture;
+        private Faker<TodoItem> _todoItemFaker;
+        private readonly Faker<Person> _personFaker;
+
+        public NonExistentResourceTests(TestFixture<Startup> fixture)
+        {
+            _fixture = fixture;
+            _todoItemFaker = new Faker<TodoItem>()
+                .RuleFor(t => t.Description, f => f.Lorem.Sentence())
+                .RuleFor(t => t.Ordinal, f => f.Random.Number())
+                .RuleFor(t => t.CreatedDate, f => f.Date.Past());
+
+            _personFaker = new Faker<Person>()
+                .RuleFor(p => p.FirstName, f => f.Name.FirstName())
+                .RuleFor(p => p.LastName, f => f.Name.LastName());
+        }
+
+        public class ErrorInnerMessage
+        {
+            [JsonProperty("title")]
+            public string Title;
+            [JsonProperty("status")]
+            public string Status;
+        }
+        public class ErrorMessage
+        {
+            [JsonProperty("errors")]
+            public List<ErrorInnerMessage> Errors;
+        }
+        [Fact]
+        public async Task Resource_UserNonExistent_ShouldReturn404WithCorrectError()
+        {
+            // Arrange
+            var context = _fixture.GetService<AppDbContext>();
+            context.TodoItems.RemoveRange(context.TodoItems.ToList());
+            var todoItem = _todoItemFaker.Generate();
+            context.TodoItems.Add(todoItem);
+            await context.SaveChangesAsync();
+            var nonExistentId = todoItem.Id;
+            context.TodoItems.Remove(todoItem);
+            context.SaveChanges();
+
+            var httpMethod = new HttpMethod("GET");
+            var route = $"/api/v1/todoItems/{nonExistentId}";
+            var request = new HttpRequestMessage(httpMethod, route);
+
+            // Act
+            var response = await _fixture.Client.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            var errorResult = JsonConvert.DeserializeObject<ErrorMessage>(body);
+            var title = errorResult.Errors.First().Title;
+            Assert.Contains(title, "todoitem");
+            Assert.Contains(title, "found");
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+    }
+}

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/NonExistentResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/Spec/NonExistentResourceTests.cs
@@ -48,20 +48,19 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             public List<ErrorInnerMessage> Errors;
         }
         [Fact]
-        public async Task Resource_UserNonExistent_ShouldReturn404WithCorrectError()
+        public async Task Resource_PersonNonExistent_ShouldReturn404WithCorrectError()
         {
             // Arrange
             var context = _fixture.GetService<AppDbContext>();
-            context.People.RemoveRange(context.People.ToList());
             var person = _personFaker.Generate();
             context.People.Add(person);
             await context.SaveChangesAsync();
-            var nonExistentId = person.Id;
+            var nonExistingId = person.Id;
             context.People.Remove(person);
             context.SaveChanges();
 
             var httpMethod = HttpMethod.Get;
-            var route = $"/api/v1/people/{nonExistentId}";
+            var route = $"/api/v1/people/{nonExistingId}";
             var request = new HttpRequestMessage(httpMethod, route);
 
             // Act
@@ -73,8 +72,9 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             var errorParsed = errorResult.Errors.First();
             var title = errorParsed.Title;
             var code = errorParsed.Status;
-            Assert.Contains(title, "person");
-            Assert.Contains(title, "found");
+            Assert.Contains("found", title);
+            Assert.Contains("people", title);
+            Assert.Contains(nonExistingId.ToString(), title);
             Assert.Equal("404", code);
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
@@ -100,7 +100,6 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance.Spec
             // Assert
             var errorResult = JsonConvert.DeserializeObject<ErrorMessage>(body);
             var title = errorResult.Errors.First().Title;
-            Assert.Contains(title, "todoitem");
             Assert.Contains(title, "found");
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }

--- a/test/UnitTests/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/test/UnitTests/Extensions/IServiceCollectionExtensionsTests.cs
@@ -165,7 +165,7 @@ namespace UnitTests.Extensions
             public Task<IEnumerable<IntResource>> GetAsync() => throw new NotImplementedException();
             public Task<IntResource> GetAsync(int id) => throw new NotImplementedException();
             public Task<object> GetRelationshipAsync(int id, string relationshipName) => throw new NotImplementedException();
-            public Task<(IntResource model, bool emptyResults)> GetRelationshipsAsync(int id, string relationshipName) => throw new NotImplementedException();
+            public Task<IntResource> GetRelationshipsAsync(int id, string relationshipName) => throw new NotImplementedException();
             public Task<IntResource> UpdateAsync(int id, IntResource entity) => throw new NotImplementedException();
             public Task UpdateRelationshipsAsync(int id, string relationshipName, object relationships) => throw new NotImplementedException();
         }
@@ -177,7 +177,7 @@ namespace UnitTests.Extensions
             public Task<IEnumerable<GuidResource>> GetAsync() => throw new NotImplementedException();
             public Task<GuidResource> GetAsync(Guid id) => throw new NotImplementedException();
             public Task<object> GetRelationshipAsync(Guid id, string relationshipName) => throw new NotImplementedException();
-            public Task<(GuidResource model, emptyResults bool)> GetRelationshipsAsync(Guid id, string relationshipName) => throw new NotImplementedException();
+            public Task<GuidResource> GetRelationshipsAsync(Guid id, string relationshipName) => throw new NotImplementedException();
             public Task<GuidResource> UpdateAsync(Guid id, GuidResource entity) => throw new NotImplementedException();
             public Task UpdateRelationshipsAsync(Guid id, string relationshipName, object relationships) => throw new NotImplementedException();
         }

--- a/test/UnitTests/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/test/UnitTests/Extensions/IServiceCollectionExtensionsTests.cs
@@ -165,7 +165,7 @@ namespace UnitTests.Extensions
             public Task<IEnumerable<IntResource>> GetAsync() => throw new NotImplementedException();
             public Task<IntResource> GetAsync(int id) => throw new NotImplementedException();
             public Task<object> GetRelationshipAsync(int id, string relationshipName) => throw new NotImplementedException();
-            public Task<IntResource> GetRelationshipsAsync(int id, string relationshipName) => throw new NotImplementedException();
+            public Task<(IntResource model, bool emptyResults)> GetRelationshipsAsync(int id, string relationshipName) => throw new NotImplementedException();
             public Task<IntResource> UpdateAsync(int id, IntResource entity) => throw new NotImplementedException();
             public Task UpdateRelationshipsAsync(int id, string relationshipName, object relationships) => throw new NotImplementedException();
         }
@@ -177,7 +177,7 @@ namespace UnitTests.Extensions
             public Task<IEnumerable<GuidResource>> GetAsync() => throw new NotImplementedException();
             public Task<GuidResource> GetAsync(Guid id) => throw new NotImplementedException();
             public Task<object> GetRelationshipAsync(Guid id, string relationshipName) => throw new NotImplementedException();
-            public Task<GuidResource> GetRelationshipsAsync(Guid id, string relationshipName) => throw new NotImplementedException();
+            public Task<(GuidResource model, emptyResults bool)> GetRelationshipsAsync(Guid id, string relationshipName) => throw new NotImplementedException();
             public Task<GuidResource> UpdateAsync(Guid id, GuidResource entity) => throw new NotImplementedException();
             public Task UpdateRelationshipsAsync(Guid id, string relationshipName, object relationships) => throw new NotImplementedException();
         }


### PR DESCRIPTION
Closes #631

## Problem
Upon getting to a resource that is non-existent, the following object is returned:
```json
{
  "links": {
    "self": "https://localhost/api/users"
  },
  "data": null
}
```
## Proposed solution
When a `200` is applicable, i.e. the route exists, but nothing can be returned, i.e. when a user with id `1` exists and a GET request is sent to `http://example.com/users/1/books`. But it should return a 404 if user `1` does not exist, also for `http://example.com/users/1`.

We also require a descriptive error message, instead of just returning 404.

## Done

- [x] Requesting an existing base model with no to-one relationships should return `200` with `null` for data. ( GET `/api/v1/todoItems/412/oneToOnePerson`)
- [] Requesting an existing base model's relationships with a to-many relationship should return `200` with `[]` for data ( GET `/api/v1/todoItems/1/stakeHolders`)
- [ ] Requesting an existing base model with no to-one relationships should return `200` with `null` for data. ( GET `/api/v1/todoItems/412/relationships/oneToOnePerson`)
- [ ] Requesting an existing base model's relationships with a to-many relationship should return `200` with `[]` for data ( GET `/api/v1/todoItems/1/relationships/stakeHolders`)
- [x] Requesting an non-existing base model (todoItem) should return 404
