### PR TITLE
Optimized/fixed TypeLocator.GetGenericInterfaceImplementation

### DIFF
--- a/src/JsonApiDotNetCore/Configuration/ServiceDiscoveryFacade.cs
+++ b/src/JsonApiDotNetCore/Configuration/ServiceDiscoveryFacade.cs
@@ -185,10 +185,10 @@ namespace JsonApiDotNetCore.Configuration
         private void RegisterImplementations(Assembly assembly, Type interfaceType, ResourceDescriptor resourceDescriptor)
         {
             var genericArguments = interfaceType.GetTypeInfo().GenericTypeParameters.Length == 2 ? new[] { resourceDescriptor.ResourceType, resourceDescriptor.IdType } : new[] { resourceDescriptor.ResourceType };
-            var (implementation, registrationInterface) = TypeLocator.GetGenericInterfaceImplementation(assembly, interfaceType, genericArguments);
-
-            if (implementation != null)
+            var result = TypeLocator.GetGenericInterfaceImplementation(assembly, interfaceType, genericArguments);
+            if (result != null)
             {
+                var (implementation, registrationInterface) = result.Value;
                 _services.AddScoped(registrationInterface, implementation);
             }
         }

--- a/test/UnitTests/Graph/TypeLocator_Tests.cs
+++ b/test/UnitTests/Graph/TypeLocator_Tests.cs
@@ -19,15 +19,16 @@ namespace UnitTests.Internal
             var expectedInterface = typeof(IGenericInterface<int>);
 
             // Act
-            var (implementation, registrationInterface) = TypeLocator.GetGenericInterfaceImplementation(
+            var result = TypeLocator.GetGenericInterfaceImplementation(
                 assembly,
                 openGeneric,
                 genericArg
             );
 
             // Assert
-            Assert.Equal(expectedImplementation, implementation);
-            Assert.Equal(expectedInterface, registrationInterface);
+            Assert.NotNull(result);
+            Assert.Equal(expectedImplementation, result.Value.implementation);
+            Assert.Equal(expectedInterface, result.Value.registrationInterface);
         }
 
         [Fact]


### PR DESCRIPTION
This method was identified as a hot path in profiling JsonApiDotNetCoreExample tests.

Type.GetGenericTypeDefinition() on the incoming parameter was called inside the loop, which is unneeded. And it compared generic type parameters before looking at the type itself, potentially evaluating too much.

This change makes it run 30% faster. This change also improves input validation and fixes the bug where only the first type parameter was matched against found types.