### PR TITLE
Fixed: only run custom path cutting logic when RouteAttribute is used

### DIFF
--- a/test/UnitTests/Middleware/JsonApiMiddlewareTests.cs
+++ b/test/UnitTests/Middleware/JsonApiMiddlewareTests.cs
@@ -144,6 +144,7 @@ namespace UnitTests.Middleware
                 feature.RouteValues["id"] = id;
             }
             context.Features.Set<IRouteValuesFeature>(feature);
+            context.SetEndpoint(new Endpoint(null, new EndpointMetadataCollection(), null));
             return context;
         }
 


### PR DESCRIPTION
Follow-up for #766.