### PR TITLE
fix: gitignore macOS file systems and scoped client serializer extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,9 @@ StyleCopReport.xml
 *.svclog
 *.scc
 
+# MacOS file systems
+**/.DS_STORE
+
 # Chutzpah Test files
 _Chutzpah*
 

--- a/src/JsonApiDotNetCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore/Extensions/ServiceCollectionExtensions.cs
@@ -76,8 +76,8 @@ namespace JsonApiDotNetCore
         /// </summary>
         public static IServiceCollection AddClientSerialization(this IServiceCollection services)
         {
-            services.AddSingleton<IResponseDeserializer, ResponseDeserializer>();
-            services.AddSingleton<IRequestSerializer>(sp =>
+            services.AddScoped<IResponseDeserializer, ResponseDeserializer>();
+            services.AddScoped<IRequestSerializer>(sp =>
             {
                 var graph = sp.GetService<IResourceGraph>();
                 return new RequestSerializer(graph, new ResourceObjectBuilder(graph, new ResourceObjectBuilderSettings()));


### PR DESCRIPTION

- Closes #783
- Also adds macOS system files (.DS_STORE) to gitignore
