### PR TITLE
Fix for OnReturn hook in GetSecondary pipeline

### DIFF
--- a/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutor.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutor.cs
@@ -118,7 +118,7 @@ namespace JsonApiDotNetCore.Hooks.Internal
         /// <inheritdoc />
         public IEnumerable<TResource> OnReturn<TResource>(IEnumerable<TResource> resources, ResourcePipeline pipeline) where TResource : class, IIdentifiable
         {
-            if (GetHook(ResourceHook.OnReturn, resources, out var container, out var node) && pipeline != ResourcePipeline.GetRelationship)
+            if (GetHook(ResourceHook.OnReturn, resources, out var container, out var node))
             {
                 IEnumerable<TResource> updated = container.OnReturn((HashSet<TResource>)node.UniqueResources, pipeline);
                 ValidateHookResponse(updated);

--- a/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutorFacade.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutorFacade.cs
@@ -121,7 +121,7 @@ namespace JsonApiDotNetCore.Hooks.Internal
         {
             if (resourceOrResources is IEnumerable enumerable)
             {
-                var resources = enumerable.Cast<IIdentifiable>();
+                dynamic resources = enumerable;
                 return _resourceHookExecutor.OnReturn(resources, ResourcePipeline.GetRelationship).ToArray();
             }
 

--- a/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutorFacade.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutorFacade.cs
@@ -119,9 +119,9 @@ namespace JsonApiDotNetCore.Hooks.Internal
 
         public object OnReturnRelationship(object resourceOrResources)
         {
-            if (resourceOrResources is IEnumerable enumerable)
+            if (resourceOrResources is IEnumerable)
             {
-                dynamic resources = enumerable;
+                dynamic resources = resourceOrResources;
                 return _resourceHookExecutor.OnReturn(resources, ResourcePipeline.GetRelationship).ToArray();
             }
 

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/ResourceDefinitions/ResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/ResourceDefinitions/ResourceDefinitionTests.cs
@@ -218,6 +218,30 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
         }
 
         [Fact]
+        public async Task Article_Through_Secondary_Endpoint_Is_Hidden()
+        {
+            // Arrange
+            var articles = _articleFaker.Generate(3);
+            string toBeExcluded = "This should not be included";
+            articles[0].Caption = toBeExcluded;
+            var author = _authorFaker.Generate();
+            author.Articles = articles;
+
+            _dbContext.AuthorDifferentDbContextName.Add(author);
+            await _dbContext.SaveChangesAsync();
+
+            var route = $"/api/v1/authors/{author.Id}/articles";
+
+            // Act
+            var response = await _client.GetAsync(route);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.True(HttpStatusCode.OK == response.StatusCode, $"{route} returned {response.StatusCode} status code with body: {body}");
+            Assert.DoesNotContain(toBeExcluded, body);
+        }
+
+        [Fact]
         public async Task Tag_Is_Hidden()
         {
             // Arrange

--- a/test/UnitTests/ResourceHooks/ResourceHookExecutor/IdentifiableManyToMany_OnReturnTests.cs
+++ b/test/UnitTests/ResourceHooks/ResourceHookExecutor/IdentifiableManyToMany_OnReturnTests.cs
@@ -45,6 +45,7 @@ namespace UnitTests.ResourceHooks
             hookExecutor.OnReturn(articles, ResourcePipeline.GetRelationship);
 
             // Assert
+            articleResourceMock.Verify(rd => rd.OnReturn(It.Is<HashSet<Article>>((collection) => !collection.Except(articles).Any()), ResourcePipeline.GetRelationship), Times.Once());
             joinResourceMock.Verify(rd => rd.OnReturn(It.Is<HashSet<IdentifiableArticleTag>>((collection) => !collection.Except(joins).Any()), ResourcePipeline.GetRelationship), Times.Once());
             tagResourceMock.Verify(rd => rd.OnReturn(It.Is<HashSet<Tag>>((collection) => !collection.Except(tags).Any()), ResourcePipeline.GetRelationship), Times.Once());
             VerifyNoOtherCalls(articleResourceMock, joinResourceMock, tagResourceMock);


### PR DESCRIPTION
Fixes #924

An invalid cast to `IIdentifiable` threw off the hook executor. 

Additionally, previously the `IResourceService.GetSecondaryAsync` returned a primary resource with a set relationship field that corresponded to the secondary resources of the request. This has been changed recently to returning just the requested secondary resources. The hook executor also needs to take this into account.