### PR TITLE
Disabled resource hooks by default, as they are still experimental

### DIFF
--- a/src/Examples/JsonApiDotNetCoreExample/Startups/Startup.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Startups/Startup.cs
@@ -45,6 +45,7 @@ namespace JsonApiDotNetCoreExample
                     options.IncludeTotalRecordCount = true;
                     options.LoadDatabaseValues = true;
                     options.ValidateModelState = true;
+                    options.EnableResourceHooks = true;
                 },
                 discovery => discovery.AddCurrentAssembly());
             // once all tests have been moved to WebApplicationFactory format we can get rid of this line below

--- a/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
@@ -30,11 +30,10 @@ namespace JsonApiDotNetCore.Configuration
         public bool IncludeExceptionStackTraceInErrors { get; set; } = false;
 
         /// <summary>
-        /// Whether or not ResourceHooks are enabled. 
-        /// 
-        /// Default is set to <see langword="true"/>
+        /// Whether or not resource hooks are enabled. 
+        /// This is currently an experimental feature and defaults to <see langword="false"/>.
         /// </summary>
-        public bool EnableResourceHooks { get; set; } = true;
+        public bool EnableResourceHooks { get; set; } = false;
 
         /// <summary>
         /// Whether or not database values should be included by default


### PR DESCRIPTION
Discussed this with @maurei.

If time permits to finalize the work resource hooks, we may re-enable them for the stable release of V4. Biggest concern for now, it that it is an all-or-nothing experience. Once enabled, each GET request performs a full table fetch, which makes it unusable with large tables.