### PR TITLE
Docs hotfix

### DIFF
--- a/docs/generate-examples.ps1
+++ b/docs/generate-examples.ps1
@@ -3,17 +3,17 @@
 # This script generates response documents for ./request-examples
 
 function Kill-WebServer {
-    $tcpConnections = $null
+    $processId = $null
     if ($IsMacOs || $IsLinux) {
-        $tcpConnections = $(lsof -ti:8080)
+        $processId = $(lsof -ti:8080)
     }
     elseif ($IsWindows) {
-        $tcpConnections = $(Get-NetTCPConnection -LocalPort 14141 -ErrorAction SilentlyContinue).OwningProcess
+        $processId = $(Get-NetTCPConnection -LocalPort 14141 -ErrorAction SilentlyContinue).OwningProcess
     }
 
-    if ($tcpConnections -ne $null) {
+    if ($processId -ne $null) {
         Write-Output "Stopping web server"
-        Get-Process -Id $tcpConnections | Stop-Process
+        Get-Process -Id $processId | Stop-Process
     }
 
 }

--- a/docs/generate-examples.ps1
+++ b/docs/generate-examples.ps1
@@ -3,11 +3,19 @@
 # This script generates response documents for ./request-examples
 
 function Kill-WebServer {
-    $tcpConnections = Get-NetTCPConnection -LocalPort 14141 -ErrorAction SilentlyContinue
+    $tcpConnections = $null
+    if ($IsMacOs || $IsLinux) {
+        $tcpConnections = $(lsof -ti:8080)
+    }
+    elseif ($IsWindows) {
+        $tcpConnections = $(Get-NetTCPConnection -LocalPort 14141 -ErrorAction SilentlyContinue).OwningProcess
+    }
+
     if ($tcpConnections -ne $null) {
         Write-Output "Stopping web server"
-        Get-Process -Id $tcpConnections.OwningProcess | Stop-Process
+        Get-Process -Id $tcpConnections | Stop-Process
     }
+
 }
 
 function Start-Webserver {

--- a/docs/home/index.html
+++ b/docs/home/index.html
@@ -3,7 +3,7 @@
    <head>
       <meta charset="utf-8">
       <meta content="width=device-width, initial-scale=1.0" name="viewport">
-      <title>JsonApiDotNetCore</title>
+      <title>JSON:API .NET Core</title>
       <meta content="" name="descriptison">
       <meta content="" name="keywords">
       <link href="favicon.ico" rel="icon">
@@ -213,7 +213,8 @@ GET /articles?filter=contains(summary,'web')&sort=-lastModifiedAt&fields=title,s
           "links": {
             "self": "/articles/1/relationships/author",
             "related": "/articles/1/author"
-          }
+          },
+          "data": { "type": "people", "id": "1" }
         }
       },
       "links": {

--- a/docs/home/index.html
+++ b/docs/home/index.html
@@ -214,7 +214,10 @@ GET /articles?filter=contains(summary,'web')&sort=-lastModifiedAt&fields=title,s
             "self": "/articles/1/relationships/author",
             "related": "/articles/1/author"
           },
-          "data": { "type": "people", "id": "1" }
+          "data": {
+            "type": "people",
+            "id": "1"
+          }
         }
       },
       "links": {


### PR DESCRIPTION
- fix: adjust `generate-examples.ps1` to also work on non-windows
- fix: title and example in `index.html`