### PR TITLE
Fixes in resource definition callbacks

### DIFF
--- a/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
+++ b/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
@@ -285,7 +285,7 @@ namespace JsonApiDotNetCore.Repositories
         }
 
         /// <inheritdoc />
-        public async Task UpdateRelationshipsAsync(object parent, RelationshipAttribute relationship, IReadOnlyCollection<string> relationshipIds)
+        public async Task UpdateRelationshipAsync(object parent, RelationshipAttribute relationship, IReadOnlyCollection<string> relationshipIds)
         {
             _traceWriter.LogMethodStart(new {parent, relationship, relationshipIds});
             if (parent == null) throw new ArgumentNullException(nameof(parent));

--- a/src/JsonApiDotNetCore/Repositories/IResourceWriteRepository.cs
+++ b/src/JsonApiDotNetCore/Repositories/IResourceWriteRepository.cs
@@ -32,9 +32,9 @@ namespace JsonApiDotNetCore.Repositories
         Task UpdateAsync(TResource requestResource, TResource databaseResource);
 
         /// <summary>
-        /// Updates relationships in the underlying data store.
+        /// Updates a relationship in the underlying data store.
         /// </summary>
-        Task UpdateRelationshipsAsync(object parent, RelationshipAttribute relationship, IReadOnlyCollection<string> relationshipIds);
+        Task UpdateRelationshipAsync(object parent, RelationshipAttribute relationship, IReadOnlyCollection<string> relationshipIds);
 
         /// <summary>
         /// Deletes a resource from the underlying data store.

--- a/test/JsonApiDotNetCoreExampleTests/AppDbContextExtensions.cs
+++ b/test/JsonApiDotNetCoreExampleTests/AppDbContextExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using JsonApiDotNetCoreExample.Data;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
 
@@ -8,7 +7,7 @@ namespace JsonApiDotNetCoreExampleTests
 {
     public static class AppDbContextExtensions
     {
-        public static async Task ClearTableAsync<TEntity>(this AppDbContext dbContext) where TEntity : class
+        public static async Task ClearTableAsync<TEntity>(this DbContext dbContext) where TEntity : class
         {
             var entityType = dbContext.Model.FindEntityType(typeof(TEntity));
             if (entityType == null)
@@ -30,7 +29,7 @@ namespace JsonApiDotNetCoreExampleTests
             }
         }
 
-        public static void ClearTable<TEntity>(this AppDbContext dbContext) where TEntity : class
+        public static void ClearTable<TEntity>(this DbContext dbContext) where TEntity : class
         {
             var entityType = dbContext.Model.FindEntityType(typeof(TEntity));
             if (entityType == null)

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/CompaniesController.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/CompaniesController.cs
@@ -1,0 +1,16 @@
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Services;
+using Microsoft.Extensions.Logging;
+
+namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
+{
+    public sealed class CompaniesController : JsonApiController<Company>
+    {
+        public CompaniesController(IJsonApiOptions options, ILoggerFactory loggerFactory,
+            IResourceService<Company> resourceService)
+            : base(options, loggerFactory, resourceService)
+        {
+        }
+    }
+}

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/Company.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/Company.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
+{
+    public sealed class Company : Identifiable
+    {
+        [Attr]
+        public string Name { get; set; }
+
+        [Attr]
+        public bool IsSoftDeleted { get; set; }
+
+        [HasMany]
+        public ICollection<Department> Departments { get; set; }
+    }
+}

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/CompanyResourceDefinition.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/CompanyResourceDefinition.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Queries.Expressions;
+using JsonApiDotNetCore.Resources;
+
+namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
+{
+    public sealed class CompanyResourceDefinition : ResourceDefinition<Company>
+    {
+        private readonly IResourceGraph _resourceGraph;
+
+        public CompanyResourceDefinition(IResourceGraph resourceGraph) : base(resourceGraph)
+        {
+            _resourceGraph = resourceGraph;
+        }
+
+        public override FilterExpression OnApplyFilter(FilterExpression existingFilter)
+        {
+            var resourceContext = _resourceGraph.GetResourceContext<Company>();
+            var isSoftDeletedAttribute = resourceContext.Attributes.Single(attribute => attribute.Property.Name == nameof(Company.IsSoftDeleted));
+
+            var isNotSoftDeleted = new ComparisonExpression(ComparisonOperator.Equals,
+                new ResourceFieldChainExpression(isSoftDeletedAttribute), new LiteralConstantExpression("false"));
+
+            return existingFilter == null
+                ? (FilterExpression) isNotSoftDeleted
+                : new LogicalExpression(LogicalOperator.And, new[] {isNotSoftDeleted, existingFilter});
+        }
+    }
+}

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/Department.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/Department.cs
@@ -1,0 +1,17 @@
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
+{
+    public sealed class Department : Identifiable
+    {
+        [Attr]
+        public string Name { get; set; }
+
+        [Attr]
+        public bool IsSoftDeleted { get; set; }
+
+        [HasOne]
+        public Company Company { get; set; }
+    }
+}

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/DepartmentResourceDefinition.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/DepartmentResourceDefinition.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Queries.Expressions;
+using JsonApiDotNetCore.Resources;
+
+namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
+{
+    public sealed class DepartmentResourceDefinition : ResourceDefinition<Department>
+    {
+        private readonly IResourceGraph _resourceGraph;
+
+        public DepartmentResourceDefinition(IResourceGraph resourceGraph) : base(resourceGraph)
+        {
+            _resourceGraph = resourceGraph;
+        }
+
+        public override FilterExpression OnApplyFilter(FilterExpression existingFilter)
+        {
+            var resourceContext = _resourceGraph.GetResourceContext<Department>();
+            var isSoftDeletedAttribute = resourceContext.Attributes.Single(attribute => attribute.Property.Name == nameof(Department.IsSoftDeleted));
+
+            var isNotSoftDeleted = new ComparisonExpression(ComparisonOperator.Equals,
+                new ResourceFieldChainExpression(isSoftDeletedAttribute), new LiteralConstantExpression("false"));
+
+            return existingFilter == null
+                ? (FilterExpression) isNotSoftDeleted
+                : new LogicalExpression(LogicalOperator.And, new[] {isNotSoftDeleted, existingFilter});
+        }
+    }
+}

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/DepartmentsController.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/DepartmentsController.cs
@@ -1,0 +1,16 @@
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Services;
+using Microsoft.Extensions.Logging;
+
+namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
+{
+    public sealed class DepartmentsController : JsonApiController<Department>
+    {
+        public DepartmentsController(IJsonApiOptions options, ILoggerFactory loggerFactory,
+            IResourceService<Department> resourceService)
+            : base(options, loggerFactory, resourceService)
+        {
+        }
+    }
+}

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/SoftDeletionDbContext.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/SoftDeletionDbContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
+{
+    public sealed class SoftDeletionDbContext : DbContext
+    {
+        public DbSet<Company> Companies { get; set; }
+        public DbSet<Department> Departments { get; set; }
+
+        public SoftDeletionDbContext(DbContextOptions<SoftDeletionDbContext> options) : base(options)
+        {
+        }
+    }
+}

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/SoftDeletionTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/SoftDeletionTests.cs
@@ -1,0 +1,440 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using FluentAssertions;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Serialization.Objects;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
+{
+    public sealed class SoftDeletionTests : IClassFixture<IntegrationTestContext<TestableStartup<SoftDeletionDbContext>, SoftDeletionDbContext>>
+    {
+        private readonly IntegrationTestContext<TestableStartup<SoftDeletionDbContext>, SoftDeletionDbContext> _testContext;
+
+        public SoftDeletionTests(IntegrationTestContext<TestableStartup<SoftDeletionDbContext>, SoftDeletionDbContext> testContext)
+        {
+            _testContext = testContext;
+
+            testContext.ConfigureServicesAfterStartup(services =>
+            {
+                services.AddScoped<ResourceDefinition<Company>, CompanyResourceDefinition>();
+                services.AddScoped<ResourceDefinition<Department>, DepartmentResourceDefinition>();
+            });
+        }
+
+        [Fact]
+        public async Task Can_get_primary_resources()
+        {
+            // Arrange
+            var departments = new List<Department>
+            {
+                new Department
+                {
+                    Name = "Sales",
+                    IsSoftDeleted = true
+                },
+                new Department
+                {
+                    Name = "Marketing"
+                }
+            };
+
+            await _testContext.RunOnDatabaseAsync(async dbContext =>
+            {
+                await dbContext.ClearTableAsync<Department>();
+                dbContext.Departments.AddRange(departments);
+
+                await dbContext.SaveChangesAsync();
+            });
+
+            var route = "/departments";
+
+            // Act
+            var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+            // Assert
+            httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
+
+            responseDocument.ManyData.Should().HaveCount(1);
+            responseDocument.ManyData[0].Id.Should().Be(departments[1].StringId);
+        }
+
+        [Fact]
+        public async Task Can_filter_in_primary_resources()
+        {
+            // Arrange
+            var departments = new List<Department>
+            {
+                new Department
+                {
+                    Name = "Support"
+                },
+                new Department
+                {
+                    Name = "Sales",
+                    IsSoftDeleted = true
+                },
+                new Department
+                {
+                    Name = "Marketing"
+                }
+            };
+
+            await _testContext.RunOnDatabaseAsync(async dbContext =>
+            {
+                await dbContext.ClearTableAsync<Department>();
+                dbContext.Departments.AddRange(departments);
+
+                await dbContext.SaveChangesAsync();
+            });
+
+            var route = "/departments?filter=startsWith(name,'S')";
+
+            // Act
+            var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+            // Assert
+            httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
+
+            responseDocument.ManyData.Should().HaveCount(1);
+            responseDocument.ManyData[0].Id.Should().Be(departments[0].StringId);
+        }
+
+        [Fact]
+        public async Task Cannot_get_deleted_primary_resource_by_ID()
+        {
+            // Arrange
+            var department = new Department
+            {
+                Name = "Sales",
+                IsSoftDeleted = true
+            };
+
+            await _testContext.RunOnDatabaseAsync(async dbContext =>
+            {
+                dbContext.Departments.Add(department);
+
+                await dbContext.SaveChangesAsync();
+            });
+
+            var route = "/departments/" + department.StringId;
+
+            // Act
+            var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<ErrorDocument>(route);
+
+            // Assert
+            httpResponse.Should().HaveStatusCode(HttpStatusCode.NotFound);
+
+            responseDocument.Errors.Should().HaveCount(1);
+            responseDocument.Errors[0].StatusCode.Should().Be(HttpStatusCode.NotFound);
+            responseDocument.Errors[0].Title.Should().Be("The requested resource does not exist.");
+            responseDocument.Errors[0].Detail.Should().Be($"Resource of type 'departments' with ID '{department.StringId}' does not exist.");
+            responseDocument.Errors[0].Source.Parameter.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Can_get_secondary_resources()
+        {
+            // Arrange
+            var company = new Company
+            {
+                Departments = new List<Department>
+                {
+                    new Department
+                    {
+                        Name = "Sales",
+                        IsSoftDeleted = true
+                    },
+                    new Department
+                    {
+                        Name = "Marketing"
+                    }
+                }
+            };
+
+            await _testContext.RunOnDatabaseAsync(async dbContext =>
+            {
+                dbContext.Companies.Add(company);
+
+                await dbContext.SaveChangesAsync();
+            });
+
+            var route = $"/companies/{company.StringId}/departments";
+
+            // Act
+            var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+            // Assert
+            httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
+
+            responseDocument.ManyData.Should().HaveCount(1);
+            responseDocument.ManyData[0].Id.Should().Be(company.Departments.Skip(1).Single().StringId);
+        }
+
+        [Fact]
+        public async Task Cannot_get_secondary_resources_for_deleted_parent()
+        {
+            // Arrange
+            var company = new Company
+            {
+                IsSoftDeleted = true,
+                Departments = new List<Department>
+                {
+                    new Department
+                    {
+                        Name = "Marketing"
+                    }
+                }
+            };
+
+            await _testContext.RunOnDatabaseAsync(async dbContext =>
+            {
+                dbContext.Companies.Add(company);
+
+                await dbContext.SaveChangesAsync();
+            });
+
+            var route = $"/companies/{company.StringId}/departments";
+
+            // Act
+            var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<ErrorDocument>(route);
+
+            // Assert
+            httpResponse.Should().HaveStatusCode(HttpStatusCode.NotFound);
+
+            responseDocument.Errors.Should().HaveCount(1);
+            responseDocument.Errors[0].StatusCode.Should().Be(HttpStatusCode.NotFound);
+            responseDocument.Errors[0].Title.Should().Be("The requested resource does not exist.");
+            responseDocument.Errors[0].Detail.Should().Be($"Resource of type 'companies' with ID '{company.StringId}' does not exist.");
+            responseDocument.Errors[0].Source.Parameter.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Can_get_primary_resources_with_include()
+        {
+            // Arrange
+            var companies = new List<Company>
+            {
+                new Company
+                {
+                    Name = "Acme Corporation",
+                    IsSoftDeleted = true,
+                    Departments = new List<Department>
+                    {
+                        new Department
+                        {
+                            Name = "Recruitment"
+                        }
+                    }
+                },
+                new Company
+                {
+                    Name = "AdventureWorks",
+                    Departments = new List<Department>
+                    {
+                        new Department
+                        {
+                            Name = "Reception"
+                        },
+                        new Department
+                        {
+                            Name = "Sales",
+                            IsSoftDeleted = true
+                        }
+                    }
+                }
+            };
+
+            await _testContext.RunOnDatabaseAsync(async dbContext =>
+            {
+                await dbContext.ClearTableAsync<Company>();
+                dbContext.Companies.AddRange(companies);
+
+                await dbContext.SaveChangesAsync();
+            });
+
+            var route = "/companies?include=departments";
+
+            // Act
+            var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+            // Assert
+            httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
+
+            responseDocument.ManyData.Should().HaveCount(1);
+            responseDocument.ManyData[0].Type.Should().Be("companies");
+            responseDocument.ManyData[0].Id.Should().Be(companies[1].StringId);
+
+            responseDocument.Included.Should().HaveCount(1);
+            responseDocument.Included[0].Type.Should().Be("departments");
+            responseDocument.Included[0].Id.Should().Be(companies[1].Departments.First().StringId);
+        }
+
+        [Fact]
+        public async Task Can_get_relationship()
+        {
+            // Arrange
+            var company = new Company
+            {
+                Departments = new List<Department>
+                {
+                    new Department
+                    {
+                        Name = "Sales",
+                        IsSoftDeleted = true
+                    },
+                    new Department
+                    {
+                        Name = "Marketing"
+                    }
+                }
+            };
+
+            await _testContext.RunOnDatabaseAsync(async dbContext =>
+            {
+                dbContext.Companies.Add(company);
+
+                await dbContext.SaveChangesAsync();
+            });
+
+            var route = $"/companies/{company.StringId}/relationships/departments";
+
+            // Act
+            var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+            // Assert
+            httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
+
+            responseDocument.ManyData.Should().HaveCount(1);
+            responseDocument.ManyData[0].Id.Should().Be(company.Departments.Skip(1).Single().StringId);
+        }
+
+        [Fact]
+        public async Task Cannot_get_relationship_for_deleted_parent()
+        {
+            // Arrange
+            var company = new Company
+            {
+                IsSoftDeleted = true,
+                Departments = new List<Department>
+                {
+                    new Department
+                    {
+                        Name = "Marketing"
+                    }
+                }
+            };
+
+            await _testContext.RunOnDatabaseAsync(async dbContext =>
+            {
+                dbContext.Companies.Add(company);
+
+                await dbContext.SaveChangesAsync();
+            });
+
+            var route = $"/companies/{company.StringId}/relationships/departments";
+
+            // Act
+            var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<ErrorDocument>(route);
+
+            // Assert
+            httpResponse.Should().HaveStatusCode(HttpStatusCode.NotFound);
+
+            responseDocument.Errors.Should().HaveCount(1);
+            responseDocument.Errors[0].StatusCode.Should().Be(HttpStatusCode.NotFound);
+            responseDocument.Errors[0].Title.Should().Be("The requested resource does not exist.");
+            responseDocument.Errors[0].Detail.Should().Be($"Resource of type 'companies' with ID '{company.StringId}' does not exist.");
+            responseDocument.Errors[0].Source.Parameter.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Cannot_update_deleted_resource()
+        {
+            // Arrange
+            var company = new Company
+            {
+                IsSoftDeleted = true
+            };
+
+            await _testContext.RunOnDatabaseAsync(async dbContext =>
+            {
+                dbContext.Companies.Add(company);
+
+                await dbContext.SaveChangesAsync();
+            });
+
+            var requestBody = new
+            {
+                data = new
+                {
+                    type = "companies",
+                    id = company.StringId,
+                    attributes = new Dictionary<string, object>
+                    {
+                        {"name", "Umbrella Corporation"}
+                    }
+                }
+            };
+
+            var route = "/companies/" + company.StringId;
+
+            // Act
+            var (httpResponse, responseDocument) = await _testContext.ExecutePatchAsync<ErrorDocument>(route, requestBody);
+
+            // Assert
+            httpResponse.Should().HaveStatusCode(HttpStatusCode.NotFound);
+
+            responseDocument.Errors.Should().HaveCount(1);
+            responseDocument.Errors[0].StatusCode.Should().Be(HttpStatusCode.NotFound);
+            responseDocument.Errors[0].Title.Should().Be("The requested resource does not exist.");
+            responseDocument.Errors[0].Detail.Should().Be($"Resource of type 'companies' with ID '{company.StringId}' does not exist.");
+            responseDocument.Errors[0].Source.Parameter.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Cannot_update_relationship_for_deleted_parent()
+        {
+            // Arrange
+            var company = new Company
+            {
+                IsSoftDeleted = true,
+                Departments = new List<Department>
+                {
+                    new Department
+                    {
+                        Name = "Marketing"
+                    }
+                }
+            };
+
+            await _testContext.RunOnDatabaseAsync(async dbContext =>
+            {
+                dbContext.Companies.Add(company);
+
+                await dbContext.SaveChangesAsync();
+            });
+
+            var route = $"/companies/{company.StringId}/relationships/departments";
+
+            var requestBody = new
+            {
+                data = new object[0]
+            };
+
+            // Act
+            var (httpResponse, responseDocument) = await _testContext.ExecutePatchAsync<ErrorDocument>(route, requestBody);
+
+            // Assert
+            httpResponse.Should().HaveStatusCode(HttpStatusCode.NotFound);
+
+            responseDocument.Errors.Should().HaveCount(1);
+            responseDocument.Errors[0].StatusCode.Should().Be(HttpStatusCode.NotFound);
+            responseDocument.Errors[0].Title.Should().Be("The requested resource does not exist.");
+            responseDocument.Errors[0].Detail.Should().Be($"Resource of type 'companies' with ID '{company.StringId}' does not exist.");
+            responseDocument.Errors[0].Source.Parameter.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #819 and adds examples for soft-delete via parent/child `ResourceDefinition`s.