### PR TITLE
Removed leftover `mappedby` property

### DIFF
--- a/src/JsonApiDotNetCore/Models/Annotation/HasManyThroughAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/Annotation/HasManyThroughAttribute.cs
@@ -36,15 +36,14 @@ namespace JsonApiDotNetCore.Models
         /// <param name="internalThroughName">The name of the navigation property that will be used to get the HasMany relationship</param>
         /// <param name="relationshipLinks">Which links are available. Defaults to <see cref="Link.All"/></param>
         /// <param name="canInclude">Whether or not this relationship can be included using the <c>?include=public-name</c> query string</param>
-        /// <param name="mappedBy">The name of the entity mapped property, defaults to null</param>
         /// 
         /// <example>
         /// <code>
         /// [HasManyThrough(nameof(ArticleTags), documentLinks: Link.All, canInclude: true)]
         /// </code>
         /// </example>
-        public HasManyThroughAttribute(string internalThroughName, Link relationshipLinks = Link.All, bool canInclude = true, string mappedBy = null)
-        : base(null, relationshipLinks, canInclude, mappedBy)
+        public HasManyThroughAttribute(string internalThroughName, Link relationshipLinks = Link.All, bool canInclude = true)
+        : base(null, relationshipLinks, canInclude)
         {
             InternalThroughName = internalThroughName;
         }
@@ -57,15 +56,14 @@ namespace JsonApiDotNetCore.Models
         /// <param name="internalThroughName">The name of the navigation property that will be used to get the HasMany relationship</param>
         /// <param name="documentLinks">Which links are available. Defaults to <see cref="Link.All"/></param>
         /// <param name="canInclude">Whether or not this relationship can be included using the <c>?include=public-name</c> query string</param>
-        /// <param name="mappedBy">The name of the entity mapped property, defaults to null</param>
         /// 
         /// <example>
         /// <code>
         /// [HasManyThrough("tags", nameof(ArticleTags), documentLinks: Link.All, canInclude: true)]
         /// </code>
         /// </example>
-        public HasManyThroughAttribute(string publicName, string internalThroughName, Link documentLinks = Link.All, bool canInclude = true, string mappedBy = null)
-        : base(publicName, documentLinks, canInclude, mappedBy)
+        public HasManyThroughAttribute(string publicName, string internalThroughName, Link documentLinks = Link.All, bool canInclude = true)
+        : base(publicName, documentLinks, canInclude)
         {
             InternalThroughName = internalThroughName;
         }


### PR DESCRIPTION
Code cleanup, as discussed in https://github.com/json-api-dotnet/JsonApiDotNetCore/pull/670.
