### PR TITLE
Fixed parsing of incoming comma-separated list of Accept headers

### DIFF
--- a/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
@@ -16,7 +16,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
 
 namespace JsonApiDotNetCore.Middleware
@@ -120,7 +119,7 @@ namespace JsonApiDotNetCore.Middleware
         private static async Task<bool> ValidateAcceptHeaderAsync(MediaTypeHeaderValue allowedMediaTypeValue, HttpContext httpContext,
             JsonSerializerSettings serializerSettings)
         {
-            StringValues acceptHeaders = httpContext.Request.Headers["Accept"];
+            string[] acceptHeaders = httpContext.Request.Headers.GetCommaSeparatedValues("Accept");
 
             if (!acceptHeaders.Any())
             {

--- a/test/TestBuildingBlocks/IntegrationTest.cs
+++ b/test/TestBuildingBlocks/IntegrationTest.cs
@@ -63,16 +63,15 @@ namespace TestBuildingBlocks
                 }
             }
 
-            using HttpClient client = CreateClient();
-
             if (acceptHeaders != null)
             {
                 foreach (MediaTypeWithQualityHeaderValue acceptHeader in acceptHeaders)
                 {
-                    client.DefaultRequestHeaders.Accept.Add(acceptHeader);
+                    request.Headers.Accept.Add(acceptHeader);
                 }
             }
 
+            using HttpClient client = CreateClient();
             HttpResponseMessage responseMessage = await client.SendAsync(request);
 
             string responseText = await responseMessage.Content.ReadAsStringAsync();


### PR DESCRIPTION
Our [integration tests](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/59d2b510fbf94bdb9ffaa0f1d7eaba420a6cb693/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ContentNegotiation/AcceptHeaderTests.cs#L85-L86) did actually test for compound values. But they use an internal loopback, which bypasses the actual Accept header parsing that occurs on incoming socket bytes.

Because `httpContext.Request.Headers["Accept"]` returns `StringValues`, I blindly assumed that this would break up comma-separated values. But it does not, as explained [here](https://github.com/aspnet/HttpAbstractions/issues/745). It only contains multiple entries when multiple Accept header lines are sent sequentially (or when short-circuited, as in our tests).

There seems no way to bypass the internal comma-separated values parsing that occurs in integration tests. Even passing a single comma-delimited string runs through an internal parser, producing a `StringValues` with multiple entries.

Fixes #970.