### PR TITLE
task: make [Attr] and RequestDeserializer.SetAttributes open to extension

### DIFF
--- a/src/JsonApiDotNetCore/Resources/Annotations/AttrAttribute.cs
+++ b/src/JsonApiDotNetCore/Resources/Annotations/AttrAttribute.cs
@@ -6,7 +6,7 @@ namespace JsonApiDotNetCore.Resources.Annotations
     /// Used to expose a property on a resource class as a JSON:API attribute (https://jsonapi.org/format/#document-resource-object-attributes).
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
-    public sealed class AttrAttribute : ResourceFieldAttribute
+    public class AttrAttribute : ResourceFieldAttribute
     {
         private AttrCapabilities? _capabilities;
 

--- a/src/JsonApiDotNetCore/Serialization/BaseDeserializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/BaseDeserializer.cs
@@ -70,7 +70,7 @@ namespace JsonApiDotNetCore.Serialization
         /// <param name="resource">The parsed resource.</param>
         /// <param name="attributeValues">Attributes and their values, as in the serialized content.</param>
         /// <param name="attributes">Exposed attributes for <paramref name="resource"/>.</param>
-        protected IIdentifiable SetAttributes(IIdentifiable resource, IDictionary<string, object> attributeValues, IReadOnlyCollection<AttrAttribute> attributes)
+        protected virtual IIdentifiable SetAttributes(IIdentifiable resource, IDictionary<string, object> attributeValues, IReadOnlyCollection<AttrAttribute> attributes)
         {
             if (resource == null) throw new ArgumentNullException(nameof(resource));
             if (attributes == null) throw new ArgumentNullException(nameof(attributes));


### PR DESCRIPTION
#### QUALITY CHECKLIST
- [X] Changes implemented in code
- [ ] Adapted tests
- [ ] Documentation updated

Hello!

This is a very minor change to open a couple of types to extension, which allows me to implement some custom deserialisation logic without needing to duplicate large chunks of code. Would you be willing to accept? Please let me know if you need further work to justify such as docs etc.

Unsealing Attr allows me to create my own variant of the Attr attribute that has custom metadata about how that attr should be deserialised. Making SetAttributes virtual allows me to inherit from RequestDeserializer and override SetAttributes so that is can observer my custom attribute and implement the custom deserialisation at the correct moment so that _targetedFields gets populated. Also open to alternative implementations if opening these up is unfavourable.

(My requirement is that my custom Attr attribute triggers the property to be populated from route data rather than from the JSON Body and although that is outside the scope of this PR it might help explain why these are required)

Thanks for the great project.