### PR TITLE
fixed ToArray issue on dynamic object

### DIFF
--- a/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutorFacade.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutorFacade.cs
@@ -122,7 +122,7 @@ namespace JsonApiDotNetCore.Hooks.Internal
             if (resourceOrResources is IEnumerable)
             {
                 dynamic resources = resourceOrResources;
-                return _resourceHookExecutor.OnReturn(resources, ResourcePipeline.GetRelationship).ToArray();
+                return Enumerable.ToArray(_resourceHookExecutor.OnReturn(resources, ResourcePipeline.GetRelationship));
             }
 
             if (resourceOrResources is IIdentifiable)

--- a/test/JsonApiDotNetCoreExampleTests/Acceptance/ResourceDefinitions/ResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/Acceptance/ResourceDefinitions/ResourceDefinitionTests.cs
@@ -242,6 +242,42 @@ namespace JsonApiDotNetCoreExampleTests.Acceptance
         }
 
         [Fact]
+        public async Task Tag_HashSet_Through_Secondary_Endpoint_Is_Hidden()
+        {
+            // Arrange
+            var article = _articleFaker.Generate();
+            var tags = _tagFaker.Generate(2);
+            string toBeExcluded = "This should not be included";
+            tags[0].Name = toBeExcluded;
+
+            var articleTags = new[]
+            {
+                new ArticleTag
+                {
+                    Article = article,
+                    Tag = tags[0]
+                },
+                new ArticleTag
+                {
+                    Article = article,
+                    Tag = tags[1]
+                }
+            };
+            _dbContext.ArticleTags.AddRange(articleTags);
+            await _dbContext.SaveChangesAsync();
+
+            var route = $"/api/v1/articles/{article.Id}/tags";
+
+            // Act
+            var response = await _client.GetAsync(route);
+
+            // Assert
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.True(HttpStatusCode.OK == response.StatusCode, $"{route} returned {response.StatusCode} status code with body: {body}");
+            Assert.DoesNotContain(toBeExcluded, body);
+        }
+
+        [Fact]
         public async Task Passport_Through_Secondary_Endpoint_Is_Hidden()
         {
             // Arrange


### PR DESCRIPTION
If the basetype of an relationship is ISet or ICollection a HahSet will be used.
HahSet has no implementation for ToArray it's just an extension method on Enumerable, so let's use this.