### PR TITLE
Fixed totalResourceCount for ResourceDefinition.OnApplyFilter usage

### DIFF
--- a/src/JsonApiDotNetCore/Queries/IQueryLayerComposer.cs
+++ b/src/JsonApiDotNetCore/Queries/IQueryLayerComposer.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Queries
         /// <summary>
         /// Builds a top-level filter from constraints, used to determine total resource count.
         /// </summary>
-        FilterExpression GetTopFilterFromConstraints();
+        FilterExpression GetTopFilterFromConstraints(ResourceContext resourceContext);
 
         /// <summary>
         /// Collects constraints and builds a <see cref="QueryLayer"/> out of them, used to retrieve the actual resources.

--- a/src/JsonApiDotNetCore/Queries/Internal/QueryLayerComposer.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryLayerComposer.cs
@@ -35,22 +35,17 @@ namespace JsonApiDotNetCore.Queries.Internal
         }
 
         /// <inheritdoc />
-        public FilterExpression GetTopFilterFromConstraints()
+        public FilterExpression GetTopFilterFromConstraints(ResourceContext resourceContext)
         {
             var constraints = _constraintProviders.SelectMany(provider => provider.GetConstraints()).ToArray();
 
-            var topFilters = constraints
+            var filtersInTopScope = constraints
                 .Where(constraint => constraint.Scope == null)
                 .Select(constraint => constraint.Expression)
                 .OfType<FilterExpression>()
                 .ToArray();
 
-            if (topFilters.Length > 1)
-            {
-                return new LogicalExpression(LogicalOperator.And, topFilters);
-            }
-
-            return topFilters.Length == 1 ? topFilters[0] : null;
+            return GetFilter(filtersInTopScope, resourceContext);
         }
 
         /// <inheritdoc />

--- a/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
@@ -66,7 +66,7 @@ namespace JsonApiDotNetCore.Services
 
             if (_options.IncludeTotalResourceCount)
             {
-                var topFilter = _queryLayerComposer.GetTopFilterFromConstraints();
+                var topFilter = _queryLayerComposer.GetTopFilterFromConstraints(_request.PrimaryResource);
                 _paginationContext.TotalResourceCount = await _repositoryAccessor.CountAsync<TResource>(topFilter, cancellationToken);
 
                 if (_paginationContext.TotalResourceCount == 0)


### PR DESCRIPTION
Fixed: When determining total resource count, `ResourceDefinition.OnApplyFilter` needs to be called, so that user-defined filters are taken into account.

Fixes #881.