### PR TITLE
Fixed NullReferenceException on parallel requests

### DIFF
--- a/src/Examples/GettingStarted/Startup.cs
+++ b/src/Examples/GettingStarted/Startup.cs
@@ -22,7 +22,9 @@ namespace GettingStarted
 
         public void Configure(IApplicationBuilder app, SampleDbContext context)
         {
-            context.Database.EnsureDeleted(); // indices need to be reset
+            // indices need to be reset
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
             app.UseJsonApi();
         }
     }


### PR DESCRIPTION
At startup, a single instance of `CurrentRequestMiddleware` is created, which is used to process multiple requests in parallel. Therefore it cannot contain request-specific state in its fields, because parallel requests then overwrite the state of each other.

As a result of overwriting state, the FilterService is unable to find the matching CurrentRequest data, causing a NullReferenceException in its constructor.

Fixes #727.