### PR TITLE
Removed unused property RelationshipAttribute.EntityPropertyName

### DIFF
--- a/src/JsonApiDotNetCore/Models/Annotation/HasManyAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/Annotation/HasManyAttribute.cs
@@ -12,7 +12,6 @@ namespace JsonApiDotNetCore.Models
         /// <param name="publicName">The relationship name as exposed by the API</param>
         /// <param name="relationshipLinks">Which links are available. Defaults to <see cref="Link.All"/></param>
         /// <param name="canInclude">Whether or not this relationship can be included using the <c>?include=public-name</c> query string</param>
-        /// <param name="mappedBy">The name of the entity mapped property, defaults to null</param>
         /// 
         /// <example>
         /// 
@@ -25,8 +24,8 @@ namespace JsonApiDotNetCore.Models
         /// </code>
         /// 
         /// </example>
-        public HasManyAttribute(string publicName = null, Link relationshipLinks = Link.All, bool canInclude = true, string mappedBy = null, string inverseNavigationProperty = null)
-        : base(publicName, relationshipLinks, canInclude, mappedBy)
+        public HasManyAttribute(string publicName = null, Link relationshipLinks = Link.All, bool canInclude = true, string inverseNavigationProperty = null)
+        : base(publicName, relationshipLinks, canInclude)
         {
             InverseNavigation = inverseNavigationProperty;
         }

--- a/src/JsonApiDotNetCore/Models/Annotation/HasOneAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/Annotation/HasOneAttribute.cs
@@ -14,7 +14,6 @@ namespace JsonApiDotNetCore.Models
         /// <see cref="ILinksConfiguration"/> or <see cref="ResourceContext"/> is used.</param>
         /// <param name="canInclude">Whether or not this relationship can be included using the <c>?include=public-name</c> query string</param>
         /// <param name="withForeignKey">The foreign key property name. Defaults to <c>"{RelationshipName}Id"</c></param>
-        /// <param name="mappedBy">The name of the entity mapped property, defaults to null</param>
         /// 
         /// <example>
         /// Using an alternative foreign key:
@@ -28,9 +27,8 @@ namespace JsonApiDotNetCore.Models
         /// }
         /// </code>
         /// </example>
-        public HasOneAttribute(string publicName = null, Link links = Link.NotConfigured, bool canInclude = true, string withForeignKey = null, string mappedBy = null, string inverseNavigationProperty = null)
-
-        : base(publicName, links, canInclude, mappedBy)
+        public HasOneAttribute(string publicName = null, Link links = Link.NotConfigured, bool canInclude = true, string withForeignKey = null, string inverseNavigationProperty = null)
+        : base(publicName, links, canInclude)
         {
             _explicitIdentifiablePropertyName = withForeignKey;
             InverseNavigation = inverseNavigationProperty;

--- a/src/JsonApiDotNetCore/Models/Annotation/RelationshipAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/Annotation/RelationshipAttribute.cs
@@ -7,7 +7,7 @@ namespace JsonApiDotNetCore.Models
 {
     public abstract class RelationshipAttribute : Attribute, IResourceField
     {
-        protected RelationshipAttribute(string publicName, Link relationshipLinks, bool canInclude, string mappedBy)
+        protected RelationshipAttribute(string publicName, Link relationshipLinks, bool canInclude)
         {
             if (relationshipLinks == Link.Paging)
                 throw new JsonApiSetupException($"{Link.Paging.ToString("g")} not allowed for argument {nameof(relationshipLinks)}");
@@ -15,7 +15,6 @@ namespace JsonApiDotNetCore.Models
             PublicRelationshipName = publicName;
             RelationshipLinks = relationshipLinks;
             CanInclude = canInclude;
-            EntityPropertyName = mappedBy;
         }
 
         public string ExposedInternalMemberName => InternalRelationshipName;
@@ -49,7 +48,6 @@ namespace JsonApiDotNetCore.Models
         /// </summary>
         public Link RelationshipLinks { get; }
         public bool CanInclude { get; }
-        public string EntityPropertyName { get; }
 
         public abstract void SetValue(object entity, object newValue);
 


### PR DESCRIPTION
Fixes #649.

Related to this, I found that `HasManyThroughAttribute` has a constructor parameter named `mappedBy`, whose value is passed to the base class string parameter called `inverseNavigationProperty`. I wonder if that is correct (sounds like something else entirely), but will leave that up to reviewers to decide.

Also note that the `inverseNavigationProperty` parameter is missing in the constructor documentation parameter list.