### PR TITLE
Naming consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 <img src ="https://raw.githubusercontent.com/json-api-dotnet/JsonApiDotnetCore/master/logo.png" />
 </p>
 
-# JSON:API Framework for ASP.NET Core
+# JsonApiDotNetCore
+A framework for building [JSON:API](http://jsonapi.org/) compliant REST APIs using .NET Core and Entity Framework Core.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/5go47hrm0iik0ls3/branch/master?svg=true)](https://ci.appveyor.com/project/jaredcnance/jsonapidotnetcore/branch/master)
 [![Travis](https://travis-ci.org/json-api-dotnet/JsonApiDotNetCore.svg?branch=master)](https://travis-ci.org/json-api-dotnet/JsonApiDotNetCore)
@@ -10,14 +11,14 @@
 [![Join the chat at https://gitter.im/json-api-dotnet-core/Lobby](https://badges.gitter.im/json-api-dotnet-core/Lobby.svg)](https://gitter.im/json-api-dotnet-core/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![FIRST-TIMERS](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](http://www.firsttimersonly.com/)
 
-A framework for building [json:api](http://jsonapi.org/) compliant web APIs. The ultimate goal of this library is to eliminate as much boilerplate as possible by offering out-of-the-box features such as sorting, filtering and pagination. You just need to focus on defining the resources and implementing your custom business logic. This library has been designed around dependency injection making extensibility incredibly easy.
+The ultimate goal of this library is to eliminate as much boilerplate as possible by offering out-of-the-box features such as sorting, filtering and pagination. You just need to focus on defining the resources and implementing your custom business logic. This library has been designed around dependency injection, making extensibility incredibly easy.
 
 ## Getting Started
 
 These are some steps you can take to help you understand what this project is and how you can use it:
 
-- [What is json:api and why should I use it?](https://nordicapis.com/the-benefits-of-using-json-api/)
-- [The json:api specification](http://jsonapi.org/format/)
+- [What is JSON:API and why should I use it?](https://nordicapis.com/the-benefits-of-using-json-api/)
+- [The JSON:API specification](http://jsonapi.org/format/)
 - [Demo [Video]](https://youtu.be/KAMuo6K7VcE)
 - [Our documentation](https://json-api-dotnet.github.io/JsonApiDotNetCore/)
 - [Check out the example projects](https://github.com/json-api-dotnet/JsonApiDotNetCore/tree/master/src/Examples)

--- a/docs/home/index.html
+++ b/docs/home/index.html
@@ -3,9 +3,9 @@
    <head>
       <meta charset="utf-8">
       <meta content="width=device-width, initial-scale=1.0" name="viewport">
-      <title>JSON:API .NET Core</title>
-      <meta content="A framework for building json:api compliant REST APIs using .NET Core and Entity Framework Core" name="description">
-      <meta content="jsonapidotnetcore jsonapi json:api dotnetcore" name="keywords">
+      <title>JsonApiDotNetCore documentation</title>
+      <meta content="A framework for building JSON:API compliant REST APIs using .NET Core and Entity Framework Core" name="description">
+      <meta content="jsonapidotnetcore jsonapi json:api dotnet asp.net" name="keywords">
       <link href="favicon.ico" rel="icon">
       <link href="favicon.ico" rel="apple-touch-icon">
       <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Raleway:300,300i,400,400i,600,600i,700,700i" rel="stylesheet">
@@ -21,8 +21,8 @@
          <div class="container">
             <div class="row">
                <div class="col-lg-7 pt-5 pt-lg-0 order-2 order-lg-1">
-                  <h1>JSON:API .NET Core</h1>
-                  <h2>A framework for building <a href="https://jsonapi.org/" target="_blank">json:api</a> compliant REST APIs using .NET Core and Entity Framework Core</h2>
+                  <h1>JsonApiDotNetCore</h1>
+                  <h2>A framework for building <a href="https://jsonapi.org/" target="_blank">JSON:API</a> compliant REST APIs using .NET Core and Entity Framework Core</h2>
                   <a href="#about" class="btn-get-started scrollto">Read more</a>
                   <a href="../../getting-started/install.html" class="btn-get-started">Getting started</a>
                   <a href="https://github.com/json-api-dotnet/JsonApiDotNetCore/" target="_blank" class="btn-get-started">Contribute on GitHub</a>
@@ -43,7 +43,7 @@
                   <div class="col-lg-6 pt-5 pt-lg-0">
                      <h3 data-aos="fade-up">Objectives</h3>
                      <p data-aos="fade-up" data-aos-delay="100">
-                        The goal of this library is to simplify the development of APIs that leverage the full range of features provided by the <a href="https://jsonapi.org/" target="_blank">json:api</a> specification.
+                        The goal of this library is to simplify the development of APIs that leverage the full range of features provided by the <a href="https://jsonapi.org/" target="_blank">JSON:API</a> specification.
                         You just need to focus on defining the resources and implementing your custom business logic.
                      </p>
                      <div class="row">

--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -2,7 +2,7 @@
 
 Errors returned will contain only the properties that are set on the `Error` class. Custom fields can be added through `Error.Meta`.
 You can create a custom error by throwing a `JsonApiException` (which accepts an `Error` instance), or returning an `Error` instance from an `ActionResult` in a controller.
-Please keep in mind that json:api requires Title to be a generic message, while Detail should contain information about the specific problem occurence.
+Please keep in mind that JSON:API requires Title to be a generic message, while Detail should contain information about the specific problem occurence.
 
 From a controller method:
 ```c#
@@ -22,7 +22,7 @@ throw new JsonApiException(new Error(HttpStatusCode.Conflict)
 });
 ```
 
-In both cases, the middleware will properly serialize it and return it as a json:api error.
+In both cases, the middleware will properly serialize it and return it as a JSON:API error.
 
 # Exception handling
 

--- a/docs/usage/meta.md
+++ b/docs/usage/meta.md
@@ -1,6 +1,6 @@
 # Metadata
 
-We support two ways to add json:api meta to your responses: global and per resource.
+We support two ways to add JSON:API meta to your responses: global and per resource.
 
 ## Global Meta
 

--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -64,7 +64,7 @@ options.UseRelativeLinks = true;
 
 ## Unknown Query String Parameters
 
-If you would like to allow unknown query string parameters (parameters not reserved by the json:api specification or registered using resource definitions), you can set `AllowUnknownQueryStringParameters = true`. When set to `false` (the default), an HTTP 400 Bad Request is returned for unknown query string parameters.
+If you would like to allow unknown query string parameters (parameters not reserved by the JSON:API specification or registered using resource definitions), you can set `AllowUnknownQueryStringParameters = true`. When set to `false` (the default), an HTTP 400 Bad Request is returned for unknown query string parameters.
 
 ```c#
 options.AllowUnknownQueryStringParameters = true;

--- a/docs/usage/resource-graph.md
+++ b/docs/usage/resource-graph.md
@@ -2,7 +2,7 @@
 
 _NOTE: prior to v4 this was called the `ContextGraph`_
 
-The `ResourceGraph` is a map of all the json:api resources and their relationships that your API serves.
+The `ResourceGraph` is a map of all the JSON:API resources and their relationships that your API serves.
 
 It is built at app startup and available as a singleton through Dependency Injection.
 
@@ -21,7 +21,7 @@ is prioritized by the list above in descending order.
 ### Auto-discovery
 
 Auto-discovery refers to the process of reflecting on an assembly and
-detecting all of the json:api resources, resource definitions, resource services and repositories.
+detecting all of the JSON:API resources, resource definitions, resource services and repositories.
 
 The following command builds the resource graph using all `IIdentifiable` implementations and registers the services mentioned.
 You can enable auto-discovery for the current assembly by adding the following to your `Startup` class.
@@ -73,7 +73,7 @@ public void ConfigureServices(IServiceCollection services)
 
 ## Resource Name
 
-The public resource name is exposed through the `type` member in the json:api payload. This can be configured by the following approaches (in order of priority):
+The public resource name is exposed through the `type` member in the JSON:API payload. This can be configured by the following approaches (in order of priority):
 
 1. The `publicName` parameter when manually adding a resource to the graph
 ```c#

--- a/docs/usage/resources/attributes.md
+++ b/docs/usage/resources/attributes.md
@@ -29,7 +29,7 @@ public class Person : Identifiable
 
 _since v4.0_
 
-Default json:api attribute capabilities are specified in @JsonApiDotNetCore.Configuration.JsonApiOptions#JsonApiDotNetCore_Configuration_JsonApiOptions_DefaultAttrCapabilities:
+Default JSON:API attribute capabilities are specified in @JsonApiDotNetCore.Configuration.JsonApiOptions#JsonApiDotNetCore_Configuration_JsonApiOptions_DefaultAttrCapabilities:
 
 ```c#
 options.DefaultAttrCapabilities = AttrCapabilities.None; // default: All

--- a/docs/usage/resources/relationships.md
+++ b/docs/usage/resources/relationships.md
@@ -77,7 +77,7 @@ public class TodoItem : Identifiable
 
 _since v4.0_
 
-Your resource may expose a calculated property, whose value depends on a related entity that is not exposed as a json:api resource.
+Your resource may expose a calculated property, whose value depends on a related entity that is not exposed as a JSON:API resource.
 So for the calculated property to be evaluated correctly, the related entity must always be retrieved. You can achieve that using `EagerLoad`, for example:
 
 ```c#

--- a/docs/usage/resources/resource-definitions.md
+++ b/docs/usage/resources/resource-definitions.md
@@ -13,7 +13,7 @@ For various reasons (see examples below) you may need to change parts of the que
 `JsonApiResourceDefinition<TResource>` (which is an empty implementation of `IResourceDefinition<TResource>`) provides overridable methods that pass you the result of query string parameter parsing.
 The value returned by you determines what will be used to execute the query.
 
-An intermediate format (`QueryExpression` and derived types) is used, which enables us to separate json:api implementation 
+An intermediate format (`QueryExpression` and derived types) is used, which enables us to separate JSON:API implementation 
 from Entity Framework Core `IQueryable` execution.
 
 ### Excluding fields

--- a/docs/usage/routing.md
+++ b/docs/usage/routing.md
@@ -14,7 +14,7 @@ Which results in URLs like: https://yourdomain.com/api/v1/people
 
 ## Default Routing Convention
 
-The library will configure routes for all controllers in your project. By default, routes are camel-cased. This is based on the [recommendations](https://jsonapi.org/recommendations/) outlined in the json:api spec.
+The library will configure routes for all controllers in your project. By default, routes are camel-cased. This is based on the [recommendations](https://jsonapi.org/recommendations/) outlined in the JSON:API spec.
 
 ```c#
 public class OrderLine : Identifiable { }
@@ -35,7 +35,7 @@ GET /orderLines HTTP/1.1
 
 The exposed name of the resource ([which can be customized](~/usage/resource-graph.md#resource-name)) is used for the route, instead of the controller name.
 
-### Non-json:api controllers
+### Non-JSON:API controllers
 
 If a controller does not inherit from `JsonApiController<TResource>`, the [configured naming convention](~/usage/options.md#custom-serializer-settings) is applied to the name of the controller.
 ```c#

--- a/src/JsonApiDotNetCore/Configuration/IJsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/IJsonApiOptions.cs
@@ -56,21 +56,21 @@ namespace JsonApiDotNetCore.Configuration
         bool UseRelativeLinks { get; }
 
         /// <summary>
-        /// Configures globally which links to show in the <see cref="TopLevelLinks"/>
+        /// Configures globally which links to show in the <see cref="Serialization.Objects.TopLevelLinks"/>
         /// object for a requested resource. Setting can be overridden per resource by
         /// adding a <see cref="ResourceLinksAttribute"/> to the class definition of that resource.
         /// </summary>
         LinkTypes TopLevelLinks { get; }
 
         /// <summary>
-        /// Configures globally which links to show in the <see cref="ResourceLinks"/>
+        /// Configures globally which links to show in the <see cref="Serialization.Objects.ResourceLinks"/>
         /// object for a requested resource. Setting can be overridden per resource by
         /// adding a <see cref="ResourceLinksAttribute"/> to the class definition of that resource.
         /// </summary>
         LinkTypes ResourceLinks { get; }
 
         /// <summary>
-        /// Configures globally which links to show in the <see cref="RelationshipLinks"/>
+        /// Configures globally which links to show in the <see cref="Serialization.Objects.RelationshipLinks"/>
         /// object for a requested resource. Setting can be overridden per resource by
         /// adding a <see cref="ResourceLinksAttribute"/> to the class definition of that resource.
         /// This option can also be specified per relationship by using the associated links argument

--- a/src/JsonApiDotNetCore/Configuration/IJsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/IJsonApiOptions.cs
@@ -20,7 +20,7 @@ namespace JsonApiDotNetCore.Configuration
         string Namespace { get; }
 
         /// <summary>
-        /// Specifies the default query string capabilities that can be used on exposed json:api attributes.
+        /// Specifies the default query string capabilities that can be used on exposed JSON:API attributes.
         /// Defaults to <see cref="AttrCapabilities.All"/>.
         /// </summary>
         AttrCapabilities DefaultAttrCapabilities { get; }
@@ -174,7 +174,7 @@ namespace JsonApiDotNetCore.Configuration
 
         /// <summary>
         /// Specifies the settings that are used by the <see cref="JsonSerializer"/>.
-        /// Note that at some places a few settings are ignored, to ensure json:api spec compliance.
+        /// Note that at some places a few settings are ignored, to ensure JSON:API spec compliance.
         /// <example>
         /// The next example changes the naming convention to kebab casing.
         /// <code><![CDATA[

--- a/src/JsonApiDotNetCore/Configuration/JsonApiMetadataProvider.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiMetadataProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 namespace JsonApiDotNetCore.Configuration
 {
     /// <summary>
-    /// Custom implementation of <see cref="IModelMetadataProvider"/> to support json:api partial patching.
+    /// Custom implementation of <see cref="IModelMetadataProvider"/> to support JSON:API partial patching.
     /// </summary>
     internal class JsonApiModelMetadataProvider : DefaultModelMetadataProvider
     {

--- a/src/JsonApiDotNetCore/Configuration/JsonApiValidationFilter.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiValidationFilter.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace JsonApiDotNetCore.Configuration
 {
     /// <summary>
-    /// Validation filter that blocks ASP.NET Core ModelState validation on data according to the json:api spec.
+    /// Validation filter that blocks ASP.NET Core ModelState validation on data according to the JSON:API spec.
     /// </summary>
     internal sealed class JsonApiValidationFilter : IPropertyValidationFilter
     {

--- a/src/JsonApiDotNetCore/Configuration/ResourceContext.cs
+++ b/src/JsonApiDotNetCore/Configuration/ResourceContext.cs
@@ -51,7 +51,7 @@ namespace JsonApiDotNetCore.Configuration
         public IReadOnlyCollection<ResourceFieldAttribute> Fields => _fields ??= Attributes.Cast<ResourceFieldAttribute>().Concat(Relationships).ToArray();
 
         /// <summary>
-        /// Configures which links to show in the <see cref="TopLevelLinks"/>
+        /// Configures which links to show in the <see cref="Serialization.Objects.TopLevelLinks"/>
         /// object for this resource. If set to <see cref="LinkTypes.NotConfigured"/>,
         /// the configuration will be read from <see cref="IJsonApiOptions"/>.
         /// Defaults to <see cref="LinkTypes.NotConfigured"/>.
@@ -59,7 +59,7 @@ namespace JsonApiDotNetCore.Configuration
         public LinkTypes TopLevelLinks { get; internal set; } = LinkTypes.NotConfigured;
 
         /// <summary>
-        /// Configures which links to show in the <see cref="ResourceLinks"/>
+        /// Configures which links to show in the <see cref="Serialization.Objects.ResourceLinks"/>
         /// object for this resource. If set to <see cref="LinkTypes.NotConfigured"/>,
         /// the configuration will be read from <see cref="IJsonApiOptions"/>.
         /// Defaults to <see cref="LinkTypes.NotConfigured"/>.
@@ -67,7 +67,7 @@ namespace JsonApiDotNetCore.Configuration
         public LinkTypes ResourceLinks { get; internal set; } = LinkTypes.NotConfigured;
 
         /// <summary>
-        /// Configures which links to show in the <see cref="RelationshipLinks"/>
+        /// Configures which links to show in the <see cref="Serialization.Objects.RelationshipLinks"/>
         /// for all relationships of the resource for which this attribute was instantiated.
         /// If set to <see cref="LinkTypes.NotConfigured"/>, the configuration will
         /// be read from <see cref="RelationshipAttribute.Links"/>  or

--- a/src/JsonApiDotNetCore/Configuration/ResourceGraph.cs
+++ b/src/JsonApiDotNetCore/Configuration/ResourceGraph.cs
@@ -169,7 +169,7 @@ namespace JsonApiDotNetCore.Configuration
 
         private void ThrowNotExposedError(string memberName, FieldFilterType type)
         {
-            throw new ArgumentException($"{memberName} is not an json:api exposed {type:g}.");
+            throw new ArgumentException($"{memberName} is not a JSON:API exposed {type:g}.");
         }
 
         private enum FieldFilterType

--- a/src/JsonApiDotNetCore/Configuration/ResourceGraphBuilder.cs
+++ b/src/JsonApiDotNetCore/Configuration/ResourceGraphBuilder.cs
@@ -47,7 +47,7 @@ namespace JsonApiDotNetCore.Configuration
         }
         
         /// <summary>
-        /// Adds a json:api resource with <code>int</code> as the identifier type.
+        /// Adds a JSON:API resource with <code>int</code> as the identifier type.
         /// </summary>
         /// <typeparam name="TResource">The resource model type.</typeparam>
         /// <param name="publicName">
@@ -58,7 +58,7 @@ namespace JsonApiDotNetCore.Configuration
             => Add<TResource, int>(publicName);
         
         /// <summary>
-        /// Adds a json:api resource.
+        /// Adds a JSON:API resource.
         /// </summary>
         /// <typeparam name="TResource">The resource model type.</typeparam>
         /// <typeparam name="TId">The resource model identifier type.</typeparam>
@@ -70,7 +70,7 @@ namespace JsonApiDotNetCore.Configuration
             => Add(typeof(TResource), typeof(TId), publicName);
         
         /// <summary>
-        /// Adds a json:api resource.
+        /// Adds a JSON:API resource.
         /// </summary>
         /// <param name="resourceType">The resource model type.</param>
         /// <param name="idType">The resource model identifier type.</param>

--- a/src/JsonApiDotNetCore/Configuration/ServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore/Configuration/ServiceCollectionExtensions.cs
@@ -61,7 +61,7 @@ namespace JsonApiDotNetCore.Configuration
         
         /// <summary>
         /// Enables client serializers for sending requests and receiving responses
-        /// in json:api format. Internally only used for testing.
+        /// in JSON:API format. Internally only used for testing.
         /// Will be extended in the future to be part of a JsonApiClientDotNetCore package.
         /// </summary>
         public static IServiceCollection AddClientSerialization(this IServiceCollection services)

--- a/src/JsonApiDotNetCore/Controllers/CoreJsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/CoreJsonApiController.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace JsonApiDotNetCore.Controllers
 {
     /// <summary>
-    /// Provides helper methods to raise json:api compliant errors from controller actions.
+    /// Provides helper methods to raise JSON:API compliant errors from controller actions.
     /// </summary>
     public abstract class CoreJsonApiController : ControllerBase
     {

--- a/src/JsonApiDotNetCore/Errors/JsonApiException.cs
+++ b/src/JsonApiDotNetCore/Errors/JsonApiException.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 namespace JsonApiDotNetCore.Errors
 {
     /// <summary>
-    /// The base class for an <see cref="Exception"/> that represents one or more json:api error objects in an unsuccessful response.
+    /// The base class for an <see cref="Exception"/> that represents one or more JSON:API error objects in an unsuccessful response.
     /// </summary>
     public class JsonApiException : Exception
     {

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageTags>jsonapi;json:api;dotnet;core</PackageTags>
-    <Description>A framework for building json:api compliant web APIs. The ultimate goal of this library is to eliminate as much boilerplate as possible by offering out-of-the-box features such as sorting, filtering and pagination. You just need to focus on defining the resources and implementing your custom business logic. This library has been designed around dependency injection making extensibility incredibly easy.</Description>
+    <PackageTags>jsonapidotnetcore;jsonapi;json:api;dotnet;asp.net</PackageTags>
+    <Description>A framework for building JSON:API compliant web APIs. The ultimate goal of this library is to eliminate as much boilerplate as possible by offering out-of-the-box features such as sorting, filtering and pagination. You just need to focus on defining the resources and implementing your custom business logic. This library has been designed around dependency injection making extensibility incredibly easy.</Description>
     <PackageProjectUrl>https://github.com/json-api-dotnet/JsonApiDotNetCore</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/JsonApiDotNetCore/Middleware/IAsyncConvertEmptyActionResultFilter.cs
+++ b/src/JsonApiDotNetCore/Middleware/IAsyncConvertEmptyActionResultFilter.cs
@@ -5,7 +5,7 @@ namespace JsonApiDotNetCore.Middleware
     /// <summary>
     /// Converts action result without parameters into action result with null parameter.
     /// For example: return NotFound() -> return NotFound(null)
-    /// This ensures our formatter is invoked, where we'll build a json:api compliant response.
+    /// This ensures our formatter is invoked, where we'll build a JSON:API compliant response.
     /// For details, see: https://github.com/dotnet/aspnetcore/issues/16969
     /// </summary>
     public interface IAsyncConvertEmptyActionResultFilter : IAsyncAlwaysRunResultFilter { }

--- a/src/JsonApiDotNetCore/Middleware/IAsyncJsonApiExceptionFilter.cs
+++ b/src/JsonApiDotNetCore/Middleware/IAsyncJsonApiExceptionFilter.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 namespace JsonApiDotNetCore.Middleware
 {
     /// <summary>
-    /// Application-wide exception filter that invokes <see cref="IExceptionHandler"/> for json:api requests.
+    /// Application-wide exception filter that invokes <see cref="IExceptionHandler"/> for JSON:API requests.
     /// </summary>
     public interface IAsyncJsonApiExceptionFilter : IAsyncExceptionFilter { }
 }

--- a/src/JsonApiDotNetCore/Middleware/IAsyncQueryStringActionFilter.cs
+++ b/src/JsonApiDotNetCore/Middleware/IAsyncQueryStringActionFilter.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 namespace JsonApiDotNetCore.Middleware
 {
     /// <summary>
-    /// Application-wide entry point for processing json:api request query strings.
+    /// Application-wide entry point for processing JSON:API request query strings.
     /// </summary>
     public interface IAsyncQueryStringActionFilter : IAsyncActionFilter { }
 }

--- a/src/JsonApiDotNetCore/Middleware/IJsonApiInputFormatter.cs
+++ b/src/JsonApiDotNetCore/Middleware/IJsonApiInputFormatter.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 namespace JsonApiDotNetCore.Middleware
 {
     /// <summary>
-    /// Application-wide entry point for reading json:api request bodies.
+    /// Application-wide entry point for reading JSON:API request bodies.
     /// </summary>
     public interface IJsonApiInputFormatter : IInputFormatter { }
 }

--- a/src/JsonApiDotNetCore/Middleware/IJsonApiOutputFormatter.cs
+++ b/src/JsonApiDotNetCore/Middleware/IJsonApiOutputFormatter.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 namespace JsonApiDotNetCore.Middleware
 {
     /// <summary>
-    /// Application-wide entry point for writing json:api response bodies.
+    /// Application-wide entry point for writing JSON:API response bodies.
     /// </summary>
     public interface IJsonApiOutputFormatter : IOutputFormatter { }
 }

--- a/src/JsonApiDotNetCore/Middleware/IJsonApiRequest.cs
+++ b/src/JsonApiDotNetCore/Middleware/IJsonApiRequest.cs
@@ -4,7 +4,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCore.Middleware
 {
     /// <summary>
-    /// Metadata associated with the json:api request that is currently being processed.
+    /// Metadata associated with the JSON:API request that is currently being processed.
     /// </summary>
     public interface IJsonApiRequest
     {

--- a/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
@@ -19,7 +19,7 @@ using Newtonsoft.Json;
 namespace JsonApiDotNetCore.Middleware
 {
     /// <summary>
-    /// Intercepts HTTP requests to populate injected <see cref="IJsonApiRequest"/> instance for json:api requests.
+    /// Intercepts HTTP requests to populate injected <see cref="IJsonApiRequest"/> instance for JSON:API requests.
     /// </summary>
     public sealed class JsonApiMiddleware
     {

--- a/src/JsonApiDotNetCore/Resources/Annotations/AttrAttribute.cs
+++ b/src/JsonApiDotNetCore/Resources/Annotations/AttrAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace JsonApiDotNetCore.Resources.Annotations
 {
     /// <summary>
-    /// Used to expose a property on a resource class as a json:api attribute (https://jsonapi.org/format/#document-resource-object-attributes).
+    /// Used to expose a property on a resource class as a JSON:API attribute (https://jsonapi.org/format/#document-resource-object-attributes).
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class AttrAttribute : ResourceFieldAttribute

--- a/src/JsonApiDotNetCore/Resources/Annotations/EagerLoadAttribute.cs
+++ b/src/JsonApiDotNetCore/Resources/Annotations/EagerLoadAttribute.cs
@@ -5,10 +5,10 @@ using System.Reflection;
 namespace JsonApiDotNetCore.Resources.Annotations
 {
     /// <summary>
-    /// Used to unconditionally load a related entity that is not exposed as a json:api relationship.
+    /// Used to unconditionally load a related entity that is not exposed as a JSON:API relationship.
     /// </summary>
     /// <remarks>
-    /// This is intended for calculated properties that are exposed as json:api attributes, which depend on a related entity to always be loaded.
+    /// This is intended for calculated properties that are exposed as JSON:API attributes, which depend on a related entity to always be loaded.
     /// <example><![CDATA[
     /// public class User : Identifiable
     /// {

--- a/src/JsonApiDotNetCore/Resources/Annotations/HasManyAttribute.cs
+++ b/src/JsonApiDotNetCore/Resources/Annotations/HasManyAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace JsonApiDotNetCore.Resources.Annotations
 {
     /// <summary>
-    /// Used to expose a property on a resource class as a json:api to-many relationship (https://jsonapi.org/format/#document-resource-object-relationships).
+    /// Used to expose a property on a resource class as a JSON:API to-many relationship (https://jsonapi.org/format/#document-resource-object-relationships).
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class HasManyAttribute : RelationshipAttribute

--- a/src/JsonApiDotNetCore/Resources/Annotations/HasManyThroughAttribute.cs
+++ b/src/JsonApiDotNetCore/Resources/Annotations/HasManyThroughAttribute.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 namespace JsonApiDotNetCore.Resources.Annotations
 {
     /// <summary>
-    /// Used to expose a property on a resource class as a json:api to-many relationship (https://jsonapi.org/format/#document-resource-object-relationships)
+    /// Used to expose a property on a resource class as a JSON:API to-many relationship (https://jsonapi.org/format/#document-resource-object-relationships)
     /// through a many-to-many join relationship.
     /// </summary>
     /// <example>

--- a/src/JsonApiDotNetCore/Resources/Annotations/HasOneAttribute.cs
+++ b/src/JsonApiDotNetCore/Resources/Annotations/HasOneAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace JsonApiDotNetCore.Resources.Annotations
 {
     /// <summary>
-    /// Used to expose a property on a resource class as a json:api to-one relationship (https://jsonapi.org/format/#document-resource-object-relationships).
+    /// Used to expose a property on a resource class as a JSON:API to-one relationship (https://jsonapi.org/format/#document-resource-object-relationships).
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class HasOneAttribute : RelationshipAttribute

--- a/src/JsonApiDotNetCore/Resources/Annotations/RelationshipAttribute.cs
+++ b/src/JsonApiDotNetCore/Resources/Annotations/RelationshipAttribute.cs
@@ -6,7 +6,7 @@ using JsonApiDotNetCore.Errors;
 namespace JsonApiDotNetCore.Resources.Annotations
 {
     /// <summary>
-    /// Used to expose a property on a resource class as a json:api relationship (https://jsonapi.org/format/#document-resource-object-relationships).
+    /// Used to expose a property on a resource class as a JSON:API relationship (https://jsonapi.org/format/#document-resource-object-relationships).
     /// </summary>
     public abstract class RelationshipAttribute : ResourceFieldAttribute
     {
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Resources.Annotations
 
         /// <summary>
         /// The property name of the EF Core inverse navigation, which may or may not exist.
-        /// Even if it exists, it may not be exposed as a json:api relationship.
+        /// Even if it exists, it may not be exposed as a JSON:API relationship.
         /// </summary>
         /// <example>
         /// <code><![CDATA[

--- a/src/JsonApiDotNetCore/Resources/Annotations/ResourceFieldAttribute.cs
+++ b/src/JsonApiDotNetCore/Resources/Annotations/ResourceFieldAttribute.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 namespace JsonApiDotNetCore.Resources.Annotations
 {
     /// <summary>
-    /// Used to expose a property on a resource class as a json:api field (attribute or relationship).
+    /// Used to expose a property on a resource class as a JSON:API field (attribute or relationship).
     /// See https://jsonapi.org/format/#document-resource-object-fields.
     /// </summary>
     public abstract class ResourceFieldAttribute : Attribute
@@ -12,7 +12,7 @@ namespace JsonApiDotNetCore.Resources.Annotations
         private string _publicName;
 
         /// <summary>
-        /// The publicly exposed name of this json:api field.
+        /// The publicly exposed name of this JSON:API field.
         /// When not explicitly assigned, the configured naming convention is applied on the property name.
         /// </summary>
         public string PublicName

--- a/src/JsonApiDotNetCore/Resources/Annotations/ResourceLinksAttribute.cs
+++ b/src/JsonApiDotNetCore/Resources/Annotations/ResourceLinksAttribute.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCore.Resources.Annotations
         private LinkTypes _relationshipLinks = LinkTypes.NotConfigured;
 
         /// <summary>
-        /// Configures which links to show in the <see cref="TopLevelLinks"/>
+        /// Configures which links to show in the <see cref="Serialization.Objects.TopLevelLinks"/>
         /// section for this resource.
         /// Defaults to <see cref="LinkTypes.NotConfigured"/>.
         /// </summary>
@@ -35,7 +35,7 @@ namespace JsonApiDotNetCore.Resources.Annotations
         }
 
         /// <summary>
-        /// Configures which links to show in the <see cref="ResourceLinks"/>
+        /// Configures which links to show in the <see cref="Serialization.Objects.ResourceLinks"/>
         /// section for this resource.
         /// Defaults to <see cref="LinkTypes.NotConfigured"/>.
         /// </summary>
@@ -54,7 +54,7 @@ namespace JsonApiDotNetCore.Resources.Annotations
         }
 
         /// <summary>
-        /// Configures which links to show in the <see cref="RelationshipLinks"/>
+        /// Configures which links to show in the <see cref="Serialization.Objects.RelationshipLinks"/>
         /// for all relationships of the resource type on which this attribute was used.
         /// Defaults to <see cref="LinkTypes.NotConfigured"/>.
         /// </summary>

--- a/src/JsonApiDotNetCore/Resources/IIdentifiable.cs
+++ b/src/JsonApiDotNetCore/Resources/IIdentifiable.cs
@@ -1,19 +1,19 @@
 namespace JsonApiDotNetCore.Resources
 {
     /// <summary>
-    /// When implemented by a class, indicates to JsonApiDotNetCore that the class represents a json:api resource.
+    /// When implemented by a class, indicates to JsonApiDotNetCore that the class represents a JSON:API resource.
     /// Note that JsonApiDotNetCore also assumes that a property named 'Id' exists.
     /// </summary>
     public interface IIdentifiable
     {
         /// <summary>
-        /// The value for element 'id' in a json:api request or response.
+        /// The value for element 'id' in a JSON:API request or response.
         /// </summary>
         string StringId { get; set; }
     }
 
     /// <summary>
-    /// When implemented by a class, indicates to JsonApiDotNetCore that the class represents a json:api resource.
+    /// When implemented by a class, indicates to JsonApiDotNetCore that the class represents a JSON:API resource.
     /// </summary>
     /// <typeparam name="TId">The resource identifier type.</typeparam>
     public interface IIdentifiable<TId> : IIdentifiable

--- a/src/JsonApiDotNetCore/Resources/IResourceDefinition.cs
+++ b/src/JsonApiDotNetCore/Resources/IResourceDefinition.cs
@@ -115,7 +115,7 @@ namespace JsonApiDotNetCore.Resources
         QueryStringParameterHandlers<TResource> OnRegisterQueryableHandlersForQueryStringParameters();
 
         /// <summary>
-        /// Enables to add json:api meta information, specific to this resource.
+        /// Enables to add JSON:API meta information, specific to this resource.
         /// </summary>
         IDictionary<string, object> GetMeta(TResource resource);
     }

--- a/src/JsonApiDotNetCore/Resources/Identifiable.cs
+++ b/src/JsonApiDotNetCore/Resources/Identifiable.cs
@@ -25,7 +25,7 @@ namespace JsonApiDotNetCore.Resources
         }
 
         /// <summary>
-        /// Converts an outgoing typed resource identifier to string format for use in a json:api response.
+        /// Converts an outgoing typed resource identifier to string format for use in a JSON:API response.
         /// </summary>
         protected virtual string GetStringId(TId value)
         {
@@ -33,7 +33,7 @@ namespace JsonApiDotNetCore.Resources
         }
 
         /// <summary>
-        /// Converts an incoming 'id' element from a json:api request to the typed resource identifier.
+        /// Converts an incoming 'id' element from a JSON:API request to the typed resource identifier.
         /// </summary>
         protected virtual TId GetTypedId(string value)
         {

--- a/src/JsonApiDotNetCore/Serialization/Building/ResourceObjectBuilderSettings.cs
+++ b/src/JsonApiDotNetCore/Serialization/Building/ResourceObjectBuilderSettings.cs
@@ -5,7 +5,7 @@ namespace JsonApiDotNetCore.Serialization.Building
 {
     /// <summary>
     /// Options used to configure how fields of a model get serialized into
-    /// a json:api <see cref="Document"/>.
+    /// a JSON:API <see cref="Document"/>.
     /// </summary>
     public sealed class ResourceObjectBuilderSettings
     {

--- a/src/JsonApiDotNetCore/Serialization/Building/ResponseResourceObjectBuilder.cs
+++ b/src/JsonApiDotNetCore/Serialization/Building/ResponseResourceObjectBuilder.cs
@@ -60,7 +60,7 @@ namespace JsonApiDotNetCore.Serialization.Building
         /// The server serializer only populates the "data" member when the relationship is included,
         /// and adds links unless these are turned off. This means that if a relationship is not included
         /// and links are turned off, the entry would be completely empty, ie { }, which is not conform
-        /// json:api spec. In that case we return null which will omit the entry from the output.
+        /// JSON:API spec. In that case we return null which will omit the entry from the output.
         /// </summary>
         protected override RelationshipEntry GetRelationshipData(RelationshipAttribute relationship, IIdentifiable resource)
         {

--- a/src/JsonApiDotNetCore/Serialization/Client/Internal/ResponseDeserializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/Client/Internal/ResponseDeserializer.cs
@@ -91,7 +91,7 @@ namespace JsonApiDotNetCore.Serialization.Client.Internal
 
             if (relatedResourceContext == null)
             {
-                throw new InvalidOperationException($"Included type '{relatedResourceIdentifier.Type}' is not a registered json:api resource.");
+                throw new InvalidOperationException($"Included type '{relatedResourceIdentifier.Type}' is not a registered JSON:API resource.");
             }
             
             var relatedInstance = ResourceFactory.CreateInstance(relatedResourceContext.ResourceType);

--- a/src/JsonApiDotNetCore/Serialization/IResponseMeta.cs
+++ b/src/JsonApiDotNetCore/Serialization/IResponseMeta.cs
@@ -5,13 +5,13 @@ using JsonApiDotNetCore.Serialization.Objects;
 namespace JsonApiDotNetCore.Serialization
 {
     /// <summary>
-    /// Provides a method to obtain global json:api meta, which is added at top-level to a response <see cref="Document"/>.
+    /// Provides a method to obtain global JSON:API meta, which is added at top-level to a response <see cref="Document"/>.
     /// Use <see cref="IResourceDefinition{TResource,TId}.GetMeta"/> to specify nested metadata per individual resource.
     /// </summary>
     public interface IResponseMeta
     {
         /// <summary>
-        /// Gets the global top-level json:api meta information to add to the response.
+        /// Gets the global top-level JSON:API meta information to add to the response.
         /// </summary>
         IReadOnlyDictionary<string, object> GetMeta();
     }

--- a/src/JsonApiDotNetCore/Serialization/JsonApiSerializationException.cs
+++ b/src/JsonApiDotNetCore/Serialization/JsonApiSerializationException.cs
@@ -3,7 +3,7 @@ using System;
 namespace JsonApiDotNetCore.Serialization
 {
     /// <summary>
-    /// The error that is thrown when (de)serialization of a json:api body fails.
+    /// The error that is thrown when (de)serialization of a JSON:API body fails.
     /// </summary>
     public class JsonApiSerializationException : Exception
     {

--- a/src/JsonApiDotNetCore/Serialization/Objects/Error.cs
+++ b/src/JsonApiDotNetCore/Serialization/Objects/Error.cs
@@ -7,7 +7,7 @@ namespace JsonApiDotNetCore.Serialization.Objects
 {
     /// <summary>
     /// Provides additional information about a problem encountered while performing an operation.
-    /// Error objects MUST be returned as an array keyed by errors in the top level of a json:api document.
+    /// Error objects MUST be returned as an array keyed by errors in the top level of a JSON:API document.
     /// </summary>
     public sealed class Error
     {

--- a/src/JsonApiDotNetCore/Serialization/ResponseSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/ResponseSerializer.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCore.Serialization
     /// Server serializer implementation of <see cref="BaseSerializer"/>
     /// </summary>
     /// <remarks>
-    /// Because in JsonApiDotNetCore every json:api request is associated with exactly one
+    /// Because in JsonApiDotNetCore every JSON:API request is associated with exactly one
     /// resource (the primary resource, see <see cref="IJsonApiRequest.PrimaryResource"/>),
     /// the serializer can leverage this information using generics.
     /// See <see cref="ResponseSerializerFactory"/> for how this is instantiated.

--- a/src/JsonApiDotNetCore/Services/IAddToRelationshipService.cs
+++ b/src/JsonApiDotNetCore/Services/IAddToRelationshipService.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCore.Services
         where TResource : class, IIdentifiable<TId>
     {
         /// <summary>
-        /// Handles a json:api request to add resources to a to-many relationship.
+        /// Handles a JSON:API request to add resources to a to-many relationship.
         /// </summary>
         /// <param name="primaryId">The identifier of the primary resource.</param>
         /// <param name="relationshipName">The relationship to add resources to.</param>

--- a/src/JsonApiDotNetCore/Services/ICreateService.cs
+++ b/src/JsonApiDotNetCore/Services/ICreateService.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Services
         where TResource : class, IIdentifiable<TId>
     {
         /// <summary>
-        /// Handles a json:api request to create a new resource with attributes, relationships or both.
+        /// Handles a JSON:API request to create a new resource with attributes, relationships or both.
         /// </summary>
         Task<TResource> CreateAsync(TResource resource, CancellationToken cancellationToken);
     }

--- a/src/JsonApiDotNetCore/Services/IDeleteService.cs
+++ b/src/JsonApiDotNetCore/Services/IDeleteService.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Services
         where TResource : class, IIdentifiable<TId>
     {
         /// <summary>
-        /// Handles a json:api request to delete an existing resource.
+        /// Handles a JSON:API request to delete an existing resource.
         /// </summary>
         Task DeleteAsync(TId id, CancellationToken cancellationToken);
     }

--- a/src/JsonApiDotNetCore/Services/IGetAllService.cs
+++ b/src/JsonApiDotNetCore/Services/IGetAllService.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCore.Services
         where TResource : class, IIdentifiable<TId>
     {
         /// <summary>
-        /// Handles a json:api request to retrieve a collection of resources for a primary endpoint.
+        /// Handles a JSON:API request to retrieve a collection of resources for a primary endpoint.
         /// </summary>
         Task<IReadOnlyCollection<TResource>> GetAsync(CancellationToken cancellationToken);
     }

--- a/src/JsonApiDotNetCore/Services/IGetByIdService.cs
+++ b/src/JsonApiDotNetCore/Services/IGetByIdService.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Services
         where TResource : class, IIdentifiable<TId>
     {
         /// <summary>
-        /// Handles a json:api request to retrieve a single resource for a primary endpoint.
+        /// Handles a JSON:API request to retrieve a single resource for a primary endpoint.
         /// </summary>
         Task<TResource> GetAsync(TId id, CancellationToken cancellationToken);
     }

--- a/src/JsonApiDotNetCore/Services/IGetRelationshipService.cs
+++ b/src/JsonApiDotNetCore/Services/IGetRelationshipService.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Services
         where TResource : class, IIdentifiable<TId>
     {
         /// <summary>
-        /// Handles a json:api request to retrieve a single relationship.
+        /// Handles a JSON:API request to retrieve a single relationship.
         /// </summary>
         Task<object> GetRelationshipAsync(TId id, string relationshipName, CancellationToken cancellationToken);
     }

--- a/src/JsonApiDotNetCore/Services/IGetSecondaryService.cs
+++ b/src/JsonApiDotNetCore/Services/IGetSecondaryService.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Services
         where TResource : class, IIdentifiable<TId>
     {
         /// <summary>
-        /// Handles a json:api request to retrieve a single resource or a collection of resources for a secondary endpoint, such as /articles/1/author or /articles/1/revisions.
+        /// Handles a JSON:API request to retrieve a single resource or a collection of resources for a secondary endpoint, such as /articles/1/author or /articles/1/revisions.
         /// </summary>
         Task<object> GetSecondaryAsync(TId id, string relationshipName, CancellationToken cancellationToken);
     }

--- a/src/JsonApiDotNetCore/Services/IRemoveFromRelationshipService.cs
+++ b/src/JsonApiDotNetCore/Services/IRemoveFromRelationshipService.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCore.Services
         where TResource : class, IIdentifiable<TId>
     {
         /// <summary>
-        /// Handles a json:api request to remove resources from a to-many relationship.
+        /// Handles a JSON:API request to remove resources from a to-many relationship.
         /// </summary>
         /// <param name="primaryId">The identifier of the primary resource.</param>
         /// <param name="relationshipName">The relationship to remove resources from.</param>

--- a/src/JsonApiDotNetCore/Services/ISetRelationshipService.cs
+++ b/src/JsonApiDotNetCore/Services/ISetRelationshipService.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Services
         where TResource : class, IIdentifiable<TId>
     {
         /// <summary>
-        /// Handles a json:api request to perform a complete replacement of a relationship on an existing resource.
+        /// Handles a JSON:API request to perform a complete replacement of a relationship on an existing resource.
         /// </summary>
         /// <param name="primaryId">The identifier of the primary resource.</param>
         /// <param name="relationshipName">The relationship for which to perform a complete replacement.</param>

--- a/src/JsonApiDotNetCore/Services/IUpdateService.cs
+++ b/src/JsonApiDotNetCore/Services/IUpdateService.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Services
         where TResource : class, IIdentifiable<TId>
     {
         /// <summary>
-        /// Handles a json:api request to update the attributes and/or relationships of an existing resource.
+        /// Handles a JSON:API request to update the attributes and/or relationships of an existing resource.
         /// Only the values of sent attributes are replaced. And only the values of sent relationships are replaced.
         /// </summary>
         Task<TResource> UpdateAsync(TId id, TResource resource, CancellationToken cancellationToken);

--- a/test/JsonApiDotNetCoreExampleTests/Helpers/Models/TodoItemClient.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Helpers/Models/TodoItemClient.cs
@@ -9,7 +9,7 @@ namespace JsonApiDotNetCoreExampleTests.Helpers.Models
     /// <summary>
     /// this "client" version of the <see cref="TodoItem"/> is required because the
     /// base property that is overridden here does not have a setter. For a model
-    /// defined on a json:api client, it would not make sense to have an exposed attribute
+    /// defined on a JSON:API client, it would not make sense to have an exposed attribute
     /// without a setter.
     /// </summary>
     public class TodoItemClient : TodoItem

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ObjectAssertionsExtensions.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ObjectAssertionsExtensions.cs
@@ -7,7 +7,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests
     public static class ObjectAssertionsExtensions
     {
         /// <summary>
-        /// Used to assert on a nullable <see cref="DateTimeOffset"/> column, whose value is returned as <see cref="DateTime"/> in json:api response body.
+        /// Used to assert on a nullable <see cref="DateTimeOffset"/> column, whose value is returned as <see cref="DateTime"/> in JSON:API response body.
         /// </summary>
         public static void BeCloseTo(this ObjectAssertions source, DateTimeOffset? expected, string because = "",
             params object[] becauseArgs)

--- a/wiki/v4/content/serialization.md
+++ b/wiki/v4/content/serialization.md
@@ -8,7 +8,7 @@ The main change for serialization is that we have split the serialization respon
 
 This split is done because during deserialization, some parts are relevant only for *client*-side parsing whereas others are only for *server*-side parsing. for example, a server deserializer will never have to deal with a `included` object list. Similarly, in serialization, a client serializer will for example never ever have to populate any other top-level members than the primary data (like `meta`, `included`). 
 
-Throughout the document and the code when referring to fields, members, object types, the technical language of json:api spec is used. At the core of (de)serialization is the
+Throughout the document and the code when referring to fields, members, object types, the technical language of JSON:API spec is used. At the core of (de)serialization is the
 `Document` class, [see document spec](https://jsonapi.org/format/#document-structure).
 
 ## Changes
@@ -23,7 +23,7 @@ The previous `JsonApiDeSerializer` implementation is now split into a `RequestDe
 
 This (base) class is responsible for:
 
-* Converting the serialized string content into an intance of the `Document` class. Which is the most basic version of JSON API which has a `Data`, `Meta` and `Included` property.
+* Converting the serialized string content into an intance of the `Document` class. Which is the most basic version of JSON:API which has a `Data`, `Meta` and `Included` property.
 * Building instances of the corresponding resource class (eg `Article`) by going through the document's primary data (`Document.Data`) For the spec for this: [Document spec](https://jsonapi.org/format/#document-top-level).
 
 Responsibility of any implementation the base class-specific parsing is shifted through the abstract `BaseDocumentParser.AfterProcessField()` method. This method is fired once each time after a `AttrAttribute` or `RelationshipAttribute` is processed. It allows a implementation of `BaseDocumentParser` to intercept the parsing and add steps that are only required for new implementations.


### PR DESCRIPTION
Naming consistency: our framework is called JsonApiDotNetCore and the spec it implements is called JSON:API (in this casing)
Fixed invalid doc-comment reference