### PR TITLE
Fixed: write content type on invalid Accept headers

### DIFF
--- a/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
@@ -140,6 +140,7 @@ namespace JsonApiDotNetCore.Middleware
 
         private static async Task FlushResponseAsync(HttpResponse httpResponse, JsonSerializerSettings serializerSettings, Error error)
         {
+            httpResponse.ContentType = HeaderConstants.MediaType;
             httpResponse.StatusCode = (int) error.StatusCode;
 
             JsonSerializer serializer = JsonSerializer.CreateDefault(serializerSettings);


### PR DESCRIPTION
Fixed: write content type on invalid Accept headers, to enable FireFox to render the response as json.

Before/after:
![image](https://user-images.githubusercontent.com/54280078/101493851-e10b6580-3966-11eb-91eb-fa9d7057650c.png)
