### PR TITLE
Fix OnReturn secondary resource pipeline for HasOne relationships

### DIFF
--- a/src/Examples/JsonApiDotNetCoreExample/Definitions/PassportHooksDefinition.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Definitions/PassportHooksDefinition.cs
@@ -32,6 +32,11 @@ namespace JsonApiDotNetCoreExample.Definitions
             resourcesByRelationship.GetByRelationship<Person>().ToList().ForEach(kvp => DoesNotTouchLockedPassports(kvp.Value));
         }
 
+        public override IEnumerable<Passport> OnReturn(HashSet<Passport> resources, ResourcePipeline pipeline)
+        {
+            return resources.Where(p => !p.IsLocked);
+        }
+
         private void DoesNotTouchLockedPassports(IEnumerable<Passport> resources)
         {
             foreach (var passport in resources ?? Enumerable.Empty<Passport>())

--- a/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutorFacade.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutorFacade.cs
@@ -127,8 +127,8 @@ namespace JsonApiDotNetCore.Hooks.Internal
 
             if (resourceOrResources is IIdentifiable)
             {
-                var resources = ToList((dynamic) resourceOrResources);
-                return _resourceHookExecutor.OnReturn(resources, ResourcePipeline.GetRelationship).SingleOrDefault();
+                var resources = ToList((dynamic)resourceOrResources);
+                return Enumerable.SingleOrDefault(_resourceHookExecutor.OnReturn(resources, ResourcePipeline.GetRelationship));
             }
 
             return resourceOrResources;

--- a/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutorFacade.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutorFacade.cs
@@ -125,10 +125,10 @@ namespace JsonApiDotNetCore.Hooks.Internal
                 return _resourceHookExecutor.OnReturn(resources, ResourcePipeline.GetRelationship).ToArray();
             }
 
-            if (resourceOrResources is IIdentifiable identifiable)
+            if (resourceOrResources is IIdentifiable)
             {
-                var resources = ToList(identifiable);
-                return _resourceHookExecutor.OnReturn(resources, ResourcePipeline.GetRelationship).Single();
+                var resources = ToList((dynamic) resourceOrResources);
+                return _resourceHookExecutor.OnReturn(resources, ResourcePipeline.GetRelationship).SingleOrDefault();
             }
 
             return resourceOrResources;

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/ResourceDefinitions/ResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/ResourceDefinitions/ResourceDefinitionTests.cs
@@ -242,6 +242,28 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
         }
 
         [Fact]
+        public async Task Passport_Through_Secondary_Endpoint_Is_Hidden()
+        {
+            // Arrange
+            var person = _personFaker.Generate();
+            var passport = new Passport(_dbContext) {IsLocked = true};
+            person.Passport = passport;
+
+            _dbContext.People.Add(person);
+            await _dbContext.SaveChangesAsync();
+
+            var route = $"/api/v1/people/{person.Id}/passport";
+
+            // Act
+            var response = await _client.GetAsync(route);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            var document = JsonConvert.DeserializeObject<Document>(body);
+            Assert.Null(document.Data);
+        }
+
+        [Fact]
         public async Task Tag_Is_Hidden()
         {
             // Arrange

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/ResourceDefinitions/ResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/ResourceDefinitions/ResourceDefinitionTests.cs
@@ -246,8 +246,7 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
         {
             // Arrange
             var person = _personFaker.Generate();
-            var passport = new Passport(_dbContext) {IsLocked = true};
-            person.Passport = passport;
+            person.Passport = new Passport(_dbContext) {IsLocked = true};
 
             _dbContext.People.Add(person);
             await _dbContext.SaveChangesAsync();
@@ -259,8 +258,10 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
 
             // Assert
             var body = await response.Content.ReadAsStringAsync();
+            Assert.True(HttpStatusCode.OK == response.StatusCode, $"{route} returned {response.StatusCode} status code with body: {body}");
             var document = JsonConvert.DeserializeObject<Document>(body);
             Assert.Null(document.Data);
+
         }
 
         [Fact]


### PR DESCRIPTION
Additional fix for #924 that covers the case of HasOne relationships