### PR TITLE
fix: support for lazy loading proxies

### DIFF
--- a/src/JsonApiDotNetCore/Internal/ResourceGraph.cs
+++ b/src/JsonApiDotNetCore/Internal/ResourceGraph.cs
@@ -26,7 +26,7 @@ namespace JsonApiDotNetCore.Internal
             => Resources.SingleOrDefault(e => e.ResourceName == resourceName);
         /// <inheritdoc />
         public ResourceContext GetResourceContext(Type resourceType)
-            => Resources.SingleOrDefault(e => e.ResourceType == resourceType);
+            => Resources.SingleOrDefault(e => e.ResourceType == resourceType) ?? Resources.SingleOrDefault(e => e.ResourceType.IsAssignableFrom(resourceType));
         /// <inheritdoc />
         public ResourceContext GetResourceContext<TResource>() where TResource : class, IIdentifiable
             => GetResourceContext(typeof(TResource));

--- a/src/JsonApiDotNetCore/Internal/ResourceGraph.cs
+++ b/src/JsonApiDotNetCore/Internal/ResourceGraph.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using JsonApiDotNetCore.Internal.Contracts;
 using JsonApiDotNetCore.Models;
-using Castle.DynamicProxy;
 
 namespace JsonApiDotNetCore.Internal
 {
@@ -14,10 +13,12 @@ namespace JsonApiDotNetCore.Internal
     public class ResourceGraph : IResourceGraph
     {
         private List<ResourceContext> Resources { get; }
+        private Type ProxyInterface { get; }
 
         public ResourceGraph(List<ResourceContext> resources)
         {
             Resources = resources;
+            ProxyInterface = Type.GetType("Castle.DynamicProxy.IProxyTargetAccessor, Castle.Core");
         }
 
         /// <inheritdoc />
@@ -128,10 +129,7 @@ namespace JsonApiDotNetCore.Internal
                 $"For example: 'article => article.Title' or 'article => new {{ article.Title, article.PageCount }}'.");
         }
 
-        private bool IsDynamicProxy(Type resourceType)
-        {
-            return typeof(IProxyTargetAccessor).IsAssignableFrom(resourceType);
-        }
+        private bool IsDynamicProxy(Type resourceType) => ProxyInterface?.IsAssignableFrom(resourceType) ?? false;
 
         private static Expression RemoveConvert(Expression expression)
             => expression is UnaryExpression unaryExpression

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.1.6" />
+    <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="Humanizer" Version="2.7.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.1.6" />
-    <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="Humanizer" Version="2.7.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/test/UnitTests/Internal/ResourceGraphBuilder_Tests.cs
+++ b/test/UnitTests/Internal/ResourceGraphBuilder_Tests.cs
@@ -44,7 +44,7 @@ namespace UnitTests.Internal
         }
 
         [Fact]
-        public void GetResourceContext_Yields_Right_Type_For_Proxy()
+        public void GetResourceContext_Yields_Right_Type_For_LazyLoadingProxy()
         {
             // Arrange
             var resourceGraphBuilder = new ResourceGraphBuilder(new JsonApiOptions(), NullLoggerFactory.Instance);

--- a/test/UnitTests/Internal/ResourceGraphBuilder_Tests.cs
+++ b/test/UnitTests/Internal/ResourceGraphBuilder_Tests.cs
@@ -1,4 +1,3 @@
-using System;
 using JsonApiDotNetCore.Builders;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Internal;
@@ -6,6 +5,7 @@ using JsonApiDotNetCore.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Castle.DynamicProxy;
 using Xunit;
 
 namespace UnitTests.Internal
@@ -50,16 +50,18 @@ namespace UnitTests.Internal
             var resourceGraphBuilder = new ResourceGraphBuilder(new JsonApiOptions(), NullLoggerFactory.Instance);
             resourceGraphBuilder.AddResource<Bar>();
             var resourceGraph = (ResourceGraph)resourceGraphBuilder.Build();
+            var proxyGenerator = new ProxyGenerator();
 
             // Act
-            var result = resourceGraph.GetResourceContext(typeof(DummyProxy));
+            var proxy = proxyGenerator.CreateClassProxy<Bar>();
+            var result = resourceGraph.GetResourceContext(proxy.GetType());
 
             // Assert
             Assert.Equal(typeof(Bar), result.ResourceType);
         }
 
         [Fact]
-        public void GetResourceContext_Yields_Right_Type_For_IIdentifiable()
+        public void GetResourceContext_Yields_Right_Type_For_Identifiable()
         {
             // Arrange
             var resourceGraphBuilder = new ResourceGraphBuilder(new JsonApiOptions(), NullLoggerFactory.Instance);
@@ -80,10 +82,7 @@ namespace UnitTests.Internal
             public DbSet<Foo> Foos { get; set; }
         }
 
-        private class Bar : Identifiable { }
-
-        // Used to simulate a lazy loading proxy
-        private class DummyProxy : Bar { }
+        public class Bar : Identifiable { }
 
     }
 

--- a/test/UnitTests/Internal/ResourceGraphBuilder_Tests.cs
+++ b/test/UnitTests/Internal/ResourceGraphBuilder_Tests.cs
@@ -1,6 +1,8 @@
+using System;
 using JsonApiDotNetCore.Builders;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Internal;
+using JsonApiDotNetCore.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -41,12 +43,48 @@ namespace UnitTests.Internal
             Assert.Equal("Entity 'UnitTests.Internal.ResourceGraphBuilder_Tests+TestContext' does not implement 'IIdentifiable'.", loggerFactory.Logger.Messages[0].Text);
         }
 
+        [Fact]
+        public void GetResourceContext_Yields_Right_Type_For_Proxy()
+        {
+            // Arrange
+            var resourceGraphBuilder = new ResourceGraphBuilder(new JsonApiOptions(), NullLoggerFactory.Instance);
+            resourceGraphBuilder.AddResource<Bar>();
+            var resourceGraph = (ResourceGraph)resourceGraphBuilder.Build();
+
+            // Act
+            var result = resourceGraph.GetResourceContext(typeof(DummyProxy));
+
+            // Assert
+            Assert.Equal(typeof(Bar), result.ResourceType);
+        }
+
+        [Fact]
+        public void GetResourceContext_Yields_Right_Type_For_IIdentifiable()
+        {
+            // Arrange
+            var resourceGraphBuilder = new ResourceGraphBuilder(new JsonApiOptions(), NullLoggerFactory.Instance);
+            resourceGraphBuilder.AddResource<Bar>();
+            var resourceGraph = (ResourceGraph)resourceGraphBuilder.Build();
+
+            // Act
+            var result = resourceGraph.GetResourceContext(typeof(Bar));
+
+            // Assert
+            Assert.Equal(typeof(Bar), result.ResourceType);
+        }
+
         private class Foo { }
 
         private class TestContext : DbContext
         {
             public DbSet<Foo> Foos { get; set; }
         }
+
+        private class Bar : Identifiable { }
+
+        // Used to simulate a lazy loading proxy
+        private class DummyProxy : Bar { }
+
     }
 
 }

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="$(BogusVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EFCoreVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="$(EFCoreVersion)" />
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="xunit" Version="$(XUnitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitVersion)" />


### PR DESCRIPTION
I found that when I enabled lazy loading proxies queries would fail.

This was because the `GetResourceContext(Type)` method within `ResourceGraph` was checking for strict equality of the registered and provided resource types. I added a call to `Type.IsAssignableFrom(Type)` after that equality check and now when the passed type is a lazy loading proxy the graph is able to identify the entity that corresponds to it.

I kept the equality check because some tests would break if I didn't. The reason is, I assume, that whenever you had two or more entities that had a common base type calls to `SingleOrDefault` throw that the resulting sequence has more than one element. Keeping the equality check prioritizes types that are exactly equal to those you're searching for.

Please let me know if you think this could be polished in any way!