### PR TITLE
Changes usage of fields parameter to be json:api spec compliant

### DIFF
--- a/benchmarks/Query/QueryParserBenchmarks.cs
+++ b/benchmarks/Query/QueryParserBenchmarks.cs
@@ -31,7 +31,8 @@ namespace Benchmarks.Query
 
             var request = new JsonApiRequest
             {
-                PrimaryResource = resourceGraph.GetResourceContext(typeof(BenchmarkResource))
+                PrimaryResource = resourceGraph.GetResourceContext(typeof(BenchmarkResource)),
+                IsCollection = true
             };
 
             _queryStringReaderForSort = CreateQueryParameterDiscoveryForSort(resourceGraph, request, options, _queryStringAccessor);
@@ -56,6 +57,7 @@ namespace Benchmarks.Query
         {
             var resourceFactory = new ResourceFactory(new ServiceContainer());
 
+            var includeReader = new IncludeQueryStringParameterReader(request, resourceGraph, options);
             var filterReader = new FilterQueryStringParameterReader(request, resourceGraph, resourceFactory, options);
             var sortReader = new SortQueryStringParameterReader(request, resourceGraph);
             var sparseFieldSetReader = new SparseFieldSetQueryStringParameterReader(request, resourceGraph);
@@ -65,7 +67,7 @@ namespace Benchmarks.Query
 
             var readers = new List<IQueryStringParameterReader>
             {
-                filterReader, sortReader, sparseFieldSetReader, paginationReader, defaultsReader, nullsReader
+                includeReader, filterReader, sortReader, sparseFieldSetReader, paginationReader, defaultsReader, nullsReader
             };
 
             return new QueryStringReader(options, queryStringAccessor, readers, NullLoggerFactory.Instance);
@@ -92,7 +94,7 @@ namespace Benchmarks.Query
         [Benchmark]
         public void ComplexQuery() => Run(100, () =>
         {
-            var queryString = $"?filter[{BenchmarkResourcePublicNames.NameAttr}]=abc,eq:abc&sort=-{BenchmarkResourcePublicNames.NameAttr}&include=child&page[size]=1&fields={BenchmarkResourcePublicNames.NameAttr}";
+            var queryString = $"?filter[{BenchmarkResourcePublicNames.NameAttr}]=abc,eq:abc&sort=-{BenchmarkResourcePublicNames.NameAttr}&include=child&page[size]=1&fields[{BenchmarkResourcePublicNames.Type}]={BenchmarkResourcePublicNames.NameAttr}";
 
             _queryStringAccessor.SetQueryString(queryString);
             _queryStringReaderForAll.ReadAll(null);

--- a/docs/internals/queries.md
+++ b/docs/internals/queries.md
@@ -34,13 +34,13 @@ To get a sense of what this all looks like, let's look at an example query strin
   filter=has(articles)&
   sort=count(articles)&
   page[number]=3&
-  fields=title&
+  fields[blogs]=title&
     filter[articles]=and(not(equals(author.firstName,null)),has(revisions))&
     sort[articles]=author.lastName&
     fields[articles]=url&
       filter[articles.revisions]=and(greaterThan(publishTime,'2001-01-01'),startsWith(author.firstName,'J'))&
       sort[articles.revisions]=-publishTime,author.lastName&
-      fields[articles.revisions]=publishTime
+      fields[revisions]=publishTime
 ```
 
 After parsing, the set of scoped expressions is transformed into the following tree by `QueryLayerComposer`:

--- a/docs/request-examples/004_GET_Books-PublishYear.ps1
+++ b/docs/request-examples/004_GET_Books-PublishYear.ps1
@@ -1,1 +1,1 @@
-curl -s -f http://localhost:14141/api/books?fields=publishYear
+curl -s -f http://localhost:14141/api/books?fields%5Bbooks%5D=publishYear

--- a/docs/usage/reading/sparse-fieldset-selection.md
+++ b/docs/usage/reading/sparse-fieldset-selection.md
@@ -1,21 +1,24 @@
 # Sparse Fieldset Selection
 
-As an alternative to returning all attributes from a resource, the `fields` query string parameter can be used to select only a subset.
-This can be used on the resource being requested, as well as nested endpoints and/or included resources.
+As an alternative to returning all fields (attributes and relationships) from a resource, the `fields[]` query string parameter can be used to select a subset.
+Put the resource type to apply the fieldset on between the brackets.
+This can be used on the resource being requested, as well as on nested endpoints and/or included resources.
 
 Top-level example:
 ```http
-GET /articles?fields=title,body HTTP/1.1
+GET /articles?fields[articles]=title,body,comments HTTP/1.1
 ```
 
 Nested endpoint example:
 ```http
-GET /api/blogs/1/articles?fields=title,body HTTP/1.1
+GET /api/blogs/1/articles?fields[articles]=title,body,comments HTTP/1.1
 ```
+
+When combined with the `include` query string parameter, a subset of related fields can be specified too.
 
 Example for an included HasOne relationship:
 ```http
-GET /articles?include=author&fields[author]=name HTTP/1.1
+GET /articles?include=author&fields[authors]=name HTTP/1.1
 ```
 
 Example for an included HasMany relationship:
@@ -25,8 +28,11 @@ GET /articles?include=revisions&fields[revisions]=publishTime HTTP/1.1
 
 Example for both top-level and relationship:
 ```http
-GET /articles?include=author&fields=title,body&fields[author]=name HTTP/1.1
+GET /articles?include=author&fields[articles]=title,body,author&fields[authors]=name HTTP/1.1
 ```
+
+Note that in the last example, the `author` relationship is also added to the `articles` fieldset, so that the relationship from article to author is returned.
+When omitted, you'll get the included resources returned, but without full resource linkage (as described [here](https://jsonapi.org/examples/#sparse-fieldsets)).
 
 ## Overriding
 

--- a/docs/usage/resources/attributes.md
+++ b/docs/usage/resources/attributes.md
@@ -39,7 +39,7 @@ This can be overridden per attribute.
 
 ### Viewability
 
-Attributes can be marked to allow returning their value in responses. When not allowed and requested using `?fields=`, it results in an HTTP 400 response.
+Attributes can be marked to allow returning their value in responses. When not allowed and requested using `?fields[]=`, it results in an HTTP 400 response.
 
 ```c#
 public class User : Identifiable

--- a/docs/usage/resources/resource-definitions.md
+++ b/docs/usage/resources/resource-definitions.md
@@ -18,7 +18,7 @@ from Entity Framework Core `IQueryable` execution.
 
 ### Excluding fields
 
-There are some cases where you want attributes conditionally excluded from your resource response.
+There are some cases where you want attributes (or relationships) conditionally excluded from your resource response.
 For example, you may accept some sensitive data that should only be exposed to administrators after creation.
 
 Note: to exclude attributes unconditionally, use `[Attr(Capabilities = ~AttrCapabilities.AllowView)]`.

--- a/docs/usage/writing/creating.md
+++ b/docs/usage/writing/creating.md
@@ -61,10 +61,10 @@ POST /articles HTTP/1.1
 
 # Response body
 
-POST requests can be combined with query string parameters that are normally used for reading data, such as `include` and `fields`. For example:
+POST requests can be combined with query string parameters that are normally used for reading data, such as `include` and `fields[]`. For example:
 
 ```http
-POST /articles?include=owner&fields[owner]=firstName HTTP/1.1
+POST /articles?include=owner&fields[people]=firstName HTTP/1.1
 
 {
   ...

--- a/docs/usage/writing/updating.md
+++ b/docs/usage/writing/updating.md
@@ -69,10 +69,10 @@ By combining the examples above, both attributes and relationships can be update
 
 ## Response body
 
-PATCH requests can be combined with query string parameters that are normally used for reading data, such as `include` and `fields`. For example:
+PATCH requests can be combined with query string parameters that are normally used for reading data, such as `include` and `fields[]`. For example:
 
 ```http
-PATCH /articles/1?include=owner&fields[owner]=firstName HTTP/1.1
+PATCH /articles/1?include=owner&fields[people]=firstName HTTP/1.1
 
 {
   ...

--- a/src/Examples/JsonApiDotNetCoreExample/Models/Passport.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Models/Passport.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 using JsonApiDotNetCoreExample.Data;

--- a/src/JsonApiDotNetCore/Errors/ResourcesInRelationshipsNotFoundException.cs
+++ b/src/JsonApiDotNetCore/Errors/ResourcesInRelationshipsNotFoundException.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/src/JsonApiDotNetCore/Queries/Expressions/QueryExpressionRewriter.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/QueryExpressionRewriter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using JsonApiDotNetCore.Configuration;
 
 namespace JsonApiDotNetCore.Queries.Expressions
 {
@@ -186,6 +187,30 @@ namespace JsonApiDotNetCore.Queries.Expressions
 
                 var newExpression = new EqualsAnyOfExpression(newTargetAttribute, newConstants);
                 return newExpression.Equals(expression) ? expression : newExpression;
+            }
+
+            return null;
+        }
+
+        public override QueryExpression VisitSparseFieldTable(SparseFieldTableExpression expression, TArgument argument)
+        {
+            if (expression != null)
+            {
+                var newTable = new Dictionary<ResourceContext, SparseFieldSetExpression>();
+
+                foreach (var (resourceContext, sparseFieldSet) in expression.Table)
+                {
+                    if (Visit(sparseFieldSet, argument) is SparseFieldSetExpression newSparseFieldSet)
+                    {
+                        newTable[resourceContext] = newSparseFieldSet;
+                    }
+                }
+
+                if (newTable.Count > 0)
+                {
+                    var newExpression = new SparseFieldTableExpression(newTable);
+                    return newExpression.Equals(expression) ? expression : newExpression;
+                }
             }
 
             return null;

--- a/src/JsonApiDotNetCore/Queries/Expressions/QueryExpressionVisitor.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/QueryExpressionVisitor.cs
@@ -80,6 +80,11 @@ namespace JsonApiDotNetCore.Queries.Expressions
             return DefaultVisit(expression, argument);
         }
 
+        public virtual TResult VisitSparseFieldTable(SparseFieldTableExpression expression, TArgument argument)
+        {
+            return DefaultVisit(expression, argument);
+        }
+
         public virtual TResult VisitSparseFieldSet(SparseFieldSetExpression expression, TArgument argument)
         {
             return DefaultVisit(expression, argument);

--- a/src/JsonApiDotNetCore/Queries/Expressions/SparseFieldSetExpression.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/SparseFieldSetExpression.cs
@@ -6,19 +6,19 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCore.Queries.Expressions
 {
     /// <summary>
-    /// Represents a sparse fieldset, resulting from text such as: firstName,lastName
+    /// Represents a sparse fieldset, resulting from text such as: firstName,lastName,articles
     /// </summary>
     public class SparseFieldSetExpression : QueryExpression
     {
-        public IReadOnlyCollection<AttrAttribute> Attributes { get; }
+        public IReadOnlyCollection<ResourceFieldAttribute> Fields { get; }
 
-        public SparseFieldSetExpression(IReadOnlyCollection<AttrAttribute> attributes)
+        public SparseFieldSetExpression(IReadOnlyCollection<ResourceFieldAttribute> fields)
         {
-            Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
+            Fields = fields ?? throw new ArgumentNullException(nameof(fields));
 
-            if (!attributes.Any())
+            if (!fields.Any())
             {
-                throw new ArgumentException("Must have one or more attributes.", nameof(attributes));
+                throw new ArgumentException("Must have one or more fields.", nameof(fields));
             }
         }
 
@@ -29,7 +29,7 @@ namespace JsonApiDotNetCore.Queries.Expressions
 
         public override string ToString()
         {
-            return string.Join(",", Attributes.Select(child => child.PublicName));
+            return string.Join(",", Fields.Select(child => child.PublicName));
         }
 
         public override bool Equals(object obj)
@@ -46,16 +46,16 @@ namespace JsonApiDotNetCore.Queries.Expressions
 
             var other = (SparseFieldSetExpression) obj;
 
-            return Attributes.SequenceEqual(other.Attributes);
+            return Fields.SequenceEqual(other.Fields);
         }
 
         public override int GetHashCode()
         {
             var hashCode = new HashCode();
 
-            foreach (var attribute in Attributes)
+            foreach (var field in Fields)
             {
-                hashCode.Add(attribute);
+                hashCode.Add(field);
             }
 
             return hashCode.ToHashCode();

--- a/src/JsonApiDotNetCore/Queries/Expressions/SparseFieldSetExpressionExtensions.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/SparseFieldSetExpressionExtensions.cs
@@ -10,12 +10,12 @@ namespace JsonApiDotNetCore.Queries.Expressions
     public static class SparseFieldSetExpressionExtensions
     {
         public static SparseFieldSetExpression Including<TResource>(this SparseFieldSetExpression sparseFieldSet,
-            Expression<Func<TResource, dynamic>> attributeSelector, IResourceGraph resourceGraph)
+            Expression<Func<TResource, dynamic>> fieldSelector, IResourceGraph resourceGraph)
             where TResource : class, IIdentifiable
         {
-            if (attributeSelector == null)
+            if (fieldSelector == null)
             {
-                throw new ArgumentNullException(nameof(attributeSelector));
+                throw new ArgumentNullException(nameof(fieldSelector));
             }
 
             if (resourceGraph == null)
@@ -23,33 +23,33 @@ namespace JsonApiDotNetCore.Queries.Expressions
                 throw new ArgumentNullException(nameof(resourceGraph));
             }
 
-            foreach (var attribute in resourceGraph.GetAttributes(attributeSelector))
+            foreach (var field in resourceGraph.GetFields(fieldSelector))
             {
-                sparseFieldSet = IncludeAttribute(sparseFieldSet, attribute);
+                sparseFieldSet = IncludeField(sparseFieldSet, field);
             }
 
             return sparseFieldSet;
         }
 
-        private static SparseFieldSetExpression IncludeAttribute(SparseFieldSetExpression sparseFieldSet, AttrAttribute attributeToInclude)
+        private static SparseFieldSetExpression IncludeField(SparseFieldSetExpression sparseFieldSet, ResourceFieldAttribute fieldToInclude)
         {
-            if (sparseFieldSet == null || sparseFieldSet.Attributes.Contains(attributeToInclude))
+            if (sparseFieldSet == null || sparseFieldSet.Fields.Contains(fieldToInclude))
             {
                 return sparseFieldSet;
             }
 
-            var attributeSet = sparseFieldSet.Attributes.ToHashSet();
-            attributeSet.Add(attributeToInclude);
-            return new SparseFieldSetExpression(attributeSet);
+            var fieldSet = sparseFieldSet.Fields.ToHashSet();
+            fieldSet.Add(fieldToInclude);
+            return new SparseFieldSetExpression(fieldSet);
         }
 
         public static SparseFieldSetExpression Excluding<TResource>(this SparseFieldSetExpression sparseFieldSet,
-            Expression<Func<TResource, dynamic>> attributeSelector, IResourceGraph resourceGraph)
+            Expression<Func<TResource, dynamic>> fieldSelector, IResourceGraph resourceGraph)
             where TResource : class, IIdentifiable
         {
-            if (attributeSelector == null)
+            if (fieldSelector == null)
             {
-                throw new ArgumentNullException(nameof(attributeSelector));
+                throw new ArgumentNullException(nameof(fieldSelector));
             }
 
             if (resourceGraph == null)
@@ -57,29 +57,29 @@ namespace JsonApiDotNetCore.Queries.Expressions
                 throw new ArgumentNullException(nameof(resourceGraph));
             }
 
-            foreach (var attribute in resourceGraph.GetAttributes(attributeSelector))
+            foreach (var field in resourceGraph.GetFields(fieldSelector))
             {
-                sparseFieldSet = ExcludeAttribute(sparseFieldSet, attribute);
+                sparseFieldSet = ExcludeField(sparseFieldSet, field);
             }
 
             return sparseFieldSet;
         }
 
-        private static SparseFieldSetExpression ExcludeAttribute(SparseFieldSetExpression sparseFieldSet, AttrAttribute attributeToExclude)
+        private static SparseFieldSetExpression ExcludeField(SparseFieldSetExpression sparseFieldSet, ResourceFieldAttribute fieldToExclude)
         {
-            // Design tradeoff: When the sparse fieldset is empty, it means all attributes will be selected.
-            // Adding an exclusion in that case is a no-op, which results in still retrieving the excluded attribute from data store.
-            // But later, when serializing the response, the sparse fieldset is first populated with all attributes,
-            // so then the exclusion will actually be applied and the excluded attribute is not returned to the client.
+            // Design tradeoff: When the sparse fieldset is empty, it means all fields will be selected.
+            // Adding an exclusion in that case is a no-op, which results in still retrieving the excluded field from data store.
+            // But later, when serializing the response, the sparse fieldset is first populated with all fields,
+            // so then the exclusion will actually be applied and the excluded field is not returned to the client.
 
-            if (sparseFieldSet == null || !sparseFieldSet.Attributes.Contains(attributeToExclude))
+            if (sparseFieldSet == null || !sparseFieldSet.Fields.Contains(fieldToExclude))
             {
                 return sparseFieldSet;
             }
 
-            var attributeSet = sparseFieldSet.Attributes.ToHashSet();
-            attributeSet.Remove(attributeToExclude);
-            return new SparseFieldSetExpression(attributeSet);
+            var fieldSet = sparseFieldSet.Fields.ToHashSet();
+            fieldSet.Remove(fieldToExclude);
+            return new SparseFieldSetExpression(fieldSet);
         }
     }
 }

--- a/src/JsonApiDotNetCore/Queries/Expressions/SparseFieldTableExpression.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/SparseFieldTableExpression.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using JsonApiDotNetCore.Configuration;
+
+namespace JsonApiDotNetCore.Queries.Expressions
+{
+    /// <summary>
+    /// Represents a lookup table of sparse fieldsets per resource type.
+    /// </summary>
+    public class SparseFieldTableExpression : QueryExpression
+    {
+        public IReadOnlyDictionary<ResourceContext, SparseFieldSetExpression> Table { get; }
+
+        public SparseFieldTableExpression(IReadOnlyDictionary<ResourceContext, SparseFieldSetExpression> table)
+        {
+            Table = table ?? throw new ArgumentNullException(nameof(table));
+
+            if (!table.Any())
+            {
+                throw new ArgumentException("Must have one or more entries.", nameof(table));
+            }
+        }
+
+        public override TResult Accept<TArgument, TResult>(QueryExpressionVisitor<TArgument, TResult> visitor, TArgument argument)
+        {
+            return visitor.VisitSparseFieldTable(this, argument);
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+
+            foreach (var (resource, fields) in Table)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(",");
+                }
+
+                builder.Append(resource.PublicName);
+                builder.Append("(");
+                builder.Append(fields);
+                builder.Append(")");
+            }
+
+            return builder.ToString();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj is null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            var other = (SparseFieldTableExpression) obj;
+
+            return Table.SequenceEqual(other.Table);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCode();
+
+            foreach (var (resourceContext, sparseFieldSet) in Table)
+            {
+                hashCode.Add(resourceContext);
+                hashCode.Add(sparseFieldSet);
+            }
+
+            return hashCode.ToHashCode();
+        }
+    }
+}

--- a/src/JsonApiDotNetCore/Queries/Internal/Parsing/ResourceFieldChainResolver.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/Parsing/ResourceFieldChainResolver.cs
@@ -232,7 +232,7 @@ namespace JsonApiDotNetCore.Queries.Internal.Parsing
             return relationship;
         }
 
-        public AttrAttribute GetAttribute(string publicName, ResourceContext resourceContext, string path)
+        private AttrAttribute GetAttribute(string publicName, ResourceContext resourceContext, string path)
         {
             var attribute = resourceContext.Attributes.FirstOrDefault(a => a.PublicName == publicName);
 

--- a/src/JsonApiDotNetCore/Queries/Internal/Parsing/SparseFieldTypeParser.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/Parsing/SparseFieldTypeParser.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace JsonApiDotNetCore.Queries.Internal.Parsing
+{
+    public class SparseFieldTypeParser : QueryExpressionParser
+    {
+        private readonly IResourceContextProvider _resourceContextProvider;
+
+        public SparseFieldTypeParser(IResourceContextProvider resourceContextProvider)
+            : base(resourceContextProvider)
+        {
+            _resourceContextProvider = resourceContextProvider;
+        }
+
+        public ResourceContext Parse(string source)
+        {
+            Tokenize(source);
+
+            var expression = ParseSparseFieldTarget();
+
+            AssertTokenStackIsEmpty();
+
+            return expression;
+        }
+
+        private ResourceContext ParseSparseFieldTarget()
+        {
+            if (!TokenStack.TryPop(out Token token) || token.Kind != TokenKind.Text)
+            {
+                throw new QueryParseException("Parameter name expected.");
+            }
+
+            EatSingleCharacterToken(TokenKind.OpenBracket);
+
+            var resourceContext = ParseResourceName();
+
+            EatSingleCharacterToken(TokenKind.CloseBracket);
+
+            return resourceContext;
+        }
+
+        private ResourceContext ParseResourceName()
+        {
+            if (TokenStack.TryPop(out Token token) && token.Kind == TokenKind.Text)
+            {
+                return GetResourceContext(token.Value);
+            }
+
+            throw new QueryParseException("Resource type expected.");
+        }
+
+        private ResourceContext GetResourceContext(string resourceName)
+        {
+            var resourceContext = _resourceContextProvider.GetResourceContext(resourceName);
+            if (resourceContext == null)
+            {
+                throw new QueryParseException($"Resource type '{resourceName}' does not exist.");
+            }
+
+            return resourceContext;
+        }
+
+        protected override IReadOnlyCollection<ResourceFieldAttribute> OnResolveFieldChain(string path, FieldChainRequirements chainRequirements)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/JsonApiDotNetCore/Queries/Internal/QueryLayerComposer.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryLayerComposer.cs
@@ -215,12 +215,9 @@ namespace JsonApiDotNetCore.Queries.Internal
 
         private IDictionary<ResourceFieldAttribute, QueryLayer> GetProjectionForRelationship(ResourceContext secondaryResourceContext)
         {
-            var secondaryIdAttribute = GetIdAttribute(secondaryResourceContext);
+            var secondaryAttributeSet = _sparseFieldSetCache.GetIdAttributeSetForRelationshipQuery(secondaryResourceContext);
 
-            var secondaryProjection = GetProjectionForSparseAttributeSet(secondaryResourceContext) ?? new Dictionary<ResourceFieldAttribute, QueryLayer>();
-            secondaryProjection[secondaryIdAttribute] = null;
-
-            return secondaryProjection;
+            return secondaryAttributeSet.ToDictionary(key => (ResourceFieldAttribute)key, value => (QueryLayer)null);
         }
 
         /// <inheritdoc />
@@ -233,13 +230,12 @@ namespace JsonApiDotNetCore.Queries.Internal
             var innerInclude = secondaryLayer.Include;
             secondaryLayer.Include = null;
 
-            var primaryIdAttribute = GetIdAttribute(primaryResourceContext);
-
-            var primaryProjection = GetProjectionForSparseAttributeSet(primaryResourceContext) ?? new Dictionary<ResourceFieldAttribute, QueryLayer>();
+            var primaryAttributeSet = _sparseFieldSetCache.GetIdAttributeSetForRelationshipQuery(primaryResourceContext);
+            var primaryProjection = primaryAttributeSet.ToDictionary(key => (ResourceFieldAttribute)key, value => (QueryLayer)null);
             primaryProjection[secondaryRelationship] = secondaryLayer;
-            primaryProjection[primaryIdAttribute] = null;
 
             var primaryFilter = GetFilter(Array.Empty<QueryExpression>(), primaryResourceContext);
+            var primaryIdAttribute = GetIdAttribute(primaryResourceContext);
 
             return new QueryLayer(primaryResourceContext)
             {

--- a/src/JsonApiDotNetCore/Queries/Internal/SparseFieldSetCache.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/SparseFieldSetCache.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Queries.Expressions;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace JsonApiDotNetCore.Queries.Internal
+{
+    /// <summary>
+    /// Takes sparse fieldsets from <see cref="IQueryConstraintProvider"/>s and invokes <see cref="IResourceDefinition{TResource, TId}.OnApplySparseFieldSet"/> on them.
+    /// </summary>
+    public sealed class SparseFieldSetCache
+    {
+        private readonly IResourceDefinitionAccessor _resourceDefinitionAccessor;
+        private readonly Lazy<IDictionary<ResourceContext, HashSet<ResourceFieldAttribute>>> _lazySourceTable;
+        private readonly IDictionary<ResourceContext, HashSet<ResourceFieldAttribute>> _visitedTable;
+
+        public SparseFieldSetCache(IEnumerable<IQueryConstraintProvider> constraintProviders, IResourceDefinitionAccessor resourceDefinitionAccessor)
+        {
+            if (constraintProviders == null) throw new ArgumentNullException(nameof(constraintProviders));
+            _resourceDefinitionAccessor = resourceDefinitionAccessor ?? throw new ArgumentNullException(nameof(resourceDefinitionAccessor));
+
+            _lazySourceTable = new Lazy<IDictionary<ResourceContext, HashSet<ResourceFieldAttribute>>>(() => BuildSourceTable(constraintProviders));
+            _visitedTable = new Dictionary<ResourceContext, HashSet<ResourceFieldAttribute>>();
+        }
+
+        private static IDictionary<ResourceContext, HashSet<ResourceFieldAttribute>> BuildSourceTable(IEnumerable<IQueryConstraintProvider> constraintProviders)
+        {
+            var sparseFieldTables = constraintProviders
+                .SelectMany(provider => provider.GetConstraints())
+                .Where(constraint => constraint.Scope == null)
+                .Select(constraint => constraint.Expression)
+                .OfType<SparseFieldTableExpression>()
+                .Select(expression => expression.Table)
+                .ToArray();
+
+            var mergedTable = new Dictionary<ResourceContext, HashSet<ResourceFieldAttribute>>();
+
+            foreach (var sparseFieldTable in sparseFieldTables)
+            {
+                foreach (var (resourceContext, sparseFieldSet) in sparseFieldTable)
+                {
+                    if (!mergedTable.ContainsKey(resourceContext))
+                    {
+                        mergedTable[resourceContext] = new HashSet<ResourceFieldAttribute>();
+                    }
+
+                    foreach (var field in sparseFieldSet.Fields)
+                    {
+                        mergedTable[resourceContext].Add(field);
+                    }
+                }
+            }
+
+            return mergedTable;
+        }
+
+        public IReadOnlyCollection<ResourceFieldAttribute> GetSparseFieldSetForQuery(ResourceContext resourceContext)
+        {
+            if (!_visitedTable.ContainsKey(resourceContext))
+            {
+                var inputExpression = _lazySourceTable.Value.ContainsKey(resourceContext)
+                    ? new SparseFieldSetExpression(_lazySourceTable.Value[resourceContext])
+                    : null;
+
+                var outputExpression = _resourceDefinitionAccessor.OnApplySparseFieldSet(resourceContext.ResourceType, inputExpression);
+
+                var outputFields = outputExpression == null
+                    ? new HashSet<ResourceFieldAttribute>()
+                    : outputExpression.Fields.ToHashSet();
+
+                _visitedTable[resourceContext] = outputFields;
+            }
+
+            return _visitedTable[resourceContext];
+        }
+
+        public IReadOnlyCollection<ResourceFieldAttribute> GetSparseFieldSetForSerializer(ResourceContext resourceContext)
+        {
+            if (!_visitedTable.ContainsKey(resourceContext))
+            {
+                var inputFields = _lazySourceTable.Value.ContainsKey(resourceContext)
+                    ? _lazySourceTable.Value[resourceContext]
+                    : GetResourceFields(resourceContext);
+
+                var inputExpression = new SparseFieldSetExpression(inputFields);
+                var outputExpression = _resourceDefinitionAccessor.OnApplySparseFieldSet(resourceContext.ResourceType, inputExpression);
+
+                HashSet<ResourceFieldAttribute> outputFields;
+                if (outputExpression == null)
+                {
+                    outputFields = GetResourceFields(resourceContext);
+                }
+                else
+                {
+                    outputFields = new HashSet<ResourceFieldAttribute>(inputFields);
+                    outputFields.IntersectWith(outputExpression.Fields);
+                }
+
+                _visitedTable[resourceContext] = outputFields;
+            }
+
+            return _visitedTable[resourceContext];
+        }
+
+        private HashSet<ResourceFieldAttribute> GetResourceFields(ResourceContext resourceContext)
+        {
+            var fieldSet = new HashSet<ResourceFieldAttribute>();
+
+            foreach (var attribute in resourceContext.Attributes.Where(attr => attr.Capabilities.HasFlag(AttrCapabilities.AllowView)))
+            {
+                fieldSet.Add(attribute);
+            }
+
+            foreach (var relationship in resourceContext.Relationships)
+            {
+                fieldSet.Add(relationship);
+            }
+
+            return fieldSet;
+        }
+    }
+}

--- a/src/JsonApiDotNetCore/Serialization/IFieldsToSerialize.cs
+++ b/src/JsonApiDotNetCore/Serialization/IFieldsToSerialize.cs
@@ -13,14 +13,12 @@ namespace JsonApiDotNetCore.Serialization
     {
         /// <summary>
         /// Gets the collection of attributes that are to be serialized for resources of type <paramref name="resourceType"/>.
-        /// If <paramref name="relationship"/> is non-null, it will consider the allowed collection of attributes
-        /// as an included relationship.
         /// </summary>
-        IReadOnlyCollection<AttrAttribute> GetAttributes(Type resourceType, RelationshipAttribute relationship = null);
+        IReadOnlyCollection<AttrAttribute> GetAttributes(Type resourceType);
 
         /// <summary>
-        /// Gets the collection of relationships that are to be serialized for resources of type <paramref name="type"/>.
+        /// Gets the collection of relationships that are to be serialized for resources of type <paramref name="resourceType"/>.
         /// </summary>
-        IReadOnlyCollection<RelationshipAttribute> GetRelationships(Type type);
+        IReadOnlyCollection<RelationshipAttribute> GetRelationships(Type resourceType);
     }
 }

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/InjectableResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/InjectableResourceTests.cs
@@ -153,7 +153,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
             _context.Passports.AddRange(passports);
             await _context.SaveChangesAsync();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, "/api/v1/passports?include=person&fields=socialSecurityNumber&fields[person]=firstName");
+            var request = new HttpRequestMessage(HttpMethod.Get, "/api/v1/passports?include=person&fields[passports]=socialSecurityNumber&fields[people]=firstName");
 
             // Act
             var response = await _fixture.Client.SendAsync(request);

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/CompositeKeys/CompositeKeyTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/CompositeKeys/CompositeKeyTests.cs
@@ -133,7 +133,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.CompositeKeys
                 await dbContext.SaveChangesAsync();
             });
 
-            var route = "/cars?fields=id";
+            var route = "/cars?fields[cars]=id";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/EagerLoading/EagerLoadingTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/EagerLoading/EagerLoadingTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -107,7 +106,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.EagerLoading
                 await dbContext.SaveChangesAsync();
             });
 
-            var route = $"/streets/{street.StringId}?fields=windowTotalCount";
+            var route = $"/streets/{street.StringId}?fields[streets]=windowTotalCount";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
@@ -119,6 +118,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.EagerLoading
             responseDocument.SingleData.Id.Should().Be(street.StringId);
             responseDocument.SingleData.Attributes.Should().HaveCount(1);
             responseDocument.SingleData.Attributes["windowTotalCount"].Should().Be(3);
+            responseDocument.SingleData.Relationships.Should().BeNull();
         }
 
         [Fact]
@@ -181,7 +181,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.EagerLoading
                 await dbContext.SaveChangesAsync();
             });
 
-            var route = $"/states/{state.StringId}/cities?include=streets&fields=name&fields[streets]=doorTotalCount,windowTotalCount";
+            var route = $"/states/{state.StringId}/cities?include=streets&fields[cities]=name&fields[streets]=doorTotalCount,windowTotalCount";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
@@ -193,6 +193,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.EagerLoading
             responseDocument.ManyData[0].Id.Should().Be(state.Cities[0].StringId);
             responseDocument.ManyData[0].Attributes.Should().HaveCount(1);
             responseDocument.ManyData[0].Attributes["name"].Should().Be(state.Cities[0].Name);
+            responseDocument.ManyData[0].Relationships.Should().BeNull();
 
             responseDocument.Included.Should().HaveCount(1);
             responseDocument.Included[0].Type.Should().Be("streets");
@@ -200,6 +201,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.EagerLoading
             responseDocument.Included[0].Attributes.Should().HaveCount(2);
             responseDocument.Included[0].Attributes["doorTotalCount"].Should().Be(2);
             responseDocument.Included[0].Attributes["windowTotalCount"].Should().Be(1);
+            responseDocument.Included[0].Relationships.Should().BeNull();
         }
 
         [Fact]

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/IdObfuscation/IdObfuscationTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/IdObfuscation/IdObfuscationTests.cs
@@ -152,7 +152,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.IdObfuscation
                 await dbContext.SaveChangesAsync();
             });
 
-            var route = $"/bankAccounts/{bankAccount.StringId}?include=cards&fields[cards]=ownerName";
+            var route = $"/bankAccounts/{bankAccount.StringId}?include=cards&fields[debitCards]=ownerName";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
@@ -166,6 +166,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.IdObfuscation
             responseDocument.Included.Should().HaveCount(1);
             responseDocument.Included[0].Id.Should().Be(bankAccount.Cards[0].StringId);
             responseDocument.Included[0].Attributes.Should().HaveCount(1);
+            responseDocument.Included[0].Relationships.Should().BeNull();
         }
 
         [Fact]

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Pagination/PaginationWithTotalCountTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Pagination/PaginationWithTotalCountTests.cs
@@ -730,7 +730,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Pagination
             });
 
             var routePrefix = "/api/v1/todoItems?filter=equals(owner.lastName,'" + WebUtility.UrlEncode(person.LastName) + "')" +
-                        $"&fields[owner]=firstName&include=owner&sort=ordinal&foo=bar,baz";
+                        "&fields[people]=firstName&include=owner&sort=ordinal&foo=bar,baz";
             var route = routePrefix + $"&page[number]={pageNumber}";
 
             // Act

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceTests.cs
@@ -94,7 +94,6 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.SingleData.Type.Should().Be("workItems");
             responseDocument.SingleData.Attributes["description"].Should().Be(newWorkItem.Description);
             responseDocument.SingleData.Attributes["dueAt"].Should().Be(newWorkItem.DueAt);
-
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
 
             var newWorkItemId = int.Parse(responseDocument.SingleData.Id);
@@ -143,7 +142,6 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.SingleData.Type.Should().Be("userAccounts");
             responseDocument.SingleData.Attributes["firstName"].Should().Be(newUserAccount.FirstName);
             responseDocument.SingleData.Attributes["lastName"].Should().Be(newUserAccount.LastName);
-
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
 
             var newUserAccountId = long.Parse(responseDocument.SingleData.Id);
@@ -190,7 +188,6 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.SingleData.Should().NotBeNull();
             responseDocument.SingleData.Type.Should().Be("workItemGroups");
             responseDocument.SingleData.Attributes["name"].Should().Be(newGroup.Name);
-
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
 
             var newGroupId = Guid.Parse(responseDocument.SingleData.Id);
@@ -237,7 +234,6 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.SingleData.Type.Should().Be("workItems");
             responseDocument.SingleData.Attributes["description"].Should().BeNull();
             responseDocument.SingleData.Attributes["dueAt"].Should().BeNull();
-
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
 
             var newWorkItemId = int.Parse(responseDocument.SingleData.Id);
@@ -282,6 +278,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.SingleData.Should().NotBeNull();
             responseDocument.SingleData.Type.Should().Be("workItems");
             responseDocument.SingleData.Attributes["description"].Should().Be(newWorkItem.Description);
+            responseDocument.SingleData.Relationships.Should().NotBeEmpty();
 
             var newWorkItemId = int.Parse(responseDocument.SingleData.Id);
 
@@ -327,6 +324,8 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
 
             responseDocument.SingleData.Should().NotBeNull();
             responseDocument.SingleData.Type.Should().Be("workItems");
+            responseDocument.SingleData.Attributes.Should().NotBeEmpty();
+            responseDocument.SingleData.Relationships.Should().NotBeEmpty();
 
             var newWorkItemId = int.Parse(responseDocument.SingleData.Id);
 

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithClientGeneratedIdTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithClientGeneratedIdTests.cs
@@ -57,6 +57,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.SingleData.Type.Should().Be("workItemGroups");
             responseDocument.SingleData.Id.Should().Be(newGroup.StringId);
             responseDocument.SingleData.Attributes["name"].Should().Be(newGroup.Name);
+            responseDocument.SingleData.Relationships.Should().NotBeEmpty();
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
             {
@@ -90,7 +91,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
                 }
             };
 
-            var route = "/workItemGroups?fields=name";
+            var route = "/workItemGroups?fields[workItemGroups]=name";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
@@ -103,6 +104,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.SingleData.Id.Should().Be(newGroup.StringId);
             responseDocument.SingleData.Attributes.Should().HaveCount(1);
             responseDocument.SingleData.Attributes["name"].Should().Be(newGroup.Name);
+            responseDocument.SingleData.Relationships.Should().BeNull();
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
             {
@@ -176,7 +178,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
                 }
             };
 
-            var route = "/rgbColors?fields=id";
+            var route = "/rgbColors?fields[rgbColors]=id";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecutePostAsync<string>(route, requestBody);

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToManyRelationshipTests.cs
@@ -72,6 +72,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             httpResponse.Should().HaveStatusCode(HttpStatusCode.Created);
 
             responseDocument.SingleData.Should().NotBeNull();
+            responseDocument.SingleData.Attributes.Should().NotBeEmpty();
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
             responseDocument.Included.Should().BeNull();
 
@@ -137,6 +138,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             httpResponse.Should().HaveStatusCode(HttpStatusCode.Created);
 
             responseDocument.SingleData.Should().NotBeNull();
+            responseDocument.SingleData.Attributes.Should().NotBeEmpty();
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
             
             responseDocument.Included.Should().HaveCount(2);
@@ -145,6 +147,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.Included.Should().ContainSingle(resource => resource.Id == existingUserAccounts[1].StringId);
             responseDocument.Included.Should().OnlyContain(resource => resource.Attributes["firstName"] != null);
             responseDocument.Included.Should().OnlyContain(resource => resource.Attributes["lastName"] != null);
+            responseDocument.Included.Should().OnlyContain(resource => resource.Relationships.Count > 0);
 
             var newWorkItemId = int.Parse(responseDocument.SingleData.Id);
 
@@ -199,7 +202,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
                 }
             };
 
-            var route = "/workItems?include=subscribers&fields[subscribers]=firstName";
+            var route = "/workItems?include=subscribers&fields[userAccounts]=firstName";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
@@ -208,6 +211,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             httpResponse.Should().HaveStatusCode(HttpStatusCode.Created);
 
             responseDocument.SingleData.Should().NotBeNull();
+            responseDocument.SingleData.Attributes.Should().NotBeEmpty();
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
             
             responseDocument.Included.Should().HaveCount(2);
@@ -216,6 +220,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.Included.Should().ContainSingle(resource => resource.Id == existingUserAccounts[1].StringId);
             responseDocument.Included.Should().OnlyContain(resource => resource.Attributes.Count == 1);
             responseDocument.Included.Should().OnlyContain(resource => resource.Attributes["firstName"] != null);
+            responseDocument.Included.Should().OnlyContain(resource => resource.Relationships == null);
 
             var newWorkItemId = int.Parse(responseDocument.SingleData.Id);
 
@@ -281,7 +286,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
                 }
             };
 
-            var route = "/workItems?fields=priority&include=tags&fields[tags]=text";
+            var route = "/workItems?fields[workItems]=priority,tags&include=tags&fields[workTags]=text";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
@@ -292,8 +297,11 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.SingleData.Should().NotBeNull();
             responseDocument.SingleData.Attributes.Should().HaveCount(1);
             responseDocument.SingleData.Attributes["priority"].Should().Be(workItemToCreate.Priority.ToString("G"));
-
-            responseDocument.SingleData.Relationships.Should().NotBeEmpty();
+            responseDocument.SingleData.Relationships.Should().HaveCount(1);
+            responseDocument.SingleData.Relationships["tags"].ManyData.Should().HaveCount(3);
+            responseDocument.SingleData.Relationships["tags"].ManyData[0].Id.Should().Be(existingTags[0].StringId);
+            responseDocument.SingleData.Relationships["tags"].ManyData[1].Id.Should().Be(existingTags[1].StringId);
+            responseDocument.SingleData.Relationships["tags"].ManyData[2].Id.Should().Be(existingTags[2].StringId);
             
             responseDocument.Included.Should().HaveCount(3);
             responseDocument.Included.Should().OnlyContain(resource => resource.Type == "workTags");
@@ -302,6 +310,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.Included.Should().ContainSingle(resource => resource.Id == existingTags[2].StringId);
             responseDocument.Included.Should().OnlyContain(resource => resource.Attributes.Count == 1);
             responseDocument.Included.Should().OnlyContain(resource => resource.Attributes["text"] != null);
+            responseDocument.Included.Should().OnlyContain(resource => resource.Relationships == null);
 
             var newWorkItemId = int.Parse(responseDocument.SingleData.Id);
 
@@ -575,6 +584,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             httpResponse.Should().HaveStatusCode(HttpStatusCode.Created);
 
             responseDocument.SingleData.Should().NotBeNull();
+            responseDocument.SingleData.Attributes.Should().NotBeEmpty();
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
             
             responseDocument.Included.Should().HaveCount(1);

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToOneRelationshipTests.cs
@@ -66,6 +66,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             httpResponse.Should().HaveStatusCode(HttpStatusCode.Created);
 
             responseDocument.SingleData.Should().NotBeNull();
+            responseDocument.SingleData.Attributes.Should().NotBeEmpty();
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
 
             var newGroupId = responseDocument.SingleData.Id;
@@ -187,6 +188,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             httpResponse.Should().HaveStatusCode(HttpStatusCode.Created);
 
             responseDocument.SingleData.Should().NotBeNull();
+            responseDocument.SingleData.Attributes.Should().NotBeEmpty();
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
 
             responseDocument.Included.Should().HaveCount(1);
@@ -194,6 +196,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.Included[0].Id.Should().Be(existingUserAccount.StringId);
             responseDocument.Included[0].Attributes["firstName"].Should().Be(existingUserAccount.FirstName);
             responseDocument.Included[0].Attributes["lastName"].Should().Be(existingUserAccount.LastName);
+            responseDocument.Included[0].Relationships.Should().NotBeEmpty();
 
             var newWorkItemId = int.Parse(responseDocument.SingleData.Id);
 
@@ -245,7 +248,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
                 }
             };
 
-            var route = "/workItems?fields=description&include=assignee";
+            var route = "/workItems?fields[workItems]=description,assignee&include=assignee";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
@@ -256,14 +259,15 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.SingleData.Should().NotBeNull();
             responseDocument.SingleData.Attributes.Should().HaveCount(1);
             responseDocument.SingleData.Attributes["description"].Should().Be(newWorkItem.Description);
-
-            responseDocument.SingleData.Relationships.Should().NotBeEmpty();
+            responseDocument.SingleData.Relationships.Should().HaveCount(1);
+            responseDocument.SingleData.Relationships["assignee"].SingleData.Id.Should().Be(existingUserAccount.StringId);
 
             responseDocument.Included.Should().HaveCount(1);
             responseDocument.Included[0].Type.Should().Be("userAccounts");
             responseDocument.Included[0].Id.Should().Be(existingUserAccount.StringId);
             responseDocument.Included[0].Attributes["firstName"].Should().Be(existingUserAccount.FirstName);
             responseDocument.Included[0].Attributes["lastName"].Should().Be(existingUserAccount.LastName);
+            responseDocument.Included[0].Relationships.Should().NotBeEmpty();
 
             var newWorkItemId = int.Parse(responseDocument.SingleData.Id);
 
@@ -513,6 +517,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             httpResponse.Should().HaveStatusCode(HttpStatusCode.Created);
 
             responseDocument.SingleData.Should().NotBeNull();
+            responseDocument.SingleData.Attributes.Should().NotBeEmpty();
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
 
             responseDocument.Included.Should().HaveCount(1);
@@ -520,6 +525,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
             responseDocument.Included[0].Id.Should().Be(existingUserAccounts[1].StringId);
             responseDocument.Included[0].Attributes["firstName"].Should().Be(existingUserAccounts[1].FirstName);
             responseDocument.Included[0].Attributes["lastName"].Should().Be(existingUserAccounts[1].LastName);
+            responseDocument.Included[0].Relationships.Should().NotBeEmpty();
 
             var newWorkItemId = int.Parse(responseDocument.SingleData.Id);
 

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Fetching/FetchRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Fetching/FetchRelationshipTests.cs
@@ -43,6 +43,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Fetching
             responseDocument.SingleData.Type.Should().Be("userAccounts");
             responseDocument.SingleData.Id.Should().Be(workItem.Assignee.StringId);
             responseDocument.SingleData.Attributes.Should().BeNull();
+            responseDocument.SingleData.Relationships.Should().BeNull();
         }
 
         [Fact]
@@ -93,10 +94,12 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Fetching
             var item1 = responseDocument.ManyData.Single(resource => resource.Id == userAccount.AssignedItems.ElementAt(0).StringId);
             item1.Type.Should().Be("workItems");
             item1.Attributes.Should().BeNull();
+            item1.Relationships.Should().BeNull();
 
             var item2 = responseDocument.ManyData.Single(resource => resource.Id == userAccount.AssignedItems.ElementAt(1).StringId);
             item2.Type.Should().Be("workItems");
             item2.Attributes.Should().BeNull();
+            item2.Relationships.Should().BeNull();
         }
 
         [Fact]
@@ -158,10 +161,12 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Fetching
             var item1 = responseDocument.ManyData.Single(resource => resource.Id == workItem.WorkItemTags.ElementAt(0).Tag.StringId);
             item1.Type.Should().Be("workTags");
             item1.Attributes.Should().BeNull();
+            item1.Relationships.Should().BeNull();
             
             var item2 = responseDocument.ManyData.Single(resource => resource.Id == workItem.WorkItemTags.ElementAt(1).Tag.StringId);
             item2.Type.Should().Be("workTags");
             item2.Attributes.Should().BeNull();
+            item2.Relationships.Should().BeNull();
         }
 
         [Fact]

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Fetching/FetchResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Fetching/FetchResourceTests.cs
@@ -47,12 +47,14 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Fetching
             item1.Attributes["description"].Should().Be(workItems[0].Description);
             item1.Attributes["dueAt"].Should().BeCloseTo(workItems[0].DueAt);
             item1.Attributes["priority"].Should().Be(workItems[0].Priority.ToString("G"));
-            
+            item1.Relationships.Should().NotBeEmpty();
+
             var item2 = responseDocument.ManyData.Single(resource => resource.Id == workItems[1].StringId);
             item2.Type.Should().Be("workItems");
             item2.Attributes["description"].Should().Be(workItems[1].Description);
             item2.Attributes["dueAt"].Should().BeCloseTo(workItems[1].DueAt);
             item2.Attributes["priority"].Should().Be(workItems[1].Priority.ToString("G"));
+            item2.Relationships.Should().NotBeEmpty();
         }
 
         [Fact]
@@ -96,6 +98,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Fetching
             responseDocument.SingleData.Attributes["description"].Should().Be(workItem.Description);
             responseDocument.SingleData.Attributes["dueAt"].Should().BeCloseTo(workItem.DueAt);
             responseDocument.SingleData.Attributes["priority"].Should().Be(workItem.Priority.ToString("G"));
+            responseDocument.SingleData.Relationships.Should().NotBeEmpty();
         }
 
         [Fact]
@@ -157,6 +160,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Fetching
             responseDocument.SingleData.Id.Should().Be(workItem.Assignee.StringId);
             responseDocument.SingleData.Attributes["firstName"].Should().Be(workItem.Assignee.FirstName);
             responseDocument.SingleData.Attributes["lastName"].Should().Be(workItem.Assignee.LastName);
+            responseDocument.SingleData.Relationships.Should().NotBeEmpty();
         }
 
         [Fact]
@@ -210,12 +214,14 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Fetching
             item1.Attributes["description"].Should().Be(userAccount.AssignedItems.ElementAt(0).Description);
             item1.Attributes["dueAt"].Should().BeCloseTo(userAccount.AssignedItems.ElementAt(0).DueAt);
             item1.Attributes["priority"].Should().Be(userAccount.AssignedItems.ElementAt(0).Priority.ToString("G"));
-            
+            item1.Relationships.Should().NotBeEmpty();
+
             var item2 = responseDocument.ManyData.Single(resource => resource.Id == userAccount.AssignedItems.ElementAt(1).StringId);
             item2.Type.Should().Be("workItems");
             item2.Attributes["description"].Should().Be(userAccount.AssignedItems.ElementAt(1).Description);
             item2.Attributes["dueAt"].Should().BeCloseTo(userAccount.AssignedItems.ElementAt(1).DueAt);
             item2.Attributes["priority"].Should().Be(userAccount.AssignedItems.ElementAt(1).Priority.ToString("G"));
+            item2.Relationships.Should().NotBeEmpty();
         }
 
         [Fact]
@@ -278,11 +284,13 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Fetching
             item1.Type.Should().Be("workTags");
             item1.Attributes["text"].Should().Be(workItem.WorkItemTags.ElementAt(0).Tag.Text);
             item1.Attributes["isBuiltIn"].Should().Be(workItem.WorkItemTags.ElementAt(0).Tag.IsBuiltIn);
-            
+            item1.Relationships.Should().BeNull();
+
             var item2 = responseDocument.ManyData.Single(resource => resource.Id == workItem.WorkItemTags.ElementAt(1).Tag.StringId);
             item2.Type.Should().Be("workTags");
             item2.Attributes["text"].Should().Be(workItem.WorkItemTags.ElementAt(1).Tag.Text);
             item2.Attributes["isBuiltIn"].Should().Be(workItem.WorkItemTags.ElementAt(1).Tag.IsBuiltIn);
+            item2.Relationships.Should().BeNull();
         }
 
         [Fact]

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateResourceTests.cs
@@ -195,7 +195,6 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
             responseDocument.SingleData.Id.Should().Be(existingGroup.StringId);
             responseDocument.SingleData.Attributes["name"].Should().Be(newName);
             responseDocument.SingleData.Attributes["isPublic"].Should().Be(existingGroup.IsPublic);
-
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -348,7 +347,6 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
             responseDocument.SingleData.Attributes["dueAt"].Should().BeNull();
             responseDocument.SingleData.Attributes["priority"].Should().Be(existingWorkItem.Priority.ToString("G"));
             responseDocument.SingleData.Attributes.Should().ContainKey("concurrencyToken");
-
             responseDocument.SingleData.Relationships.Should().NotBeEmpty();
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -389,7 +387,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
                 }
             };
 
-            var route = $"/workItems/{existingWorkItem.StringId}?fields=description,priority";
+            var route = $"/workItems/{existingWorkItem.StringId}?fields[workItems]=description,priority";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecutePatchAsync<Document>(route, requestBody);
@@ -403,8 +401,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
             responseDocument.SingleData.Attributes.Should().HaveCount(2);
             responseDocument.SingleData.Attributes["description"].Should().Be(newDescription);
             responseDocument.SingleData.Attributes["priority"].Should().Be(existingWorkItem.Priority.ToString("G"));
-
-            responseDocument.SingleData.Relationships.Should().NotBeEmpty();
+            responseDocument.SingleData.Relationships.Should().BeNull();
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
             {
@@ -452,7 +449,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
                 }
             };
 
-            var route = $"/workItems/{existingWorkItem.StringId}?fields=description,priority&include=tags&fields[tags]=text";
+            var route = $"/workItems/{existingWorkItem.StringId}?fields[workItems]=description,priority,tags&include=tags&fields[workTags]=text";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecutePatchAsync<Document>(route, requestBody);
@@ -466,8 +463,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
             responseDocument.SingleData.Attributes.Should().HaveCount(2);
             responseDocument.SingleData.Attributes["description"].Should().Be(newDescription);
             responseDocument.SingleData.Attributes["priority"].Should().Be(existingWorkItem.Priority.ToString("G"));
-
-            responseDocument.SingleData.Relationships.Should().ContainKey("tags");
+            responseDocument.SingleData.Relationships.Should().HaveCount(1);
             responseDocument.SingleData.Relationships["tags"].ManyData.Should().HaveCount(1);
             responseDocument.SingleData.Relationships["tags"].ManyData[0].Id.Should().Be(existingWorkItem.WorkItemTags.Single().Tag.StringId);
 
@@ -476,6 +472,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
             responseDocument.Included[0].Id.Should().Be(existingWorkItem.WorkItemTags.Single().Tag.StringId);
             responseDocument.Included[0].Attributes.Should().HaveCount(1);
             responseDocument.Included[0].Attributes["text"].Should().Be(existingWorkItem.WorkItemTags.Single().Tag.Text);
+            responseDocument.Included[0].Relationships.Should().BeNull();
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
             {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateToOneRelationshipTests.cs
@@ -352,6 +352,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
             responseDocument.Included[0].Id.Should().Be(existingUserAccount.StringId);
             responseDocument.Included[0].Attributes["firstName"].Should().Be(existingUserAccount.FirstName);
             responseDocument.Included[0].Attributes["lastName"].Should().Be(existingUserAccount.LastName);
+            responseDocument.Included[0].Relationships.Should().NotBeEmpty();
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
             {
@@ -399,7 +400,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
                 }
             };
 
-            var route = $"/workItems/{existingWorkItem.StringId}?fields=description&include=assignee&fields[assignee]=lastName";
+            var route = $"/workItems/{existingWorkItem.StringId}?fields[workItems]=description,assignee&include=assignee&fields[userAccounts]=lastName";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecutePatchAsync<Document>(route, requestBody);
@@ -412,13 +413,15 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
             responseDocument.SingleData.Id.Should().Be(existingWorkItem.StringId);
             responseDocument.SingleData.Attributes.Should().HaveCount(1);
             responseDocument.SingleData.Attributes["description"].Should().Be(existingWorkItem.Description);
-            responseDocument.SingleData.Relationships.Should().NotBeEmpty();
+            responseDocument.SingleData.Relationships.Should().HaveCount(1);
+            responseDocument.SingleData.Relationships["assignee"].SingleData.Id.Should().Be(existingUserAccount.StringId);
             
             responseDocument.Included.Should().HaveCount(1);
             responseDocument.Included[0].Type.Should().Be("userAccounts");
             responseDocument.Included[0].Id.Should().Be(existingUserAccount.StringId);
             responseDocument.Included[0].Attributes.Should().HaveCount(1);
             responseDocument.Included[0].Attributes["lastName"].Should().Be(existingUserAccount.LastName);
+            responseDocument.Included[0].Relationships.Should().BeNull();
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
             {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ResourceDefinitions/ResourceDefinitionQueryCallbackTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ResourceDefinitions/ResourceDefinitionQueryCallbackTests.cs
@@ -338,7 +338,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
                 await dbContext.SaveChangesAsync();
             });
 
-            var route = $"/callableResources/{resource.StringId}?fields=label,status";
+            var route = $"/callableResources/{resource.StringId}?fields[callableResources]=label,status";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
@@ -351,6 +351,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
             responseDocument.SingleData.Attributes.Should().HaveCount(2);
             responseDocument.SingleData.Attributes["label"].Should().Be(resource.Label);
             responseDocument.SingleData.Attributes["status"].Should().Be("5% completed.");
+            responseDocument.SingleData.Relationships.Should().BeNull();
         }
         
         [Fact]
@@ -401,7 +402,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
                 await dbContext.SaveChangesAsync();
             });
 
-            var route = $"/callableResources/{resource.StringId}?fields=label,riskLevel";
+            var route = $"/callableResources/{resource.StringId}?fields[callableResources]=label,riskLevel";
 
             // Act
             var (httpResponse, responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
@@ -413,6 +414,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
             responseDocument.SingleData.Id.Should().Be(resource.StringId);
             responseDocument.SingleData.Attributes.Should().HaveCount(1);
             responseDocument.SingleData.Attributes["label"].Should().Be(resource.Label);
+            responseDocument.SingleData.Relationships.Should().BeNull();
         }
 
         [Fact]

--- a/test/UnitTests/Serialization/SerializerTestsSetup.cs
+++ b/test/UnitTests/Serialization/SerializerTestsSetup.cs
@@ -60,7 +60,7 @@ namespace UnitTests.Serialization
 
         private IIncludedResourceObjectBuilder GetIncludedBuilder()
         {
-            return new IncludedResourceObjectBuilder(GetSerializableFields(), GetLinkBuilder(), _resourceGraph, GetResourceDefinitionAccessor(), GetSerializerSettingsProvider());
+            return new IncludedResourceObjectBuilder(GetSerializableFields(), GetLinkBuilder(), _resourceGraph, Enumerable.Empty<IQueryConstraintProvider>(), GetResourceDefinitionAccessor(), GetSerializerSettingsProvider());
         }
 
         protected IResourceObjectBuilderSettingsProvider GetSerializerSettingsProvider()
@@ -95,7 +95,7 @@ namespace UnitTests.Serialization
         protected IFieldsToSerialize GetSerializableFields()
         {
             var mock = new Mock<IFieldsToSerialize>();
-            mock.Setup(m => m.GetAttributes(It.IsAny<Type>(), It.IsAny<RelationshipAttribute>())).Returns<Type, RelationshipAttribute>((t, r) => _resourceGraph.GetResourceContext(t).Attributes);
+            mock.Setup(m => m.GetAttributes(It.IsAny<Type>())).Returns<Type>(t => _resourceGraph.GetResourceContext(t).Attributes);
             mock.Setup(m => m.GetRelationships(It.IsAny<Type>())).Returns<Type>(t => _resourceGraph.GetResourceContext(t).Relationships);
             return mock.Object;
         }

--- a/test/UnitTests/Serialization/Server/IncludedResourceObjectBuilderTests.cs
+++ b/test/UnitTests/Serialization/Server/IncludedResourceObjectBuilderTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using JsonApiDotNetCore.Queries;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 using JsonApiDotNetCore.Serialization.Building;
@@ -171,7 +172,7 @@ namespace UnitTests.Serialization.Server
             var links = GetLinkBuilder();
 
             var accessor = new Mock<IResourceDefinitionAccessor>().Object;
-            return new IncludedResourceObjectBuilder(fields, links, _resourceGraph, accessor, GetSerializerSettingsProvider());
+            return new IncludedResourceObjectBuilder(fields, links, _resourceGraph, Enumerable.Empty<IQueryConstraintProvider>(), accessor, GetSerializerSettingsProvider());
         }
     }
 }

--- a/test/e2e/postman/JADNC_GettingStarted_PostmanCollection.json
+++ b/test/e2e/postman/JADNC_GettingStarted_PostmanCollection.json
@@ -142,7 +142,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{host}}/api/books?fields=title",
+					"raw": "{{host}}/api/books?fields[books]=title",
 					"host": [
 						"{{host}}"
 					],
@@ -152,7 +152,7 @@
 					],
 					"query": [
 						{
-							"key": "fields",
+							"key": "fields[books]",
 							"value": "title"
 						}
 					]


### PR DESCRIPTION
Changes the use of `fields` query string parameter to be json:api spec compliant.

Before we'd accept a relationship path between the square brackets and would only allow attribute names in the value. Now we expect a resource type between square brackets and the value can contain both attributes and relationships.

Based on explanation at https://jsonapi.org/examples/#sparse-fieldsets.