### PR TITLE
Open up some members for extensibility.

### DIFF
--- a/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/QueryableBuilder.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/QueryableBuilder.cs
@@ -13,7 +13,7 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
     /// <summary>
     /// Drives conversion from <see cref="QueryLayer"/> into system <see cref="Expression"/> trees.
     /// </summary>
-    public sealed class QueryableBuilder
+    public class QueryableBuilder
     {
         private readonly Expression _source;
         private readonly Type _elementType;
@@ -38,7 +38,7 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
             _lambdaScopeFactory = lambdaScopeFactory ?? new LambdaScopeFactory(_nameFactory);
         }
 
-        public Expression ApplyQuery(QueryLayer layer)
+        public virtual Expression ApplyQuery(QueryLayer layer)
         {
             if (layer == null) throw new ArgumentNullException(nameof(layer));
 
@@ -72,7 +72,7 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
             return expression;
         }
 
-        private Expression ApplyInclude(Expression source, IncludeExpression include, ResourceContext resourceContext)
+        protected virtual Expression ApplyInclude(Expression source, IncludeExpression include, ResourceContext resourceContext)
         {
             using var lambdaScope = _lambdaScopeFactory.CreateScope(_elementType);
 
@@ -80,7 +80,7 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
             return builder.ApplyInclude(include);
         }
 
-        private Expression ApplyFilter(Expression source, FilterExpression filter)
+        protected virtual Expression ApplyFilter(Expression source, FilterExpression filter)
         {
             using var lambdaScope = _lambdaScopeFactory.CreateScope(_elementType);
 
@@ -88,7 +88,7 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
             return builder.ApplyWhere(filter);
         }
 
-        private Expression ApplySort(Expression source, SortExpression sort)
+        protected virtual Expression ApplySort(Expression source, SortExpression sort)
         {
             using var lambdaScope = _lambdaScopeFactory.CreateScope(_elementType);
 
@@ -96,7 +96,7 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
             return builder.ApplyOrderBy(sort);
         }
 
-        private Expression ApplyPagination(Expression source, PaginationExpression pagination)
+        protected virtual Expression ApplyPagination(Expression source, PaginationExpression pagination)
         {
             using var lambdaScope = _lambdaScopeFactory.CreateScope(_elementType);
 
@@ -104,7 +104,7 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
             return builder.ApplySkipTake(pagination);
         }
 
-        private Expression ApplyProjection(Expression source, IDictionary<ResourceFieldAttribute, QueryLayer> projection, ResourceContext resourceContext)
+        protected virtual Expression ApplyProjection(Expression source, IDictionary<ResourceFieldAttribute, QueryLayer> projection, ResourceContext resourceContext)
         {
             using var lambdaScope = _lambdaScopeFactory.CreateScope(_elementType);
 

--- a/src/JsonApiDotNetCore/Repositories/ResourceRepositoryAccessor.cs
+++ b/src/JsonApiDotNetCore/Repositories/ResourceRepositoryAccessor.cs
@@ -26,7 +26,7 @@ namespace JsonApiDotNetCore.Repositories
         public async Task<IReadOnlyCollection<TResource>> GetAsync<TResource>(QueryLayer layer, CancellationToken cancellationToken)
             where TResource : class, IIdentifiable
         {
-            dynamic repository = GetReadRepository(typeof(TResource));
+            dynamic repository = ResolveReadRepository(typeof(TResource));
             return (IReadOnlyCollection<TResource>) await repository.GetAsync(layer, cancellationToken);
         }
 
@@ -35,7 +35,7 @@ namespace JsonApiDotNetCore.Repositories
         {
             if (resourceType == null) throw new ArgumentNullException(nameof(resourceType));
 
-            dynamic repository = GetReadRepository(resourceType);
+            dynamic repository = ResolveReadRepository(resourceType);
             return (IReadOnlyCollection<IIdentifiable>) await repository.GetAsync(layer, cancellationToken);
         }
 
@@ -43,7 +43,7 @@ namespace JsonApiDotNetCore.Repositories
         public async Task<int> CountAsync<TResource>(FilterExpression topFilter, CancellationToken cancellationToken)
             where TResource : class, IIdentifiable
         {
-            dynamic repository = GetReadRepository(typeof(TResource));
+            dynamic repository = ResolveReadRepository(typeof(TResource));
             return (int) await repository.CountAsync(topFilter, cancellationToken);
         }
 
@@ -51,7 +51,7 @@ namespace JsonApiDotNetCore.Repositories
         public async Task<TResource> GetForCreateAsync<TResource, TId>(TId id, CancellationToken cancellationToken)
             where TResource : class, IIdentifiable<TId>
         {
-            dynamic repository = GetWriteRepository(typeof(TResource));
+            dynamic repository = ResolveWriteRepository(typeof(TResource));
             return await repository.GetForCreateAsync(id, cancellationToken);
         }
 
@@ -59,7 +59,7 @@ namespace JsonApiDotNetCore.Repositories
         public async Task CreateAsync<TResource>(TResource resourceFromRequest, TResource resourceForDatabase, CancellationToken cancellationToken)
             where TResource : class, IIdentifiable
         {
-            dynamic repository = GetWriteRepository(typeof(TResource));
+            dynamic repository = ResolveWriteRepository(typeof(TResource));
             await repository.CreateAsync(resourceFromRequest, resourceForDatabase, cancellationToken);
         }
 
@@ -67,7 +67,7 @@ namespace JsonApiDotNetCore.Repositories
         public async Task<TResource> GetForUpdateAsync<TResource>(QueryLayer queryLayer, CancellationToken cancellationToken)
             where TResource : class, IIdentifiable
         {
-            dynamic repository = GetWriteRepository(typeof(TResource));
+            dynamic repository = ResolveWriteRepository(typeof(TResource));
             return await repository.GetForUpdateAsync(queryLayer, cancellationToken);
         }
 
@@ -75,7 +75,7 @@ namespace JsonApiDotNetCore.Repositories
         public async Task UpdateAsync<TResource>(TResource resourceFromRequest, TResource resourceFromDatabase, CancellationToken cancellationToken)
             where TResource : class, IIdentifiable
         {
-            dynamic repository = GetWriteRepository(typeof(TResource));
+            dynamic repository = ResolveWriteRepository(typeof(TResource));
             await repository.UpdateAsync(resourceFromRequest, resourceFromDatabase, cancellationToken);
         }
 
@@ -83,7 +83,7 @@ namespace JsonApiDotNetCore.Repositories
         public async Task DeleteAsync<TResource, TId>(TId id, CancellationToken cancellationToken)
             where TResource : class, IIdentifiable<TId>
         {
-            dynamic repository = GetWriteRepository(typeof(TResource));
+            dynamic repository = ResolveWriteRepository(typeof(TResource));
             await repository.DeleteAsync(id, cancellationToken);
         }
 
@@ -91,7 +91,7 @@ namespace JsonApiDotNetCore.Repositories
         public async Task SetRelationshipAsync<TResource>(TResource primaryResource, object secondaryResourceIds, CancellationToken cancellationToken)
             where TResource : class, IIdentifiable
         {
-            dynamic repository = GetWriteRepository(typeof(TResource));
+            dynamic repository = ResolveWriteRepository(typeof(TResource));
             await repository.SetRelationshipAsync(primaryResource, secondaryResourceIds, cancellationToken);
         }
 
@@ -99,7 +99,7 @@ namespace JsonApiDotNetCore.Repositories
         public async Task AddToToManyRelationshipAsync<TResource, TId>(TId primaryId, ISet<IIdentifiable> secondaryResourceIds, CancellationToken cancellationToken)
             where TResource : class, IIdentifiable<TId>
         {
-            dynamic repository = GetWriteRepository(typeof(TResource));
+            dynamic repository = ResolveWriteRepository(typeof(TResource));
             await repository.AddToToManyRelationshipAsync(primaryId, secondaryResourceIds, cancellationToken);
         }
 
@@ -107,11 +107,11 @@ namespace JsonApiDotNetCore.Repositories
         public async Task RemoveFromToManyRelationshipAsync<TResource>(TResource primaryResource, ISet<IIdentifiable> secondaryResourceIds, CancellationToken cancellationToken)
             where TResource : class, IIdentifiable
         {
-            dynamic repository = GetWriteRepository(typeof(TResource));
+            dynamic repository = ResolveWriteRepository(typeof(TResource));
             await repository.RemoveFromToManyRelationshipAsync(primaryResource, secondaryResourceIds, cancellationToken);
         }
 
-        protected object GetReadRepository(Type resourceType)
+        protected virtual object ResolveReadRepository(Type resourceType)
         {
             var resourceContext = _resourceContextProvider.GetResourceContext(resourceType);
 
@@ -130,7 +130,7 @@ namespace JsonApiDotNetCore.Repositories
             return _serviceProvider.GetRequiredService(resourceDefinitionType);
         }
 
-        protected object GetWriteRepository(Type resourceType)
+        protected virtual object ResolveWriteRepository(Type resourceType)
         {
             var resourceContext = _resourceContextProvider.GetResourceContext(resourceType);
 

--- a/src/JsonApiDotNetCore/Resources/ResourceDefinitionAccessor.cs
+++ b/src/JsonApiDotNetCore/Resources/ResourceDefinitionAccessor.cs
@@ -23,7 +23,7 @@ namespace JsonApiDotNetCore.Resources
         {
             if (resourceType == null) throw new ArgumentNullException(nameof(resourceType));
 
-            dynamic resourceDefinition = GetResourceDefinition(resourceType);
+            dynamic resourceDefinition = ResolveResourceDefinition(resourceType);
             return resourceDefinition.OnApplyIncludes(existingIncludes);
         }
 
@@ -32,7 +32,7 @@ namespace JsonApiDotNetCore.Resources
         {
             if (resourceType == null) throw new ArgumentNullException(nameof(resourceType));
 
-            dynamic resourceDefinition = GetResourceDefinition(resourceType);
+            dynamic resourceDefinition = ResolveResourceDefinition(resourceType);
             return resourceDefinition.OnApplyFilter(existingFilter);
         }
 
@@ -41,7 +41,7 @@ namespace JsonApiDotNetCore.Resources
         {
             if (resourceType == null) throw new ArgumentNullException(nameof(resourceType));
 
-            dynamic resourceDefinition = GetResourceDefinition(resourceType);
+            dynamic resourceDefinition = ResolveResourceDefinition(resourceType);
             return resourceDefinition.OnApplySort(existingSort);
         }
 
@@ -50,7 +50,7 @@ namespace JsonApiDotNetCore.Resources
         {
             if (resourceType == null) throw new ArgumentNullException(nameof(resourceType));
 
-            dynamic resourceDefinition = GetResourceDefinition(resourceType);
+            dynamic resourceDefinition = ResolveResourceDefinition(resourceType);
             return resourceDefinition.OnApplyPagination(existingPagination);
         }
 
@@ -59,7 +59,7 @@ namespace JsonApiDotNetCore.Resources
         {
             if (resourceType == null) throw new ArgumentNullException(nameof(resourceType));
 
-            dynamic resourceDefinition = GetResourceDefinition(resourceType);
+            dynamic resourceDefinition = ResolveResourceDefinition(resourceType);
             return resourceDefinition.OnApplySparseFieldSet(existingSparseFieldSet);
         }
 
@@ -69,7 +69,7 @@ namespace JsonApiDotNetCore.Resources
             if (resourceType == null) throw new ArgumentNullException(nameof(resourceType));
             if (parameterName == null) throw new ArgumentNullException(nameof(parameterName));
 
-            dynamic resourceDefinition = GetResourceDefinition(resourceType);
+            dynamic resourceDefinition = ResolveResourceDefinition(resourceType);
             var handlers = resourceDefinition.OnRegisterQueryableHandlersForQueryStringParameters();
 
             return handlers != null && handlers.ContainsKey(parameterName) ? handlers[parameterName] : null;
@@ -80,11 +80,11 @@ namespace JsonApiDotNetCore.Resources
         {
             if (resourceType == null) throw new ArgumentNullException(nameof(resourceType));
 
-            dynamic resourceDefinition = GetResourceDefinition(resourceType);
+            dynamic resourceDefinition = ResolveResourceDefinition(resourceType);
             return resourceDefinition.GetMeta((dynamic) resourceInstance);
         }
 
-        protected object GetResourceDefinition(Type resourceType)
+        protected virtual object ResolveResourceDefinition(Type resourceType)
         {
             var resourceContext = _resourceContextProvider.GetResourceContext(resourceType);
 


### PR DESCRIPTION
Opens up some members for extensibility. This helps to reduce some copy/pasted code in [JsonApiDotNetCore.MongoDb](https://github.com/json-api-dotnet/JsonApiDotNetCore.MongoDb).

The GetXXX to ResolveXXX rename is in preparation for atomic:operations support. Although it is breaking in the technical sense, these are protected members and unlikely for anyone to have taken a dependency on.