### PR TITLE
Allow setting Property when creating AttAttribute

### DIFF
--- a/src/JsonApiDotNetCore/Models/Annotation/AttrAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/Annotation/AttrAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using JsonApiDotNetCore.Internal;
 
 namespace JsonApiDotNetCore.Models.Annotation
@@ -31,6 +32,17 @@ namespace JsonApiDotNetCore.Models.Annotation
         /// </summary>
         public AttrAttribute(string publicName) 
             : base(publicName)
+        {
+            CheckPublicName(publicName);
+        }
+
+        public AttrAttribute(string publicName, PropertyInfo property) 
+            : base(publicName, property)
+        {
+            CheckPublicName(publicName);
+        }
+
+        private void CheckPublicName(string publicName)
         {
             if (publicName == null)
             {

--- a/src/JsonApiDotNetCore/Models/Annotation/ResourceFieldAttribute.cs
+++ b/src/JsonApiDotNetCore/Models/Annotation/ResourceFieldAttribute.cs
@@ -33,6 +33,11 @@ namespace JsonApiDotNetCore.Models.Annotation
             PublicName = publicName;
         }
 
+        protected ResourceFieldAttribute(string publicName, PropertyInfo property) : this(publicName)
+        {
+            Property = property;
+        }
+
         public override string ToString()
         {
             return PublicName ?? (Property != null ? Property.Name : base.ToString());


### PR DESCRIPTION
I have a use case where part of my model attributes are not static, so I need a way to create AttAttribute in runtime. To properly do that I need to be able to tie a AttrAttribute to a PropertyInfo which this PR adds as an alternative constructor.