### PR TITLE
Fixed broken build

### DIFF
--- a/benchmarks/Serialization/JsonApiSerializerBenchmarks.cs
+++ b/benchmarks/Serialization/JsonApiSerializerBenchmarks.cs
@@ -33,7 +33,7 @@ namespace Benchmarks.Serialization
             var resourceObjectBuilder = new ResourceObjectBuilder(resourceGraph, new ResourceObjectBuilderSettings());
 
             _jsonApiSerializer = new ResponseSerializer<BenchmarkResource>(metaBuilderMock.Object, linkBuilderMock.Object,
-                includeBuilderMock.Object, fieldsToSerialize, resourceObjectBuilder, resourceGraph);
+                includeBuilderMock.Object, fieldsToSerialize, resourceObjectBuilder);
         }
 
         private static FieldsToSerialize CreateFieldsToSerialize(IResourceGraph resourceGraph)


### PR DESCRIPTION
Caused by enabling benchmarks (https://github.com/json-api-dotnet/JsonApiDotNetCore/pull/677), combined with removing resourceGraph dependency (https://github.com/json-api-dotnet/JsonApiDotNetCore/pull/672).