### PR TITLE
Fixed: exception logged in Kestrel on Delete request

### DIFF
--- a/src/JsonApiDotNetCore/Formatters/JsonApiWriter.cs
+++ b/src/JsonApiDotNetCore/Formatters/JsonApiWriter.cs
@@ -77,9 +77,19 @@ namespace JsonApiDotNetCore.Formatters
                 throw new UnsuccessfulActionResultException(problemDetails);
             }
 
-            if (contextObject == null && !IsSuccessStatusCode(statusCode))
+            if (contextObject == null)
             {
-                throw new UnsuccessfulActionResultException(statusCode);
+                if (!IsSuccessStatusCode(statusCode))
+                {
+                    throw new UnsuccessfulActionResultException(statusCode);
+                }
+
+                if (statusCode == HttpStatusCode.NoContent || statusCode == HttpStatusCode.ResetContent ||
+                    statusCode == HttpStatusCode.NotModified)
+                {
+                    // Prevent exception from Kestrel server, caused by writing data:null json response.
+                    return null;
+                }
             }
 
             contextObject = WrapErrors(contextObject);

--- a/test/NoEntityFrameworkTests/WorkItemTests.cs
+++ b/test/NoEntityFrameworkTests/WorkItemTests.cs
@@ -146,7 +146,7 @@ namespace NoEntityFrameworkTests
             string responseBody = await response.Content.ReadAsStringAsync();
             var document = JsonConvert.DeserializeObject<Document>(responseBody);
 
-            Assert.Null(document.Data);
+            Assert.Null(document);
         }
 
         private async Task ExecuteOnDbContextAsync(Func<AppDbContext, Task> asyncAction)


### PR DESCRIPTION
When an ActionResult returns null, we wrap that in a json:api response, causing an error from Kestrel because it does not allow a response body to be sent in some cases. See https://github.com/aspnet/KestrelHttpServer/blob/50bb0b3bc9c45e5c89617b9769959aa32e12278b/src/Kestrel.Core/Internal/Http/HttpProtocol.cs#L1270-L1275 for details.

Fixes #760.