### PR TITLE
Should not parse filter values as nested filters

### DIFF
--- a/src/JsonApiDotNetCore/QueryParameterServices/FilterService.cs
+++ b/src/JsonApiDotNetCore/QueryParameterServices/FilterService.cs
@@ -87,22 +87,9 @@ namespace JsonApiDotNetCore.Query
             // expected input = filter[id]=eq:1
             var propertyName = parameterName.Split(QueryConstants.OPEN_BRACKET, QueryConstants.CLOSE_BRACKET)[1];
             var queries = new List<FilterQuery>();
-            // InArray case
             string op = GetFilterOperation(parameterValue);
-            if (op == FilterOperation.@in.ToString() || op == FilterOperation.nin.ToString())
-            {
-                var (_, filterValue) = ParseFilterOperation(parameterValue);
-                queries.Add(new FilterQuery(propertyName, filterValue, op));
-            }
-            else
-            {
-                var values = ((string)parameterValue).Split(QueryConstants.COMMA);
-                foreach (var val in values)
-                {
-                    var (operation, filterValue) = ParseFilterOperation(val);
-                    queries.Add(new FilterQuery(propertyName, filterValue, operation));
-                }
-            }
+            var (_, filterValue) = ParseFilterOperation(parameterValue);
+            queries.Add(new FilterQuery(propertyName, filterValue, op));
             return queries;
         }
 

--- a/test/UnitTests/QueryParameters/FilterServiceTests.cs
+++ b/test/UnitTests/QueryParameters/FilterServiceTests.cs
@@ -43,6 +43,7 @@ namespace UnitTests.QueryParameters
         [Theory]
         [InlineData("title", "", "value")]
         [InlineData("title", "eq:", "value")]
+        [InlineData("title", "eq:", "val,ue")]
         [InlineData("title", "lt:", "value")]
         [InlineData("title", "gt:", "value")]
         [InlineData("title", "le:", "value")]


### PR DESCRIPTION
I have a case where filter values can contain commas, which I noted was not accepted by current implementation.

Removing the parsing of values and special case for array filters seem a bit too invasive, however it seems to be working. I'm currently doing more evaluation of this change but would welcome input.