### PR TITLE
Fix: crash when deserializing post with relationship to abstract base class

### DIFF
--- a/src/JsonApiDotNetCore/Repositories/RepositoryRelationshipUpdateHelper.cs
+++ b/src/JsonApiDotNetCore/Repositories/RepositoryRelationshipUpdateHelper.cs
@@ -114,6 +114,7 @@ namespace JsonApiDotNetCore.Repositories
 
             var newLinks = relationshipIds.Select(x =>
             {
+                // TODO: [#696] Potential location where we crash if the relationship targets an abstract base class.
                 var link = _resourceFactory.CreateInstance(relationship.ThroughType);
                 relationship.LeftIdProperty.SetValue(link, TypeHelper.ConvertType(parentId, relationship.LeftIdProperty.PropertyType));
                 relationship.RightIdProperty.SetValue(link, TypeHelper.ConvertType(x, relationship.RightIdProperty.PropertyType));

--- a/src/JsonApiDotNetCore/Resources/Annotations/HasManyThroughAttribute.cs
+++ b/src/JsonApiDotNetCore/Resources/Annotations/HasManyThroughAttribute.cs
@@ -137,6 +137,7 @@ namespace JsonApiDotNetCore.Resources.Annotations
                 List<object> throughResources = new List<object>();
                 foreach (IIdentifiable identifiable in (IEnumerable)newValue)
                 {
+                    // TODO: [#696] Potential location where we crash if the relationship targets an abstract base class.
                     object throughResource = resourceFactory.CreateInstance(ThroughType);
                     LeftProperty.SetValue(throughResource, resource);
                     RightProperty.SetValue(throughResource, identifiable);

--- a/src/JsonApiDotNetCore/Serialization/BaseDeserializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/BaseDeserializer.cs
@@ -237,6 +237,7 @@ namespace JsonApiDotNetCore.Serialization
             {   // if the relationship is set to null, no need to set the navigation property to null: this is the default value.
                 var relatedResources = relationshipData.ManyData.Select(rio =>
                 {
+                    // TODO: [#696] Potential location where we crash if the relationship targets an abstract base class.
                     var relatedInstance = (IIdentifiable)ResourceFactory.CreateInstance(attr.RightType);
                     relatedInstance.StringId = rio.Id;
                     return relatedInstance;

--- a/src/JsonApiDotNetCore/Serialization/BaseDeserializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/BaseDeserializer.cs
@@ -168,7 +168,9 @@ namespace JsonApiDotNetCore.Serialization
             var rio = (ResourceIdentifierObject)relationshipData.Data;
             var relatedId = rio?.Id;
 
-            var resourceContext = ResourceContextProvider.GetResourceContext(relationshipData.SingleData.Type);
+            var resourceContext = relationshipData.SingleData == null
+                ? ResourceContextProvider.GetResourceContext(attr.RightType)
+                : ResourceContextProvider.GetResourceContext(relationshipData.SingleData.Type);
 
             // this does not make sense in the following case: if we're setting the dependent of a one-to-one relationship, IdentifiablePropertyName should be null.
             var foreignKeyProperty = resourceProperties.FirstOrDefault(p => p.Name == attr.IdentifiablePropertyName);

--- a/src/JsonApiDotNetCore/Serialization/Client/Internal/ResponseDeserializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/Client/Internal/ResponseDeserializer.cs
@@ -87,6 +87,7 @@ namespace JsonApiDotNetCore.Serialization.Client.Internal
         /// </summary>
         private IIdentifiable ParseIncludedRelationship(RelationshipAttribute relationshipAttr, ResourceIdentifierObject relatedResourceIdentifier)
         {
+            // TODO: [#696] Potential location where we crash if the relationship targets an abstract base class.
             var relatedInstance = (IIdentifiable)ResourceFactory.CreateInstance(relationshipAttr.RightType);
             relatedInstance.StringId = relatedResourceIdentifier.Id;
 


### PR DESCRIPTION
I'm not sure if this is a good solution, but at least this removes the crash when trying to create an instance of abstract base class (see #696). There are likely more places we need to change.