### PR TITLE
Check method GetResourceContext(type) returns null

### DIFF
--- a/src/JsonApiDotNetCore/Configuration/ResourceGraph.cs
+++ b/src/JsonApiDotNetCore/Configuration/ResourceGraph.cs
@@ -82,7 +82,14 @@ namespace JsonApiDotNetCore.Configuration
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
 
-            return GetResourceContext(type).Relationships;
+            var resourceContext = GetResourceContext(type);
+            
+            if (resourceContext != null)
+            {
+                return resourceContext.Relationships;
+            }
+            
+            return null;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Check if method GetResourceContext(type) returns null before returning Relationships



Closes #{ISSUE_NUMBER}

#### QUALITY CHECKLIST
- [ ] Changes implemented in code
- [ ] Adapted tests
- [ ] Documentation updated
- [ ] Created issue to update [Templates](https://github.com/json-api-dotnet/Templates/issues/new): {ISSUE_NUMBER}
