### PR TITLE
Fixed: splitting on comma in legacy filter notation

### DIFF
--- a/src/JsonApiDotNetCore/QueryStrings/Internal/FilterQueryStringParameterReader.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/Internal/FilterQueryStringParameterReader.cs
@@ -64,9 +64,27 @@ namespace JsonApiDotNetCore.QueryStrings.Internal
         {
             _lastParameterName = parameterName;
 
-            foreach (string parameterValue in parameterValues)
+            foreach (string parameterValue in ExtractParameterValues(parameterName, parameterValues))
             {
                 ReadSingleValue(parameterName, parameterValue);
+            }
+        }
+
+        private IEnumerable<string> ExtractParameterValues(string parameterName, StringValues parameterValues)
+        {
+            foreach (string parameterValue in parameterValues)
+            {
+                if (_options.EnableLegacyFilterNotation)
+                {
+                    foreach (string condition in _legacyConverter.ExtractConditions(parameterName, parameterValue))
+                    {
+                        yield return condition;
+                    }
+                }
+                else
+                {
+                    yield return parameterValue;
+                }
             }
         }
 

--- a/src/JsonApiDotNetCore/QueryStrings/Internal/LegacyFilterNotationConverter.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/Internal/LegacyFilterNotationConverter.cs
@@ -25,6 +25,23 @@ namespace JsonApiDotNetCore.QueryStrings.Internal
             ["like:"] = Keywords.Contains
         };
 
+        public IEnumerable<string> ExtractConditions(string parameterName, string parameterValue)
+        {
+            if (parameterValue.StartsWith(ExpressionPrefix, StringComparison.Ordinal) ||
+                parameterValue.StartsWith(InPrefix, StringComparison.Ordinal) ||
+                parameterValue.StartsWith(NotInPrefix, StringComparison.Ordinal))
+            {
+                yield return parameterValue;
+            }
+            else
+            {
+                foreach (string condition in parameterValue.Split(','))
+                {
+                    yield return condition;
+                }
+            }
+        }
+
         public (string parameterName, string parameterValue) Convert(string parameterName, string parameterValue)
         {
             if (parameterName == null) throw new ArgumentNullException(nameof(parameterName));

--- a/test/UnitTests/QueryStringParameters/LegacyFilterParseTests.cs
+++ b/test/UnitTests/QueryStringParameters/LegacyFilterParseTests.cs
@@ -56,7 +56,6 @@ namespace UnitTests.QueryStringParameters
 
         [Theory]
         [InlineData("filter[caption]", "Brian O'Quote", "equals(caption,'Brian O''Quote')")]
-        [InlineData("filter[caption]", "using,comma", "equals(caption,'using,comma')")]
         [InlineData("filter[caption]", "am&per-sand", "equals(caption,'am&per-sand')")]
         [InlineData("filter[caption]", "2017-08-15T22:43:47.0156350-05:00", "equals(caption,'2017-08-15T22:43:47.0156350-05:00')")]
         [InlineData("filter[caption]", "eq:1", "equals(caption,'1')")]
@@ -77,6 +76,9 @@ namespace UnitTests.QueryStringParameters
         [InlineData("filter", "expr:equals(author,null)", "equals(author,null)")]
         [InlineData("filter", "expr:has(author.articles)", "has(author.articles)")]
         [InlineData("filter", "expr:equals(count(author.articles),'1')", "equals(count(author.articles),'1')")]
+        [InlineData("filter[caption]", "using,comma", "or(equals(caption,'using'),equals(caption,'comma'))")]
+        [InlineData("filter[caption]", "like:First,Second", "or(contains(caption,'First'),equals(caption,'Second'))")]
+        [InlineData("filter[caption]", "like:First,like:Second", "or(contains(caption,'First'),contains(caption,'Second'))")]
         public void Reader_Read_Succeeds(string parameterName, string parameterValue, string expressionExpected)
         {
             // Act


### PR DESCRIPTION
Fixes #815.

The [original code](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/e0270bd3cd344ebb5ff99593cc2c96e54dd17218/src/JsonApiDotNetCore/QueryParameterServices/FilterService.cs#L99) looked at the first operator and would, unless that operator was 'in' or 'nin', split the query string parameter value on comma.

This never worked correctly in composition, because the syntax becomes ambiguous.
For example: `?filter[name]=like:a,in:b,c,d` could mean:
- like(a), in(b,c,d)
- like(a), in(b,c), equals(d)

So while this fix addresses the simple case, it still fails on combinations, including mixing with the new notation.
