### PR TITLE
Renamed Cmd to Command in class names

### DIFF
--- a/docs/usage/extensibility/services.md
+++ b/docs/usage/extensibility/services.md
@@ -98,7 +98,7 @@ IResourceService
 │   └── IGetRelationshipsService
 |       GET /{id}/relationships/{relationship}
 |
-└── IResourceCmdService
+└── IResourceCommandService
     |
     ├── ICreateService
     |   POST /

--- a/src/JsonApiDotNetCore/Builders/JsonApiApplicationBuilder.cs
+++ b/src/JsonApiDotNetCore/Builders/JsonApiApplicationBuilder.cs
@@ -135,7 +135,7 @@ namespace JsonApiDotNetCore.Builders
             _services.AddScoped(typeof(IResourceService<,>), typeof(DefaultResourceService<,>));
 
             _services.AddScoped(typeof(IResourceQueryService<,>), typeof(DefaultResourceService<,>));
-            _services.AddScoped(typeof(IResourceCmdService<,>), typeof(DefaultResourceService<,>));
+            _services.AddScoped(typeof(IResourceCommandService<,>), typeof(DefaultResourceService<,>));
 
             _services.AddSingleton<ILinksConfiguration>(JsonApiOptions);
             _services.AddSingleton(resourceGraph);

--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
@@ -48,17 +48,17 @@ namespace JsonApiDotNetCore.Controllers
         public BaseJsonApiController(
             IJsonApiOptions jsonApiOptions,
             IResourceQueryService<T, TId> queryService = null,
-            IResourceCmdService<T, TId> cmdService = null)
+            IResourceCommandService<T, TId> commandService = null)
         {
             _jsonApiOptions = jsonApiOptions;
             _getAll = queryService;
             _getById = queryService;
             _getRelationship = queryService;
             _getRelationships = queryService;
-            _create = cmdService;
-            _update = cmdService;
-            _updateRelationships = cmdService;
-            _delete = cmdService;
+            _create = commandService;
+            _update = commandService;
+            _updateRelationships = commandService;
+            _delete = commandService;
         }
 
         /// <param name="jsonApiOptions"></param>
@@ -205,8 +205,8 @@ namespace JsonApiDotNetCore.Controllers
         public BaseJsonApiController(
             IJsonApiOptions jsonApiOptions,
             IResourceQueryService<T, int> queryService = null,
-            IResourceCmdService<T, int> cmdService = null
-        ) : base(jsonApiOptions, queryService, cmdService) { }
+            IResourceCommandService<T, int> commandService = null
+        ) : base(jsonApiOptions, queryService, commandService) { }
 
 
         public BaseJsonApiController(

--- a/src/JsonApiDotNetCore/Controllers/JsonApiCommandController.cs
+++ b/src/JsonApiDotNetCore/Controllers/JsonApiCommandController.cs
@@ -6,20 +6,20 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace JsonApiDotNetCore.Controllers
 {
-    public class JsonApiCmdController<T> : JsonApiCmdController<T, int>
+    public class JsonApiCommandController<T> : JsonApiCommandController<T, int>
         where T : class, IIdentifiable<int>
     {
-        public JsonApiCmdController(
+        public JsonApiCommandController(
             IJsonApiOptions jsonApiOptions,
             IResourceService<T, int> resourceService)
             : base(jsonApiOptions, resourceService)
         { }
     }
 
-    public class JsonApiCmdController<T, TId>
+    public class JsonApiCommandController<T, TId>
     : BaseJsonApiController<T, TId> where T : class, IIdentifiable<TId>
     {
-        public JsonApiCmdController(
+        public JsonApiCommandController(
             IJsonApiOptions jsonApiOptions,
             IResourceService<T, TId> resourceService)
         : base(jsonApiOptions, resourceService)

--- a/src/JsonApiDotNetCore/Graph/ServiceDiscoveryFacade.cs
+++ b/src/JsonApiDotNetCore/Graph/ServiceDiscoveryFacade.cs
@@ -17,8 +17,8 @@ namespace JsonApiDotNetCore.Graph
         internal static HashSet<Type> ServiceInterfaces = new HashSet<Type> {
             typeof(IResourceService<>),
             typeof(IResourceService<,>),
-            typeof(IResourceCmdService<>),
-            typeof(IResourceCmdService<,>),
+            typeof(IResourceCommandService<>),
+            typeof(IResourceCommandService<,>),
             typeof(IResourceQueryService<>),
             typeof(IResourceQueryService<,>),
             typeof(ICreateService<>),

--- a/src/JsonApiDotNetCore/Services/Contract/IResourceCommandService.cs
+++ b/src/JsonApiDotNetCore/Services/Contract/IResourceCommandService.cs
@@ -2,16 +2,16 @@ using JsonApiDotNetCore.Models;
 
 namespace JsonApiDotNetCore.Services
 {
-    public interface IResourceCmdService<T> : 
+    public interface IResourceCommandService<T> : 
         ICreateService<T>,
         IUpdateService<T>,
         IUpdateRelationshipService<T>,
         IDeleteService<T>,
-        IResourceCmdService<T, int>
+        IResourceCommandService<T, int>
         where T : class, IIdentifiable<int>
     { }
 
-    public interface IResourceCmdService<T, in TId> : 
+    public interface IResourceCommandService<T, in TId> : 
         ICreateService<T, TId>,
         IUpdateService<T, TId>,
         IUpdateRelationshipService<T, TId>,

--- a/src/JsonApiDotNetCore/Services/Contract/IResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/Contract/IResourceService.cs
@@ -3,12 +3,12 @@ using JsonApiDotNetCore.Models;
 namespace JsonApiDotNetCore.Services
 {
     public interface IResourceService<T> 
-        : IResourceCmdService<T>, IResourceQueryService<T>, IResourceService<T, int> 
+        : IResourceCommandService<T>, IResourceQueryService<T>, IResourceService<T, int> 
         where T : class, IIdentifiable<int>
     { }
 
     public interface IResourceService<T, in TId> 
-        : IResourceCmdService<T, TId>, IResourceQueryService<T, TId>
+        : IResourceCommandService<T, TId>, IResourceQueryService<T, TId>
         where T : class, IIdentifiable<TId>
     { }
 }

--- a/test/UnitTests/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/test/UnitTests/Extensions/IServiceCollectionExtensionsTests.cs
@@ -93,7 +93,7 @@ namespace UnitTests.Extensions
             // Assert
             var provider = services.BuildServiceProvider();
             Assert.IsType<IntResourceService>(provider.GetService(typeof(IResourceService<IntResource>)));
-            Assert.IsType<IntResourceService>(provider.GetService(typeof(IResourceCmdService<IntResource>)));
+            Assert.IsType<IntResourceService>(provider.GetService(typeof(IResourceCommandService<IntResource>)));
             Assert.IsType<IntResourceService>(provider.GetService(typeof(IResourceQueryService<IntResource>)));
             Assert.IsType<IntResourceService>(provider.GetService(typeof(IGetAllService<IntResource>)));
             Assert.IsType<IntResourceService>(provider.GetService(typeof(IGetByIdService<IntResource>)));
@@ -116,7 +116,7 @@ namespace UnitTests.Extensions
             // Assert
             var provider = services.BuildServiceProvider();
             Assert.IsType<GuidResourceService>(provider.GetService(typeof(IResourceService<GuidResource, Guid>)));
-            Assert.IsType<GuidResourceService>(provider.GetService(typeof(IResourceCmdService<GuidResource, Guid>)));
+            Assert.IsType<GuidResourceService>(provider.GetService(typeof(IResourceCommandService<GuidResource, Guid>)));
             Assert.IsType<GuidResourceService>(provider.GetService(typeof(IResourceQueryService<GuidResource, Guid>)));
             Assert.IsType<GuidResourceService>(provider.GetService(typeof(IGetAllService<GuidResource, Guid>)));
             Assert.IsType<GuidResourceService>(provider.GetService(typeof(IGetByIdService<GuidResource, Guid>)));


### PR DESCRIPTION
From the start I found it strange to have Cmd (not Command) and Query (not Qry) next to each other. So I renamed Cmd to the full version for clarity and consistency.
