### PR TITLE
Make FirstOrDefaultAsync virtual to be able to override

### DIFF
--- a/src/JsonApiDotNetCore/Data/DefaultResourceRepository.cs
+++ b/src/JsonApiDotNetCore/Data/DefaultResourceRepository.cs
@@ -340,7 +340,7 @@ namespace JsonApiDotNetCore.Data
         }
 
         /// <inheritdoc />
-        public async Task<TResource> FirstOrDefaultAsync(IQueryable<TResource> entities)
+        public virtual async Task<TResource> FirstOrDefaultAsync(IQueryable<TResource> entities)
         {
             return (entities is IAsyncEnumerable<TResource>)
                ? await entities.FirstOrDefaultAsync()


### PR DESCRIPTION
This can be desirable for example in the case of an entity where you want to force creation if it not exist.