### PR TITLE
Added auto-expansion of inheritdoc comments

### DIFF
--- a/src/JsonApiDotNetCore/Controllers/JsonApiCommandController.cs
+++ b/src/JsonApiDotNetCore/Controllers/JsonApiCommandController.cs
@@ -18,7 +18,9 @@ namespace JsonApiDotNetCore.Controllers
     /// <typeparam name="TId">The resource identifier type.</typeparam>
     public abstract class JsonApiCommandController<TResource, TId> : BaseJsonApiController<TResource, TId> where TResource : class, IIdentifiable<TId>
     {
-        /// <inheritdoc />
+        /// <summary>
+        /// Creates an instance from a write-only service.
+        /// </summary>
         protected JsonApiCommandController(
             IJsonApiOptions options,
             ILoggerFactory loggerFactory,

--- a/src/JsonApiDotNetCore/Controllers/JsonApiQueryController.cs
+++ b/src/JsonApiDotNetCore/Controllers/JsonApiQueryController.cs
@@ -17,7 +17,9 @@ namespace JsonApiDotNetCore.Controllers
     /// <typeparam name="TId">The resource identifier type.</typeparam>
     public abstract class JsonApiQueryController<TResource, TId> : BaseJsonApiController<TResource, TId> where TResource : class, IIdentifiable<TId>
     {
-        /// <inheritdoc />
+        /// <summary>
+        /// Creates an instance from a read-only service.
+        /// </summary>
         protected JsonApiQueryController(
             IJsonApiOptions context,
             ILoggerFactory loggerFactory,

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -26,6 +26,10 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="SauceControl.InheritDoc" Version="1.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Added auto-expansion of inheritdoc comments using https://github.com/saucecontrol/InheritDoc, so that VS Intellisense picks it up when consumed as package reference.

Fixes #940.