### PR TITLE
Fixed: crash when building ModelState error response

### DIFF
--- a/src/JsonApiDotNetCore/Errors/InvalidModelStateException.cs
+++ b/src/JsonApiDotNetCore/Errors/InvalidModelStateException.cs
@@ -34,10 +34,7 @@ namespace JsonApiDotNetCore.Errors
 
             foreach (var (propertyName, entry) in modelState.Where(x => x.Value.Errors.Any()))
             {
-                PropertyInfo property = resourceType.GetProperty(propertyName);
-
-                string attributeName =
-                    property.GetCustomAttribute<AttrAttribute>().PublicName ?? namingStrategy.GetPropertyName(property.Name, false);
+                string attributeName = GetDisplayNameForProperty(propertyName, resourceType, namingStrategy);
 
                 foreach (var modelError in entry.Errors)
                 {
@@ -53,6 +50,19 @@ namespace JsonApiDotNetCore.Errors
             }
 
             return errors;
+        }
+
+        private static string GetDisplayNameForProperty(string propertyName, Type resourceType,
+            NamingStrategy namingStrategy)
+        {
+            PropertyInfo property = resourceType.GetProperty(propertyName);
+            if (property != null)
+            {
+                var attrAttribute = property.GetCustomAttribute<AttrAttribute>();
+                return attrAttribute?.PublicName ?? namingStrategy.GetPropertyName(property.Name, false);
+            }
+
+            return propertyName;
         }
 
         private static Error FromModelError(ModelError modelError, string attributeName,


### PR DESCRIPTION
It may happen that `propertyName` contains something like 'Parent.Child.Some', so `property` becomes `null` and we crash on the next line with a `NullReferenceException`. This fix returns the original value if we are unable to translate between private/public names.

Found this while trying to find the root cause for #671.