### PR TITLE
Update to .NET Core 5 with EF Core 6 Preview 3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <NetCoreAppVersion>netcoreapp3.1</NetCoreAppVersion>
-    <AspNetCoreVersion>3.1.*</AspNetCoreVersion>
-    <EFCoreVersion>3.1.*</EFCoreVersion>
-    <NpgsqlPostgreSQLVersion>3.1.*</NpgsqlPostgreSQLVersion>
+    <NetCoreAppVersion>net5.0</NetCoreAppVersion>
+    <AspNetCoreVersion>5.0.*</AspNetCoreVersion>
+    <EFCoreVersion>6.0.0-preview.3.21201.2</EFCoreVersion>
+    <NpgsqlPostgreSQLVersion>6.0.0-preview3</NpgsqlPostgreSQLVersion>
     <CodeAnalysisRuleSet>$(SolutionDir)CodingGuidelines.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/benchmarks/Query/QueryParserBenchmarks.cs
+++ b/benchmarks/Query/QueryParserBenchmarks.cs
@@ -20,8 +20,8 @@ namespace Benchmarks.Query
     [MemoryDiagnoser]
     public class QueryParserBenchmarks
     {
-        private readonly DependencyFactory _dependencyFactory = new DependencyFactory();
-        private readonly FakeRequestQueryStringAccessor _queryStringAccessor = new FakeRequestQueryStringAccessor();
+        private readonly DependencyFactory _dependencyFactory = new();
+        private readonly FakeRequestQueryStringAccessor _queryStringAccessor = new();
         private readonly QueryStringReader _queryStringReaderForSort;
         private readonly QueryStringReader _queryStringReaderForAll;
 

--- a/benchmarks/Serialization/JsonApiDeserializerBenchmarks.cs
+++ b/benchmarks/Serialization/JsonApiDeserializerBenchmarks.cs
@@ -29,7 +29,7 @@ namespace Benchmarks.Serialization
             }
         });
 
-        private readonly DependencyFactory _dependencyFactory = new DependencyFactory();
+        private readonly DependencyFactory _dependencyFactory = new();
         private readonly IJsonApiDeserializer _jsonApiDeserializer;
 
         public JsonApiDeserializerBenchmarks()

--- a/benchmarks/Serialization/JsonApiSerializerBenchmarks.cs
+++ b/benchmarks/Serialization/JsonApiSerializerBenchmarks.cs
@@ -15,13 +15,13 @@ namespace Benchmarks.Serialization
     [MarkdownExporter]
     public class JsonApiSerializerBenchmarks
     {
-        private static readonly BenchmarkResource Content = new BenchmarkResource
+        private static readonly BenchmarkResource Content = new()
         {
             Id = 123,
             Name = Guid.NewGuid().ToString()
         };
 
-        private readonly DependencyFactory _dependencyFactory = new DependencyFactory();
+        private readonly DependencyFactory _dependencyFactory = new();
         private readonly IJsonApiSerializer _jsonApiSerializer;
 
         public JsonApiSerializerBenchmarks()

--- a/src/Examples/JsonApiDotNetCoreExample/Definitions/ArticleHooksDefinition.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Definitions/ArticleHooksDefinition.cs
@@ -21,7 +21,13 @@ namespace JsonApiDotNetCoreExample.Definitions
 
         public override IEnumerable<Article> OnReturn(HashSet<Article> resources, ResourcePipeline pipeline)
         {
-            if (pipeline == ResourcePipeline.GetSingle && resources.Any(article => article.Caption == "Classified"))
+            [AssertionMethod]
+            static bool Predicate(Article article)
+            {
+                return article.Caption == "Classified";
+            }
+
+            if (pipeline == ResourcePipeline.GetSingle && resources.Any(Predicate))
             {
                 throw new JsonApiException(new Error(HttpStatusCode.Forbidden)
                 {

--- a/src/Examples/ReportsExample/Services/ReportService.cs
+++ b/src/Examples/ReportsExample/Services/ReportService.cs
@@ -31,7 +31,7 @@ namespace ReportsExample.Services
         {
             return new List<Report>
             {
-                new Report
+                new()
                 {
                     Title = "Status Report",
                     Statistics = new ReportStatistics

--- a/src/JsonApiDotNetCore/AtomicOperations/Processors/SetRelationshipProcessor.cs
+++ b/src/JsonApiDotNetCore/AtomicOperations/Processors/SetRelationshipProcessor.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.AtomicOperations.Processors
     public class SetRelationshipProcessor<TResource, TId> : ISetRelationshipProcessor<TResource, TId>
         where TResource : class, IIdentifiable<TId>
     {
-        private readonly CollectionConverter _collectionConverter = new CollectionConverter();
+        private readonly CollectionConverter _collectionConverter = new();
         private readonly ISetRelationshipService<TResource, TId> _service;
 
         public SetRelationshipProcessor(ISetRelationshipService<TResource, TId> service)

--- a/src/JsonApiDotNetCore/Configuration/InverseNavigationResolver.cs
+++ b/src/JsonApiDotNetCore/Configuration/InverseNavigationResolver.cs
@@ -52,7 +52,7 @@ namespace JsonApiDotNetCore.Configuration
             {
                 if (!(relationship is HasManyThroughAttribute))
                 {
-                    INavigation inverseNavigation = entityType.FindNavigation(relationship.Property.Name)?.FindInverse();
+                    INavigation inverseNavigation = entityType.FindNavigation(relationship.Property.Name)?.Inverse;
                     relationship.InverseNavigationProperty = inverseNavigation?.PropertyInfo;
                 }
             }

--- a/src/JsonApiDotNetCore/Configuration/JsonApiApplicationBuilder.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiApplicationBuilder.cs
@@ -34,7 +34,7 @@ namespace JsonApiDotNetCore.Configuration
     /// </summary>
     internal sealed class JsonApiApplicationBuilder : IJsonApiApplicationBuilder, IDisposable
     {
-        private readonly JsonApiOptions _options = new JsonApiOptions();
+        private readonly JsonApiOptions _options = new();
         private readonly IServiceCollection _services;
         private readonly IMvcCoreBuilder _mvcBuilder;
         private readonly ResourceGraphBuilder _resourceGraphBuilder;

--- a/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
@@ -37,7 +37,7 @@ namespace JsonApiDotNetCore.Configuration
         public bool IncludeTotalResourceCount { get; set; }
 
         /// <inheritdoc />
-        public PageSize DefaultPageSize { get; set; } = new PageSize(10);
+        public PageSize DefaultPageSize { get; set; } = new(10);
 
         /// <inheritdoc />
         public PageSize MaximumPageSize { get; set; }
@@ -79,7 +79,7 @@ namespace JsonApiDotNetCore.Configuration
         public IsolationLevel? TransactionIsolationLevel { get; set; }
 
         /// <inheritdoc />
-        public JsonSerializerSettings SerializerSettings { get; } = new JsonSerializerSettings
+        public JsonSerializerSettings SerializerSettings { get; } = new()
         {
             ContractResolver = new DefaultContractResolver
             {

--- a/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
@@ -12,10 +12,6 @@ namespace JsonApiDotNetCore.Configuration
     {
         internal static readonly NamingStrategy DefaultNamingStrategy = new CamelCaseNamingStrategy();
 
-        // Workaround for https://github.com/dotnet/efcore/issues/21026
-        internal bool DisableTopPagination { get; set; }
-        internal bool DisableChildrenPagination { get; set; }
-
         /// <inheritdoc />
         public string Namespace { get; set; }
 

--- a/src/JsonApiDotNetCore/Configuration/JsonApiValidationFilter.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiValidationFilter.cs
@@ -41,7 +41,7 @@ namespace JsonApiDotNetCore.Configuration
 
             var httpContextAccessor = _serviceProvider.GetRequiredService<IHttpContextAccessor>();
 
-            if (httpContextAccessor.HttpContext.Request.Method == HttpMethods.Patch || request.OperationKind == OperationKind.UpdateResource)
+            if (httpContextAccessor.HttpContext!.Request.Method == HttpMethods.Patch || request.OperationKind == OperationKind.UpdateResource)
             {
                 var targetedFields = _serviceProvider.GetRequiredService<ITargetedFields>();
                 return IsFieldTargeted(entry, targetedFields);

--- a/src/JsonApiDotNetCore/Configuration/PageNumber.cs
+++ b/src/JsonApiDotNetCore/Configuration/PageNumber.cs
@@ -6,7 +6,7 @@ namespace JsonApiDotNetCore.Configuration
     [PublicAPI]
     public sealed class PageNumber : IEquatable<PageNumber>
     {
-        public static readonly PageNumber ValueOne = new PageNumber(1);
+        public static readonly PageNumber ValueOne = new(1);
 
         public int OneBasedValue { get; }
 

--- a/src/JsonApiDotNetCore/Configuration/ResourceDescriptorAssemblyCache.cs
+++ b/src/JsonApiDotNetCore/Configuration/ResourceDescriptorAssemblyCache.cs
@@ -10,10 +10,9 @@ namespace JsonApiDotNetCore.Configuration
     /// </summary>
     internal sealed class ResourceDescriptorAssemblyCache
     {
-        private readonly TypeLocator _typeLocator = new TypeLocator();
+        private readonly TypeLocator _typeLocator = new();
 
-        private readonly Dictionary<Assembly, IReadOnlyCollection<ResourceDescriptor>> _resourceDescriptorsPerAssembly =
-            new Dictionary<Assembly, IReadOnlyCollection<ResourceDescriptor>>();
+        private readonly Dictionary<Assembly, IReadOnlyCollection<ResourceDescriptor>> _resourceDescriptorsPerAssembly = new();
 
         public void RegisterAssembly(Assembly assembly)
         {

--- a/src/JsonApiDotNetCore/Configuration/ResourceGraphBuilder.cs
+++ b/src/JsonApiDotNetCore/Configuration/ResourceGraphBuilder.cs
@@ -18,8 +18,8 @@ namespace JsonApiDotNetCore.Configuration
     {
         private readonly IJsonApiOptions _options;
         private readonly ILogger<ResourceGraphBuilder> _logger;
-        private readonly List<ResourceContext> _resources = new List<ResourceContext>();
-        private readonly TypeLocator _typeLocator = new TypeLocator();
+        private readonly List<ResourceContext> _resources = new();
+        private readonly TypeLocator _typeLocator = new();
 
         public ResourceGraphBuilder(IJsonApiOptions options, ILoggerFactory loggerFactory)
         {
@@ -126,7 +126,7 @@ namespace JsonApiDotNetCore.Configuration
 
         private ResourceContext CreateResourceContext(string publicName, Type resourceType, Type idType)
         {
-            return new ResourceContext
+            return new()
             {
                 PublicName = publicName,
                 ResourceType = resourceType,

--- a/src/JsonApiDotNetCore/Configuration/ServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore/Configuration/ServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCore.Configuration
     [PublicAPI]
     public static class ServiceCollectionExtensions
     {
-        private static readonly TypeLocator TypeLocator = new TypeLocator();
+        private static readonly TypeLocator TypeLocator = new();
 
         /// <summary>
         /// Configures JsonApiDotNetCore by registering resources manually.

--- a/src/JsonApiDotNetCore/Configuration/ServiceDiscoveryFacade.cs
+++ b/src/JsonApiDotNetCore/Configuration/ServiceDiscoveryFacade.cs
@@ -19,7 +19,7 @@ namespace JsonApiDotNetCore.Configuration
     [PublicAPI]
     public class ServiceDiscoveryFacade
     {
-        internal static readonly HashSet<Type> ServiceInterfaces = new HashSet<Type>
+        internal static readonly HashSet<Type> ServiceInterfaces = new()
         {
             typeof(IResourceService<>),
             typeof(IResourceService<,>),
@@ -49,7 +49,7 @@ namespace JsonApiDotNetCore.Configuration
             typeof(IRemoveFromRelationshipService<,>)
         };
 
-        internal static readonly HashSet<Type> RepositoryInterfaces = new HashSet<Type>
+        internal static readonly HashSet<Type> RepositoryInterfaces = new()
         {
             typeof(IResourceRepository<>),
             typeof(IResourceRepository<,>),
@@ -59,7 +59,7 @@ namespace JsonApiDotNetCore.Configuration
             typeof(IResourceReadRepository<,>)
         };
 
-        internal static readonly HashSet<Type> ResourceDefinitionInterfaces = new HashSet<Type>
+        internal static readonly HashSet<Type> ResourceDefinitionInterfaces = new()
         {
             typeof(IResourceDefinition<>),
             typeof(IResourceDefinition<,>)
@@ -69,8 +69,8 @@ namespace JsonApiDotNetCore.Configuration
         private readonly IServiceCollection _services;
         private readonly ResourceGraphBuilder _resourceGraphBuilder;
         private readonly IJsonApiOptions _options;
-        private readonly ResourceDescriptorAssemblyCache _assemblyCache = new ResourceDescriptorAssemblyCache();
-        private readonly TypeLocator _typeLocator = new TypeLocator();
+        private readonly ResourceDescriptorAssemblyCache _assemblyCache = new();
+        private readonly TypeLocator _typeLocator = new();
 
         public ServiceDiscoveryFacade(IServiceCollection services, ResourceGraphBuilder resourceGraphBuilder, IJsonApiOptions options,
             ILoggerFactory loggerFactory)

--- a/src/JsonApiDotNetCore/Controllers/Annotations/DisableQueryStringAttribute.cs
+++ b/src/JsonApiDotNetCore/Controllers/Annotations/DisableQueryStringAttribute.cs
@@ -21,7 +21,7 @@ namespace JsonApiDotNetCore.Controllers.Annotations
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface)]
     public sealed class DisableQueryStringAttribute : Attribute
     {
-        public static readonly DisableQueryStringAttribute Empty = new DisableQueryStringAttribute(StandardQueryStringParameters.None);
+        public static readonly DisableQueryStringAttribute Empty = new(StandardQueryStringParameters.None);
         public IReadOnlyCollection<string> ParameterNames { get; }
 
         /// <summary>

--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
@@ -271,7 +271,7 @@ namespace JsonApiDotNetCore.Controllers
             }
 
             TResource updated = await _update.UpdateAsync(id, resource, cancellationToken);
-            return updated == null ? (IActionResult)NoContent() : Ok(updated);
+            return updated == null ? NoContent() : Ok(updated);
         }
 
         /// <summary>

--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiOperationsController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiOperationsController.cs
@@ -121,7 +121,7 @@ namespace JsonApiDotNetCore.Controllers
             }
 
             IList<OperationContainer> results = await _processor.ProcessAsync(operations, cancellationToken);
-            return results.Any(result => result != null) ? (IActionResult)Ok(results) : NoContent();
+            return results.Any(result => result != null) ? Ok(results) : NoContent();
         }
 
         protected virtual void ValidateClientGeneratedIds(IEnumerable<OperationContainer> operations)

--- a/src/JsonApiDotNetCore/Errors/JsonApiException.cs
+++ b/src/JsonApiDotNetCore/Errors/JsonApiException.cs
@@ -13,7 +13,7 @@ namespace JsonApiDotNetCore.Errors
     [PublicAPI]
     public class JsonApiException : Exception
     {
-        private static readonly JsonSerializerSettings ErrorSerializerSettings = new JsonSerializerSettings
+        private static readonly JsonSerializerSettings ErrorSerializerSettings = new()
         {
             NullValueHandling = NullValueHandling.Ignore,
             Formatting = Formatting.Indented

--- a/src/JsonApiDotNetCore/Errors/ResourcesInRelationshipsNotFoundException.cs
+++ b/src/JsonApiDotNetCore/Errors/ResourcesInRelationshipsNotFoundException.cs
@@ -19,7 +19,7 @@ namespace JsonApiDotNetCore.Errors
 
         private static Error CreateError(MissingResourceInRelationship missingResourceInRelationship)
         {
-            return new Error(HttpStatusCode.NotFound)
+            return new(HttpStatusCode.NotFound)
             {
                 Title = "A related resource does not exist.",
                 Detail = $"Related resource of type '{missingResourceInRelationship.ResourceType}' with ID '{missingResourceInRelationship.ResourceId}' " +

--- a/src/JsonApiDotNetCore/Hooks/Internal/Execution/DiffableResourceHashSet.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/Execution/DiffableResourceHashSet.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCore.Hooks.Internal.Execution
         where TResource : class, IIdentifiable
     {
         // ReSharper disable once StaticMemberInGenericType
-        private static readonly CollectionConverter CollectionConverter = new CollectionConverter();
+        private static readonly CollectionConverter CollectionConverter = new();
 
         private readonly HashSet<TResource> _databaseValues;
         private readonly bool _databaseValuesLoaded;

--- a/src/JsonApiDotNetCore/Hooks/Internal/Execution/HookContainerProvider.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/Execution/HookContainerProvider.cs
@@ -19,9 +19,9 @@ namespace JsonApiDotNetCore.Hooks.Internal.Execution
     /// <inheritdoc />
     internal sealed class HookContainerProvider : IHookContainerProvider
     {
-        private static readonly HooksCollectionConverter CollectionConverter = new HooksCollectionConverter();
-        private static readonly HooksObjectFactory ObjectFactory = new HooksObjectFactory();
-        private static readonly IncludeChainConverter IncludeChainConverter = new IncludeChainConverter();
+        private static readonly HooksCollectionConverter CollectionConverter = new();
+        private static readonly HooksObjectFactory ObjectFactory = new();
+        private static readonly IncludeChainConverter IncludeChainConverter = new();
 
         private readonly IdentifiableComparer _comparer = IdentifiableComparer.Instance;
         private readonly IJsonApiOptions _options;

--- a/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutor.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/ResourceHookExecutor.cs
@@ -21,9 +21,9 @@ namespace JsonApiDotNetCore.Hooks.Internal
     /// <inheritdoc />
     internal sealed class ResourceHookExecutor : IResourceHookExecutor
     {
-        private static readonly IncludeChainConverter IncludeChainConverter = new IncludeChainConverter();
-        private static readonly HooksObjectFactory ObjectFactory = new HooksObjectFactory();
-        private static readonly HooksCollectionConverter CollectionConverter = new HooksCollectionConverter();
+        private static readonly IncludeChainConverter IncludeChainConverter = new();
+        private static readonly HooksObjectFactory ObjectFactory = new();
+        private static readonly HooksCollectionConverter CollectionConverter = new();
 
         private readonly IHookContainerProvider _containerProvider;
         private readonly INodeNavigator _nodeNavigator;

--- a/src/JsonApiDotNetCore/Hooks/Internal/Traversal/ChildNode.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/Traversal/ChildNode.cs
@@ -8,7 +8,7 @@ namespace JsonApiDotNetCore.Hooks.Internal.Traversal
 {
     internal abstract class ChildNode
     {
-        protected static readonly CollectionConverter CollectionConverter = new CollectionConverter();
+        protected static readonly CollectionConverter CollectionConverter = new();
     }
 
     /// <summary>

--- a/src/JsonApiDotNetCore/Hooks/Internal/Traversal/NodeNavigator.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/Traversal/NodeNavigator.cs
@@ -17,8 +17,8 @@ namespace JsonApiDotNetCore.Hooks.Internal.Traversal
     /// </summary>
     internal sealed class NodeNavigator : INodeNavigator
     {
-        private static readonly HooksObjectFactory ObjectFactory = new HooksObjectFactory();
-        private static readonly HooksCollectionConverter CollectionConverter = new HooksCollectionConverter();
+        private static readonly HooksObjectFactory ObjectFactory = new();
+        private static readonly HooksCollectionConverter CollectionConverter = new();
 
         private readonly IdentifiableComparer _comparer = IdentifiableComparer.Instance;
         private readonly IResourceGraph _resourceGraph;
@@ -27,7 +27,7 @@ namespace JsonApiDotNetCore.Hooks.Internal.Traversal
         /// <summary>
         /// A mapper from <see cref="RelationshipAttribute" /> to <see cref="RelationshipProxy" />. See the latter for more details.
         /// </summary>
-        private readonly Dictionary<RelationshipAttribute, RelationshipProxy> _relationshipProxies = new Dictionary<RelationshipAttribute, RelationshipProxy>();
+        private readonly Dictionary<RelationshipAttribute, RelationshipProxy> _relationshipProxies = new();
 
         /// <summary>
         /// Keeps track of which resources has already been traversed through, to prevent infinite loops in eg cyclic data structures.

--- a/src/JsonApiDotNetCore/Hooks/Internal/Traversal/RelationshipProxy.cs
+++ b/src/JsonApiDotNetCore/Hooks/Internal/Traversal/RelationshipProxy.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Hooks.Internal.Traversal
     /// </summary>
     internal sealed class RelationshipProxy
     {
-        private static readonly HooksCollectionConverter CollectionConverter = new HooksCollectionConverter();
+        private static readonly HooksCollectionConverter CollectionConverter = new();
 
         private readonly bool _skipThroughType;
 

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.3.0" />
     <PackageReference Include="Humanizer" Version="2.8.26" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -14,6 +14,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DebugType>embedded</DebugType>
+    <Version>4.1.1-pre</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
@@ -102,6 +102,7 @@ namespace JsonApiDotNetCore.Middleware
         {
             string contentType = httpContext.Request.ContentType;
 
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
             if (contentType != null && contentType != allowedContentType)
             {
                 await FlushResponseAsync(httpContext.Response, serializerSettings, new Error(HttpStatusCode.UnsupportedMediaType)
@@ -257,11 +258,11 @@ namespace JsonApiDotNetCore.Middleware
             if (resourceName != null)
             {
                 Endpoint endpoint = httpContext.GetEndpoint();
-                var routeAttribute = endpoint.Metadata.GetMetadata<RouteAttribute>();
+                var routeAttribute = endpoint?.Metadata.GetMetadata<RouteAttribute>();
 
                 if (routeAttribute != null)
                 {
-                    List<string> trimmedComponents = httpContext.Request.Path.Value.Trim('/').Split('/').ToList();
+                    List<string> trimmedComponents = httpContext.Request.Path.Value!.Trim('/').Split('/').ToList();
                     int resourceNameIndex = trimmedComponents.FindIndex(component => component == resourceName);
                     string[] newComponents = trimmedComponents.Take(resourceNameIndex).ToArray();
                     string customRoute = string.Join('/', newComponents);

--- a/src/JsonApiDotNetCore/Middleware/JsonApiRoutingConvention.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiRoutingConvention.cs
@@ -33,8 +33,8 @@ namespace JsonApiDotNetCore.Middleware
     {
         private readonly IJsonApiOptions _options;
         private readonly IResourceContextProvider _resourceContextProvider;
-        private readonly Dictionary<string, string> _registeredControllerNameByTemplate = new Dictionary<string, string>();
-        private readonly Dictionary<Type, ResourceContext> _resourceContextPerControllerTypeMap = new Dictionary<Type, ResourceContext>();
+        private readonly Dictionary<string, string> _registeredControllerNameByTemplate = new();
+        private readonly Dictionary<Type, ResourceContext> _resourceContextPerControllerTypeMap = new();
 
         public JsonApiRoutingConvention(IJsonApiOptions options, IResourceContextProvider resourceContextProvider)
         {

--- a/src/JsonApiDotNetCore/ObjectExtensions.cs
+++ b/src/JsonApiDotNetCore/ObjectExtensions.cs
@@ -21,7 +21,7 @@ namespace JsonApiDotNetCore
 
         public static List<T> AsList<T>(this T element)
         {
-            return new List<T>
+            return new()
             {
                 element
             };

--- a/src/JsonApiDotNetCore/Queries/Expressions/IncludeChainConverter.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/IncludeChainConverter.cs
@@ -94,9 +94,9 @@ namespace JsonApiDotNetCore.Queries.Expressions
 
         private sealed class IncludeToChainsConverter : QueryExpressionVisitor<object, object>
         {
-            private readonly Stack<RelationshipAttribute> _parentRelationshipStack = new Stack<RelationshipAttribute>();
+            private readonly Stack<RelationshipAttribute> _parentRelationshipStack = new();
 
-            public List<ResourceFieldChainExpression> Chains { get; } = new List<ResourceFieldChainExpression>();
+            public List<ResourceFieldChainExpression> Chains { get; } = new();
 
             public override object VisitInclude(IncludeExpression expression, object argument)
             {

--- a/src/JsonApiDotNetCore/Queries/Expressions/IncludeExpression.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/IncludeExpression.cs
@@ -11,9 +11,9 @@ namespace JsonApiDotNetCore.Queries.Expressions
     [PublicAPI]
     public class IncludeExpression : QueryExpression
     {
-        private static readonly IncludeChainConverter IncludeChainConverter = new IncludeChainConverter();
+        private static readonly IncludeChainConverter IncludeChainConverter = new();
 
-        public static readonly IncludeExpression Empty = new IncludeExpression();
+        public static readonly IncludeExpression Empty = new();
 
         public IReadOnlyCollection<IncludeElementExpression> Elements { get; }
 

--- a/src/JsonApiDotNetCore/Queries/Internal/Parsing/IncludeParser.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/Parsing/IncludeParser.cs
@@ -11,7 +11,7 @@ namespace JsonApiDotNetCore.Queries.Internal.Parsing
     [PublicAPI]
     public class IncludeParser : QueryExpressionParser
     {
-        private static readonly IncludeChainConverter IncludeChainConverter = new IncludeChainConverter();
+        private static readonly IncludeChainConverter IncludeChainConverter = new();
 
         private readonly Action<RelationshipAttribute, ResourceContext, string> _validateSingleRelationshipCallback;
         private ResourceContext _resourceContextInScope;

--- a/src/JsonApiDotNetCore/Queries/Internal/Parsing/QueryTokenizer.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/Parsing/QueryTokenizer.cs
@@ -21,7 +21,7 @@ namespace JsonApiDotNetCore.Queries.Internal.Parsing
             });
 
         private readonly string _source;
-        private readonly StringBuilder _textBuffer = new StringBuilder();
+        private readonly StringBuilder _textBuffer = new();
         private int _offset;
         private bool _isInQuotedSection;
 
@@ -119,12 +119,12 @@ namespace JsonApiDotNetCore.Queries.Internal.Parsing
 
         private char? PeekChar()
         {
-            return _offset + 1 < _source.Length ? (char?)_source[_offset + 1] : null;
+            return _offset + 1 < _source.Length ? _source[_offset + 1] : null;
         }
 
         private static TokenKind? TryGetSingleCharacterTokenKind(char ch)
         {
-            return SingleCharacterToTokenKinds.ContainsKey(ch) ? (TokenKind?)SingleCharacterToTokenKinds[ch] : null;
+            return SingleCharacterToTokenKinds.ContainsKey(ch) ? SingleCharacterToTokenKinds[ch] : null;
         }
 
         private Token ProduceTokenFromTextBuffer(bool isQuotedText)

--- a/src/JsonApiDotNetCore/Queries/Internal/QueryLayerComposer.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryLayerComposer.cs
@@ -13,7 +13,7 @@ namespace JsonApiDotNetCore.Queries.Internal
     [PublicAPI]
     public class QueryLayerComposer : IQueryLayerComposer
     {
-        private readonly CollectionConverter _collectionConverter = new CollectionConverter();
+        private readonly CollectionConverter _collectionConverter = new();
         private readonly IEnumerable<IQueryConstraintProvider> _constraintProviders;
         private readonly IResourceContextProvider _resourceContextProvider;
         private readonly IResourceDefinitionAccessor _resourceDefinitionAccessor;
@@ -401,7 +401,7 @@ namespace JsonApiDotNetCore.Queries.Internal
                 Filter = leftFilter,
                 Projection = new Dictionary<ResourceFieldAttribute, QueryLayer>
                 {
-                    [hasManyRelationship] = new QueryLayer(rightResourceContext)
+                    [hasManyRelationship] = new(rightResourceContext)
                     {
                         Filter = rightFilter,
                         Projection = new Dictionary<ResourceFieldAttribute, QueryLayer>

--- a/src/JsonApiDotNetCore/Queries/Internal/QueryLayerComposer.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryLayerComposer.cs
@@ -100,7 +100,7 @@ namespace JsonApiDotNetCore.Queries.Internal
             {
                 Filter = GetFilter(expressionsInTopScope, resourceContext),
                 Sort = GetSort(expressionsInTopScope, resourceContext),
-                Pagination = ((JsonApiOptions)_options).DisableTopPagination ? null : topPagination,
+                Pagination = topPagination,
                 Projection = GetProjectionForSparseAttributeSet(resourceContext)
             };
         }
@@ -164,7 +164,7 @@ namespace JsonApiDotNetCore.Queries.Internal
                     {
                         Filter = GetFilter(expressionsInCurrentScope, resourceContext),
                         Sort = GetSort(expressionsInCurrentScope, resourceContext),
-                        Pagination = ((JsonApiOptions)_options).DisableChildrenPagination ? null : GetPagination(expressionsInCurrentScope, resourceContext),
+                        Pagination = GetPagination(expressionsInCurrentScope, resourceContext),
                         Projection = GetProjectionForSparseAttributeSet(resourceContext)
                     };
 

--- a/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/IncludeClauseBuilder.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/IncludeClauseBuilder.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
     [PublicAPI]
     public class IncludeClauseBuilder : QueryClauseBuilder<object>
     {
-        private static readonly IncludeChainConverter IncludeChainConverter = new IncludeChainConverter();
+        private static readonly IncludeChainConverter IncludeChainConverter = new();
 
         private readonly Expression _source;
         private readonly ResourceContext _resourceContext;

--- a/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/LambdaParameterNameFactory.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/LambdaParameterNameFactory.cs
@@ -10,7 +10,7 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
     [PublicAPI]
     public sealed class LambdaParameterNameFactory
     {
-        private readonly HashSet<string> _namesInScope = new HashSet<string>();
+        private readonly HashSet<string> _namesInScope = new();
 
         public LambdaParameterNameScope Create(string typeName)
         {

--- a/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/SelectClauseBuilder.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/SelectClauseBuilder.cs
@@ -9,7 +9,6 @@ using JsonApiDotNetCore.Queries.Expressions;
 using JsonApiDotNetCore.Repositories;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
@@ -21,7 +20,7 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
     [PublicAPI]
     public class SelectClauseBuilder : QueryClauseBuilder<object>
     {
-        private static readonly CollectionConverter CollectionConverter = new CollectionConverter();
+        private static readonly CollectionConverter CollectionConverter = new();
         private static readonly ConstantExpression NullConstant = Expression.Constant(null);
 
         private readonly Expression _source;

--- a/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/WhereClauseBuilder.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/WhereClauseBuilder.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
     [PublicAPI]
     public class WhereClauseBuilder : QueryClauseBuilder<Type>
     {
-        private static readonly CollectionConverter CollectionConverter = new CollectionConverter();
+        private static readonly CollectionConverter CollectionConverter = new();
         private static readonly ConstantExpression NullConstant = Expression.Constant(null);
 
         private readonly Expression _source;

--- a/src/JsonApiDotNetCore/QueryStrings/Internal/FilterQueryStringParameterReader.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/Internal/FilterQueryStringParameterReader.cs
@@ -18,16 +18,15 @@ namespace JsonApiDotNetCore.QueryStrings.Internal
     [PublicAPI]
     public class FilterQueryStringParameterReader : QueryStringParameterReader, IFilterQueryStringParameterReader
     {
-        private static readonly LegacyFilterNotationConverter LegacyConverter = new LegacyFilterNotationConverter();
+        private static readonly LegacyFilterNotationConverter LegacyConverter = new();
 
         private readonly IJsonApiOptions _options;
         private readonly QueryStringParameterScopeParser _scopeParser;
         private readonly FilterParser _filterParser;
 
-        private readonly List<FilterExpression> _filtersInGlobalScope = new List<FilterExpression>();
+        private readonly List<FilterExpression> _filtersInGlobalScope = new();
 
-        private readonly Dictionary<ResourceFieldChainExpression, List<FilterExpression>> _filtersPerScope =
-            new Dictionary<ResourceFieldChainExpression, List<FilterExpression>>();
+        private readonly Dictionary<ResourceFieldChainExpression, List<FilterExpression>> _filtersPerScope = new();
 
         private string _lastParameterName;
 

--- a/src/JsonApiDotNetCore/QueryStrings/Internal/LegacyFilterNotationConverter.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/Internal/LegacyFilterNotationConverter.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCore.QueryStrings.Internal
         private const string InPrefix = "in:";
         private const string NotInPrefix = "nin:";
 
-        private static readonly Dictionary<string, string> PrefixConversionTable = new Dictionary<string, string>
+        private static readonly Dictionary<string, string> PrefixConversionTable = new()
         {
             ["eq:"] = Keywords.Equals,
             ["lt:"] = Keywords.LessThan,

--- a/src/JsonApiDotNetCore/QueryStrings/Internal/PaginationQueryStringParameterReader.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/Internal/PaginationQueryStringParameterReader.cs
@@ -11,6 +11,8 @@ using JsonApiDotNetCore.Queries.Expressions;
 using JsonApiDotNetCore.Queries.Internal.Parsing;
 using Microsoft.Extensions.Primitives;
 
+// ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
+
 namespace JsonApiDotNetCore.QueryStrings.Internal
 {
     [PublicAPI]
@@ -144,10 +146,9 @@ namespace JsonApiDotNetCore.QueryStrings.Internal
 
         private sealed class PaginationContext
         {
-            private readonly MutablePaginationEntry _globalScope = new MutablePaginationEntry();
+            private readonly MutablePaginationEntry _globalScope = new();
 
-            private readonly Dictionary<ResourceFieldChainExpression, MutablePaginationEntry> _nestedScopes =
-                new Dictionary<ResourceFieldChainExpression, MutablePaginationEntry>();
+            private readonly Dictionary<ResourceFieldChainExpression, MutablePaginationEntry> _nestedScopes = new();
 
             public MutablePaginationEntry ResolveEntryInScope(ResourceFieldChainExpression scope)
             {

--- a/src/JsonApiDotNetCore/QueryStrings/Internal/RequestQueryStringAccessor.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/Internal/RequestQueryStringAccessor.cs
@@ -7,7 +7,7 @@ namespace JsonApiDotNetCore.QueryStrings.Internal
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public IQueryCollection Query => _httpContextAccessor.HttpContext.Request.Query;
+        public IQueryCollection Query => _httpContextAccessor.HttpContext!.Request.Query;
 
         public RequestQueryStringAccessor(IHttpContextAccessor httpContextAccessor)
         {

--- a/src/JsonApiDotNetCore/QueryStrings/Internal/ResourceDefinitionQueryableParameterReader.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/Internal/ResourceDefinitionQueryableParameterReader.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCore.QueryStrings.Internal
     {
         private readonly IJsonApiRequest _request;
         private readonly IResourceDefinitionAccessor _resourceDefinitionAccessor;
-        private readonly List<ExpressionInScope> _constraints = new List<ExpressionInScope>();
+        private readonly List<ExpressionInScope> _constraints = new();
 
         public ResourceDefinitionQueryableParameterReader(IJsonApiRequest request, IResourceDefinitionAccessor resourceDefinitionAccessor)
         {

--- a/src/JsonApiDotNetCore/QueryStrings/Internal/SortQueryStringParameterReader.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/Internal/SortQueryStringParameterReader.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCore.QueryStrings.Internal
     {
         private readonly QueryStringParameterScopeParser _scopeParser;
         private readonly SortParser _sortParser;
-        private readonly List<ExpressionInScope> _constraints = new List<ExpressionInScope>();
+        private readonly List<ExpressionInScope> _constraints = new();
         private string _lastParameterName;
 
         public SortQueryStringParameterReader(IJsonApiRequest request, IResourceContextProvider resourceContextProvider)

--- a/src/JsonApiDotNetCore/QueryStrings/Internal/SparseFieldSetQueryStringParameterReader.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/Internal/SparseFieldSetQueryStringParameterReader.cs
@@ -19,7 +19,7 @@ namespace JsonApiDotNetCore.QueryStrings.Internal
     {
         private readonly SparseFieldTypeParser _sparseFieldTypeParser;
         private readonly SparseFieldSetParser _sparseFieldSetParser;
-        private readonly Dictionary<ResourceContext, SparseFieldSetExpression> _sparseFieldTable = new Dictionary<ResourceContext, SparseFieldSetExpression>();
+        private readonly Dictionary<ResourceContext, SparseFieldSetExpression> _sparseFieldTable = new();
         private string _lastParameterName;
 
         public SparseFieldSetQueryStringParameterReader(IJsonApiRequest request, IResourceContextProvider resourceContextProvider)

--- a/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
+++ b/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
@@ -323,7 +323,7 @@ namespace JsonApiDotNetCore.Repositories
             if (relationship is HasOneAttribute)
             {
                 INavigation navigation = TryGetNavigation(relationship);
-                return navigation?.IsDependentToPrincipal() ?? false;
+                return navigation?.IsOnDependent ?? false;
             }
 
             return false;
@@ -453,7 +453,7 @@ namespace JsonApiDotNetCore.Repositories
             {
                 await _dbContext.SaveChangesAsync(cancellationToken);
             }
-            catch (DbUpdateException exception)
+            catch (Exception exception) when (exception is DbUpdateException or InvalidOperationException)
             {
                 if (_dbContext.Database.CurrentTransaction != null)
                 {

--- a/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
+++ b/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
@@ -28,7 +28,7 @@ namespace JsonApiDotNetCore.Repositories
     public class EntityFrameworkCoreRepository<TResource, TId> : IResourceRepository<TResource, TId>, IRepositorySupportsTransaction
         where TResource : class, IIdentifiable<TId>
     {
-        private readonly CollectionConverter _collectionConverter = new CollectionConverter();
+        private readonly CollectionConverter _collectionConverter = new();
         private readonly ITargetedFields _targetedFields;
         private readonly DbContext _dbContext;
         private readonly IResourceGraph _resourceGraph;
@@ -226,7 +226,7 @@ namespace JsonApiDotNetCore.Repositories
             if (!(relationship is HasManyThroughAttribute))
             {
                 INavigation navigation = TryGetNavigation(relationship);
-                relationshipIsRequired = navigation?.ForeignKey?.IsRequired ?? false;
+                relationshipIsRequired = navigation?.ForeignKey.IsRequired ?? false;
             }
 
             bool relationshipIsBeingCleared = relationship is HasOneAttribute
@@ -426,7 +426,7 @@ namespace JsonApiDotNetCore.Repositories
             IIdentifiable[] rightResourcesTracked = rightResources.Select(collector.CaptureExisting).ToArray();
 
             return rightValue is IEnumerable
-                ? (object)_collectionConverter.CopyToTypedCollection(rightResourcesTracked, relationshipPropertyType)
+                ? _collectionConverter.CopyToTypedCollection(rightResourcesTracked, relationshipPropertyType)
                 : rightResourcesTracked.Single();
         }
 

--- a/src/JsonApiDotNetCore/Repositories/PlaceholderResourceCollector.cs
+++ b/src/JsonApiDotNetCore/Repositories/PlaceholderResourceCollector.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCore.Repositories
     {
         private readonly IResourceFactory _resourceFactory;
         private readonly DbContext _dbContext;
-        private readonly List<object> _resources = new List<object>();
+        private readonly List<object> _resources = new();
 
         public PlaceholderResourceCollector(IResourceFactory resourceFactory, DbContext dbContext)
         {

--- a/src/JsonApiDotNetCore/Resources/Annotations/HasManyThroughAttribute.cs
+++ b/src/JsonApiDotNetCore/Resources/Annotations/HasManyThroughAttribute.cs
@@ -45,7 +45,7 @@ namespace JsonApiDotNetCore.Resources.Annotations
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class HasManyThroughAttribute : HasManyAttribute
     {
-        private static readonly CollectionConverter CollectionConverter = new CollectionConverter();
+        private static readonly CollectionConverter CollectionConverter = new();
 
         /// <summary>
         /// The name of the join property on the parent resource. In the example described above, this would be "ArticleTags".

--- a/src/JsonApiDotNetCore/Resources/IdentifiableComparer.cs
+++ b/src/JsonApiDotNetCore/Resources/IdentifiableComparer.cs
@@ -11,7 +11,7 @@ namespace JsonApiDotNetCore.Resources
     [PublicAPI]
     public sealed class IdentifiableComparer : IEqualityComparer<IIdentifiable>
     {
-        public static readonly IdentifiableComparer Instance = new IdentifiableComparer();
+        public static readonly IdentifiableComparer Instance = new();
 
         private IdentifiableComparer()
         {

--- a/src/JsonApiDotNetCore/Resources/OperationContainer.cs
+++ b/src/JsonApiDotNetCore/Resources/OperationContainer.cs
@@ -11,7 +11,7 @@ namespace JsonApiDotNetCore.Resources
     [PublicAPI]
     public sealed class OperationContainer
     {
-        private static readonly CollectionConverter CollectionConverter = new CollectionConverter();
+        private static readonly CollectionConverter CollectionConverter = new();
 
         public OperationKind Kind { get; }
         public IIdentifiable Resource { get; }

--- a/src/JsonApiDotNetCore/Serialization/BaseDeserializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/BaseDeserializer.cs
@@ -22,7 +22,7 @@ namespace JsonApiDotNetCore.Serialization
     [PublicAPI]
     public abstract class BaseDeserializer
     {
-        private protected static readonly CollectionConverter CollectionConverter = new CollectionConverter();
+        private protected static readonly CollectionConverter CollectionConverter = new();
 
         protected IResourceContextProvider ResourceContextProvider { get; }
         protected IResourceFactory ResourceFactory { get; }

--- a/src/JsonApiDotNetCore/Serialization/Building/MetaBuilder.cs
+++ b/src/JsonApiDotNetCore/Serialization/Building/MetaBuilder.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Serialization.Building
         private readonly IJsonApiOptions _options;
         private readonly IResponseMeta _responseMeta;
 
-        private Dictionary<string, object> _meta = new Dictionary<string, object>();
+        private Dictionary<string, object> _meta = new();
 
         public MetaBuilder(IPaginationContext paginationContext, IJsonApiOptions options, IResponseMeta responseMeta)
         {

--- a/src/JsonApiDotNetCore/Serialization/Building/ResourceIdentifierObjectComparer.cs
+++ b/src/JsonApiDotNetCore/Serialization/Building/ResourceIdentifierObjectComparer.cs
@@ -6,7 +6,7 @@ namespace JsonApiDotNetCore.Serialization.Building
 {
     internal sealed class ResourceIdentifierObjectComparer : IEqualityComparer<ResourceIdentifierObject>
     {
-        public static readonly ResourceIdentifierObjectComparer Instance = new ResourceIdentifierObjectComparer();
+        public static readonly ResourceIdentifierObjectComparer Instance = new();
 
         private ResourceIdentifierObjectComparer()
         {

--- a/src/JsonApiDotNetCore/Serialization/Building/ResourceObjectBuilder.cs
+++ b/src/JsonApiDotNetCore/Serialization/Building/ResourceObjectBuilder.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCore.Serialization.Building
     [PublicAPI]
     public class ResourceObjectBuilder : IResourceObjectBuilder
     {
-        private static readonly CollectionConverter CollectionConverter = new CollectionConverter();
+        private static readonly CollectionConverter CollectionConverter = new();
 
         private readonly ResourceObjectBuilderSettings _settings;
         protected IResourceContextProvider ResourceContextProvider { get; }
@@ -88,7 +88,7 @@ namespace JsonApiDotNetCore.Serialization.Building
             ArgumentGuard.NotNull(resource, nameof(resource));
 
             return relationship is HasOneAttribute hasOne
-                ? (object)GetRelatedResourceLinkageForHasOne(hasOne, resource)
+                ? GetRelatedResourceLinkageForHasOne(hasOne, resource)
                 : GetRelatedResourceLinkageForHasMany((HasManyAttribute)relationship, resource);
         }
 

--- a/src/JsonApiDotNetCore/Serialization/Building/ResourceObjectBuilderSettingsProvider.cs
+++ b/src/JsonApiDotNetCore/Serialization/Building/ResourceObjectBuilderSettingsProvider.cs
@@ -24,7 +24,7 @@ namespace JsonApiDotNetCore.Serialization.Building
         /// <inheritdoc />
         public ResourceObjectBuilderSettings Get()
         {
-            return new ResourceObjectBuilderSettings(_nullsReader.SerializerNullValueHandling, _defaultsReader.SerializerDefaultValueHandling);
+            return new(_nullsReader.SerializerNullValueHandling, _defaultsReader.SerializerDefaultValueHandling);
         }
     }
 }

--- a/src/JsonApiDotNetCore/Serialization/Building/ResponseResourceObjectBuilder.cs
+++ b/src/JsonApiDotNetCore/Serialization/Building/ResponseResourceObjectBuilder.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCore.Serialization.Building
     [PublicAPI]
     public class ResponseResourceObjectBuilder : ResourceObjectBuilder
     {
-        private static readonly IncludeChainConverter IncludeChainConverter = new IncludeChainConverter();
+        private static readonly IncludeChainConverter IncludeChainConverter = new();
 
         private readonly IIncludedResourceObjectBuilder _includedBuilder;
         private readonly IEnumerable<IQueryConstraintProvider> _constraintProviders;

--- a/src/JsonApiDotNetCore/Serialization/Client/Internal/RequestSerializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/Client/Internal/RequestSerializer.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCore.Serialization.Client.Internal
     public class RequestSerializer : BaseSerializer, IRequestSerializer
     {
         private readonly IResourceGraph _resourceGraph;
-        private readonly JsonSerializerSettings _jsonSerializerSettings = new JsonSerializerSettings();
+        private readonly JsonSerializerSettings _jsonSerializerSettings = new();
         private Type _currentTargetedResource;
 
         /// <inheritdoc />

--- a/src/JsonApiDotNetCore/Serialization/JsonApiReader.cs
+++ b/src/JsonApiDotNetCore/Serialization/JsonApiReader.cs
@@ -81,7 +81,7 @@ namespace JsonApiDotNetCore.Serialization
                 ValidateRequestBody(model, body, context.HttpContext.Request);
             }
 
-            return await InputFormatterResult.SuccessAsync(model);
+            return await InputFormatterResult.SuccessAsync(model!);
         }
 
         private async Task<string> GetRequestBodyAsync(Stream bodyStream)

--- a/src/JsonApiDotNetCore/Serialization/Objects/Error.cs
+++ b/src/JsonApiDotNetCore/Serialization/Objects/Error.cs
@@ -23,7 +23,7 @@ namespace JsonApiDotNetCore.Serialization.Objects
         /// A link that leads to further details about this particular occurrence of the problem.
         /// </summary>
         [JsonProperty]
-        public ErrorLinks Links { get; set; } = new ErrorLinks();
+        public ErrorLinks Links { get; set; } = new();
 
         /// <summary>
         /// The HTTP status code applicable to this problem.
@@ -61,13 +61,13 @@ namespace JsonApiDotNetCore.Serialization.Objects
         /// An object containing references to the source of the error.
         /// </summary>
         [JsonProperty]
-        public ErrorSource Source { get; set; } = new ErrorSource();
+        public ErrorSource Source { get; set; } = new();
 
         /// <summary>
         /// An object containing non-standard meta-information (key/value pairs) about the error.
         /// </summary>
         [JsonProperty]
-        public ErrorMeta Meta { get; set; } = new ErrorMeta();
+        public ErrorMeta Meta { get; set; } = new();
 
         public Error(HttpStatusCode statusCode)
         {

--- a/src/JsonApiDotNetCore/Serialization/RequestDeserializer.cs
+++ b/src/JsonApiDotNetCore/Serialization/RequestDeserializer.cs
@@ -505,14 +505,14 @@ namespace JsonApiDotNetCore.Serialization
         {
             return _request.Kind == EndpointKind.AtomicOperations
                 ? _request.OperationKind == OperationKind.CreateResource
-                : _request.Kind == EndpointKind.Primary && _httpContextAccessor.HttpContext.Request.Method == HttpMethod.Post.Method;
+                : _request.Kind == EndpointKind.Primary && _httpContextAccessor.HttpContext!.Request.Method == HttpMethod.Post.Method;
         }
 
         private bool IsUpdatingResource()
         {
             return _request.Kind == EndpointKind.AtomicOperations
                 ? _request.OperationKind == OperationKind.UpdateResource
-                : _request.Kind == EndpointKind.Primary && _httpContextAccessor.HttpContext.Request.Method == HttpMethod.Patch.Method;
+                : _request.Kind == EndpointKind.Primary && _httpContextAccessor.HttpContext!.Request.Method == HttpMethod.Patch.Method;
         }
     }
 }

--- a/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
@@ -25,7 +25,7 @@ namespace JsonApiDotNetCore.Services
     public class JsonApiResourceService<TResource, TId> : IResourceService<TResource, TId>
         where TResource : class, IIdentifiable<TId>
     {
-        private readonly CollectionConverter _collectionConverter = new CollectionConverter();
+        private readonly CollectionConverter _collectionConverter = new();
         private readonly IResourceRepositoryAccessor _repositoryAccessor;
         private readonly IQueryLayerComposer _queryLayerComposer;
         private readonly IPaginationContext _paginationContext;

--- a/test/DiscoveryTests/ServiceDiscoveryFacadeTests.cs
+++ b/test/DiscoveryTests/ServiceDiscoveryFacadeTests.cs
@@ -20,7 +20,7 @@ namespace DiscoveryTests
     {
         private static readonly NullLoggerFactory LoggerFactory = NullLoggerFactory.Instance;
         private readonly IServiceCollection _services = new ServiceCollection();
-        private readonly JsonApiOptions _options = new JsonApiOptions();
+        private readonly JsonApiOptions _options = new();
         private readonly ResourceGraphBuilder _resourceGraphBuilder;
 
         public ServiceDiscoveryFacadeTests()

--- a/test/JsonApiDotNetCoreExampleTests/ExampleFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/ExampleFakers.cs
@@ -11,36 +11,36 @@ namespace JsonApiDotNetCoreExampleTests
 {
     internal sealed class ExampleFakers : FakerContainer
     {
-        private readonly Lazy<Faker<Author>> _lazyAuthorFaker = new Lazy<Faker<Author>>(() =>
+        private readonly Lazy<Faker<Author>> _lazyAuthorFaker = new(() =>
             new Faker<Author>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(author => author.FirstName, faker => faker.Person.FirstName)
                 .RuleFor(author => author.LastName, faker => faker.Person.LastName));
 
-        private readonly Lazy<Faker<Article>> _lazyArticleFaker = new Lazy<Faker<Article>>(() =>
+        private readonly Lazy<Faker<Article>> _lazyArticleFaker = new(() =>
             new Faker<Article>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(article => article.Caption, faker => faker.Lorem.Word())
                 .RuleFor(article => article.Url, faker => faker.Internet.Url()));
 
-        private readonly Lazy<Faker<User>> _lazyUserFaker = new Lazy<Faker<User>>(() =>
+        private readonly Lazy<Faker<User>> _lazyUserFaker = new(() =>
             new Faker<User>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(user => user.UserName, faker => faker.Person.UserName)
                 .RuleFor(user => user.Password, faker => faker.Internet.Password()));
 
-        private readonly Lazy<Faker<TodoItem>> _lazyTodoItemFaker = new Lazy<Faker<TodoItem>>(() =>
+        private readonly Lazy<Faker<TodoItem>> _lazyTodoItemFaker = new(() =>
             new Faker<TodoItem>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(todoItem => todoItem.Description, faker => faker.Random.Words()));
 
-        private readonly Lazy<Faker<Person>> _lazyPersonFaker = new Lazy<Faker<Person>>(() =>
+        private readonly Lazy<Faker<Person>> _lazyPersonFaker = new(() =>
             new Faker<Person>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(person => person.FirstName, faker => faker.Person.FirstName)
                 .RuleFor(person => person.LastName, faker => faker.Person.LastName));
 
-        private readonly Lazy<Faker<Tag>> _lazyTagFaker = new Lazy<Faker<Tag>>(() =>
+        private readonly Lazy<Faker<Tag>> _lazyTagFaker = new(() =>
             new Faker<Tag>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(tag => tag.Name, faker => faker.Lorem.Word()));

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Controllers/AtomicConstrainedOperationsControllerTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Controllers/AtomicConstrainedOperationsControllerTests.cs
@@ -13,7 +13,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Contro
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicConstrainedOperationsControllerTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceTests.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Creati
     public sealed class AtomicCreateResourceTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicCreateResourceTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithClientGeneratedIdTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithClientGeneratedIdTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Creati
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicCreateResourceWithClientGeneratedIdTests(
             ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithToManyRelationshipTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Creati
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicCreateResourceWithToManyRelationshipTests(
             ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithToOneRelationshipTests.cs
@@ -19,7 +19,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Creati
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicCreateResourceWithToOneRelationshipTests(
             ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Deleting/AtomicDeleteResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Deleting/AtomicDeleteResourceTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Deleti
     public sealed class AtomicDeleteResourceTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicDeleteResourceTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Links/AtomicAbsoluteLinksTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Links/AtomicAbsoluteLinksTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Links
         private const string HostPrefix = "http://localhost";
 
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicAbsoluteLinksTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/LocalIds/AtomicLocalIdTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/LocalIds/AtomicLocalIdTests.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.LocalI
     public sealed class AtomicLocalIdTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicLocalIdTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Meta/AtomicResourceMetaTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Meta/AtomicResourceMetaTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Meta
     public sealed class AtomicResourceMetaTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicResourceMetaTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Meta/AtomicResponseMetaTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Meta/AtomicResponseMetaTests.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Meta
     public sealed class AtomicResponseMetaTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicResponseMetaTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/ModelStateValidation/AtomicModelStateValidationTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/ModelStateValidation/AtomicModelStateValidationTests.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.ModelS
         : IClassFixture<ExampleIntegrationTestContext<ModelStateValidationStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<ModelStateValidationStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicModelStateValidationTests(ExampleIntegrationTestContext<ModelStateValidationStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/OperationsFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/OperationsFakers.cs
@@ -13,18 +13,18 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations
     internal sealed class OperationsFakers : FakerContainer
     {
         private static readonly Lazy<IReadOnlyList<string>> LazyLanguageIsoCodes =
-            new Lazy<IReadOnlyList<string>>(() => CultureInfo
+            new(() => CultureInfo
                 .GetCultures(CultureTypes.NeutralCultures)
                 .Where(culture => !string.IsNullOrEmpty(culture.Name))
                 .Select(culture => culture.Name)
                 .ToArray());
 
-        private readonly Lazy<Faker<Playlist>> _lazyPlaylistFaker = new Lazy<Faker<Playlist>>(() =>
+        private readonly Lazy<Faker<Playlist>> _lazyPlaylistFaker = new(() =>
             new Faker<Playlist>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(playlist => playlist.Name, faker => faker.Lorem.Sentence()));
 
-        private readonly Lazy<Faker<MusicTrack>> _lazyMusicTrackFaker = new Lazy<Faker<MusicTrack>>(() =>
+        private readonly Lazy<Faker<MusicTrack>> _lazyMusicTrackFaker = new(() =>
             new Faker<MusicTrack>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(musicTrack => musicTrack.Title, faker => faker.Lorem.Word())
@@ -32,24 +32,24 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations
                 .RuleFor(musicTrack => musicTrack.Genre, faker => faker.Lorem.Word())
                 .RuleFor(musicTrack => musicTrack.ReleasedAt, faker => faker.Date.PastOffset()));
 
-        private readonly Lazy<Faker<Lyric>> _lazyLyricFaker = new Lazy<Faker<Lyric>>(() =>
+        private readonly Lazy<Faker<Lyric>> _lazyLyricFaker = new(() =>
             new Faker<Lyric>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(lyric => lyric.Text, faker => faker.Lorem.Text())
                 .RuleFor(lyric => lyric.Format, "LRC"));
 
-        private readonly Lazy<Faker<TextLanguage>> _lazyTextLanguageFaker = new Lazy<Faker<TextLanguage>>(() =>
+        private readonly Lazy<Faker<TextLanguage>> _lazyTextLanguageFaker = new(() =>
             new Faker<TextLanguage>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(textLanguage => textLanguage.IsoCode, faker => faker.PickRandom<string>(LazyLanguageIsoCodes.Value)));
 
-        private readonly Lazy<Faker<Performer>> _lazyPerformerFaker = new Lazy<Faker<Performer>>(() =>
+        private readonly Lazy<Faker<Performer>> _lazyPerformerFaker = new(() =>
             new Faker<Performer>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(performer => performer.ArtistName, faker => faker.Name.FullName())
                 .RuleFor(performer => performer.BornAt, faker => faker.Date.PastOffset()));
 
-        private readonly Lazy<Faker<RecordCompany>> _lazyRecordCompanyFaker = new Lazy<Faker<RecordCompany>>(() =>
+        private readonly Lazy<Faker<RecordCompany>> _lazyRecordCompanyFaker = new(() =>
             new Faker<RecordCompany>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(recordCompany => recordCompany.Name, faker => faker.Company.CompanyName())

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/QueryStrings/AtomicQueryStringTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/QueryStrings/AtomicQueryStringTests.cs
@@ -22,7 +22,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.QueryS
         private static readonly DateTime FrozenTime = 30.July(2018).At(13, 46, 12);
 
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicQueryStringTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/QueryStrings/MusicTrackReleaseDefinition.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/QueryStrings/MusicTrackReleaseDefinition.cs
@@ -24,7 +24,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.QueryS
 
         public override QueryStringParameterHandlers<MusicTrack> OnRegisterQueryableHandlersForQueryStringParameters()
         {
-            return new QueryStringParameterHandlers<MusicTrack>
+            return new()
             {
                 ["isRecentlyReleased"] = FilterOnRecentlyReleased
             };

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/ResourceDefinitions/AtomicSparseFieldSetResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/ResourceDefinitions/AtomicSparseFieldSetResourceDefinitionTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Resour
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicSparseFieldSetResourceDefinitionTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Transactions/AtomicRollbackTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Transactions/AtomicRollbackTests.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Transa
     public sealed class AtomicRollbackTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicRollbackTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Transactions/LyricRepository.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Transactions/LyricRepository.cs
@@ -13,7 +13,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Transa
     {
         private readonly ExtraDbContext _extraDbContext;
 
-        public override string TransactionId => _extraDbContext.Database.CurrentTransaction.TransactionId.ToString();
+        public override string TransactionId => _extraDbContext.Database.CurrentTransaction!.TransactionId.ToString();
 
         public LyricRepository(ExtraDbContext extraDbContext, ITargetedFields targetedFields, IDbContextResolver contextResolver, IResourceGraph resourceGraph,
             IResourceFactory resourceFactory, IEnumerable<IQueryConstraintProvider> constraintProviders, ILoggerFactory loggerFactory)

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Relationships/AtomicAddToToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Relationships/AtomicAddToToManyRelationshipTests.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicAddToToManyRelationshipTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {
@@ -166,7 +166,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
 
             existingPlaylist.PlaylistMusicTracks = new List<PlaylistMusicTrack>
             {
-                new PlaylistMusicTrack
+                new()
                 {
                     MusicTrack = _fakers.MusicTrack.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Relationships/AtomicRemoveFromToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Relationships/AtomicRemoveFromToManyRelationshipTests.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicRemoveFromToManyRelationshipTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {
@@ -165,15 +165,15 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
 
             existingPlaylist.PlaylistMusicTracks = new List<PlaylistMusicTrack>
             {
-                new PlaylistMusicTrack
+                new()
                 {
                     MusicTrack = _fakers.MusicTrack.Generate()
                 },
-                new PlaylistMusicTrack
+                new()
                 {
                     MusicTrack = _fakers.MusicTrack.Generate()
                 },
-                new PlaylistMusicTrack
+                new()
                 {
                     MusicTrack = _fakers.MusicTrack.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Relationships/AtomicReplaceToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Relationships/AtomicReplaceToManyRelationshipTests.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicReplaceToManyRelationshipTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {
@@ -88,11 +88,11 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
 
             existingPlaylist.PlaylistMusicTracks = new List<PlaylistMusicTrack>
             {
-                new PlaylistMusicTrack
+                new()
                 {
                     MusicTrack = _fakers.MusicTrack.Generate()
                 },
-                new PlaylistMusicTrack
+                new()
                 {
                     MusicTrack = _fakers.MusicTrack.Generate()
                 }
@@ -231,7 +231,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
 
             existingPlaylist.PlaylistMusicTracks = new List<PlaylistMusicTrack>
             {
-                new PlaylistMusicTrack
+                new()
                 {
                     MusicTrack = _fakers.MusicTrack.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Relationships/AtomicUpdateToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Relationships/AtomicUpdateToOneRelationshipTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicUpdateToOneRelationshipTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Resources/AtomicReplaceToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Resources/AtomicReplaceToManyRelationshipTests.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicReplaceToManyRelationshipTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {
@@ -93,11 +93,11 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
 
             existingPlaylist.PlaylistMusicTracks = new List<PlaylistMusicTrack>
             {
-                new PlaylistMusicTrack
+                new()
                 {
                     MusicTrack = _fakers.MusicTrack.Generate()
                 },
-                new PlaylistMusicTrack
+                new()
                 {
                     MusicTrack = _fakers.MusicTrack.Generate()
                 }
@@ -246,7 +246,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
 
             existingPlaylist.PlaylistMusicTracks = new List<PlaylistMusicTrack>
             {
-                new PlaylistMusicTrack
+                new()
                 {
                     MusicTrack = _fakers.MusicTrack.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Resources/AtomicUpdateResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Resources/AtomicUpdateResourceTests.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
     public sealed class AtomicUpdateResourceTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicUpdateResourceTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Resources/AtomicUpdateToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/AtomicOperations/Updating/Resources/AtomicUpdateToOneRelationshipTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.AtomicOperations.Updati
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
-        private readonly OperationsFakers _fakers = new OperationsFakers();
+        private readonly OperationsFakers _fakers = new();
 
         public AtomicUpdateToOneRelationshipTests(ExampleIntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/CompositeKeys/CompositeKeyTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/CompositeKeys/CompositeKeyTests.cs
@@ -188,7 +188,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.CompositeKeys
                 Car carInDatabase = await dbContext.Cars.FirstOrDefaultAsync(car => car.RegionId == 123 && car.LicensePlate == "AA-BB-11");
 
                 carInDatabase.Should().NotBeNull();
-                carInDatabase.Id.Should().Be("123:AA-BB-11");
+                carInDatabase!.Id.Should().Be("123:AA-BB-11");
             });
         }
 
@@ -317,12 +317,12 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.CompositeKeys
                 Address = "Dam 1, 1012JS Amsterdam, the Netherlands",
                 Inventory = new HashSet<Car>
                 {
-                    new Car
+                    new()
                     {
                         RegionId = 123,
                         LicensePlate = "AA-BB-11"
                     },
-                    new Car
+                    new()
                     {
                         RegionId = 456,
                         LicensePlate = "CC-DD-22"
@@ -432,12 +432,12 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.CompositeKeys
                 Address = "Dam 1, 1012JS Amsterdam, the Netherlands",
                 Inventory = new HashSet<Car>
                 {
-                    new Car
+                    new()
                     {
                         RegionId = 123,
                         LicensePlate = "AA-BB-11"
                     },
-                    new Car
+                    new()
                     {
                         RegionId = 456,
                         LicensePlate = "CC-DD-22"

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ContentNegotiation/ContentTypeHeaderTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ContentNegotiation/ContentTypeHeaderTests.cs
@@ -34,7 +34,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ContentNegotiation
 
             // Assert
             httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
-            httpResponse.Content.Headers.ContentType.ToString().Should().Be(HeaderConstants.MediaType);
+            httpResponse.Content.Headers.ContentType!.ToString().Should().Be(HeaderConstants.MediaType);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ContentNegotiation
 
             // Assert
             httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
-            httpResponse.Content.Headers.ContentType.ToString().Should().Be(HeaderConstants.AtomicOperationsMediaType);
+            httpResponse.Content.Headers.ContentType!.ToString().Should().Be(HeaderConstants.AtomicOperationsMediaType);
         }
 
         [Fact]

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/CustomRoutes/CustomRouteFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/CustomRoutes/CustomRouteFakers.cs
@@ -9,14 +9,14 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.CustomRoutes
 {
     internal sealed class CustomRouteFakers : FakerContainer
     {
-        private readonly Lazy<Faker<Town>> _lazyTownFaker = new Lazy<Faker<Town>>(() =>
+        private readonly Lazy<Faker<Town>> _lazyTownFaker = new(() =>
             new Faker<Town>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(town => town.Name, faker => faker.Address.City())
                 .RuleFor(town => town.Latitude, faker => faker.Address.Latitude())
                 .RuleFor(town => town.Longitude, faker => faker.Address.Longitude()));
 
-        private readonly Lazy<Faker<Civilian>> _lazyCivilianFaker = new Lazy<Faker<Civilian>>(() =>
+        private readonly Lazy<Faker<Civilian>> _lazyCivilianFaker = new(() =>
             new Faker<Civilian>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(civilian => civilian.Name, faker => faker.Person.FullName));

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/CustomRoutes/CustomRouteTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/CustomRoutes/CustomRouteTests.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.CustomRoutes
         private const string HostPrefix = "http://localhost";
 
         private readonly ExampleIntegrationTestContext<TestableStartup<CustomRouteDbContext>, CustomRouteDbContext> _testContext;
-        private readonly CustomRouteFakers _fakers = new CustomRouteFakers();
+        private readonly CustomRouteFakers _fakers = new();
 
         public CustomRouteTests(ExampleIntegrationTestContext<TestableStartup<CustomRouteDbContext>, CustomRouteDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/EagerLoading/EagerLoadingFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/EagerLoading/EagerLoadingFakers.cs
@@ -9,33 +9,33 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.EagerLoading
 {
     internal sealed class EagerLoadingFakers : FakerContainer
     {
-        private readonly Lazy<Faker<State>> _lazyStateFaker = new Lazy<Faker<State>>(() =>
+        private readonly Lazy<Faker<State>> _lazyStateFaker = new(() =>
             new Faker<State>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(state => state.Name, faker => faker.Address.City()));
 
-        private readonly Lazy<Faker<City>> _lazyCityFaker = new Lazy<Faker<City>>(() =>
+        private readonly Lazy<Faker<City>> _lazyCityFaker = new(() =>
             new Faker<City>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(city => city.Name, faker => faker.Address.City()));
 
-        private readonly Lazy<Faker<Street>> _lazyStreetFaker = new Lazy<Faker<Street>>(() =>
+        private readonly Lazy<Faker<Street>> _lazyStreetFaker = new(() =>
             new Faker<Street>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(street => street.Name, faker => faker.Address.StreetName()));
 
-        private readonly Lazy<Faker<Building>> _lazyBuildingFaker = new Lazy<Faker<Building>>(() =>
+        private readonly Lazy<Faker<Building>> _lazyBuildingFaker = new(() =>
             new Faker<Building>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(building => building.Number, faker => faker.Address.BuildingNumber()));
 
-        private readonly Lazy<Faker<Window>> _lazyWindowFaker = new Lazy<Faker<Window>>(() =>
+        private readonly Lazy<Faker<Window>> _lazyWindowFaker = new(() =>
             new Faker<Window>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(window => window.HeightInCentimeters, faker => faker.Random.Number(30, 199))
                 .RuleFor(window => window.WidthInCentimeters, faker => faker.Random.Number(30, 199)));
 
-        private readonly Lazy<Faker<Door>> _lazyDoorFaker = new Lazy<Faker<Door>>(() =>
+        private readonly Lazy<Faker<Door>> _lazyDoorFaker = new(() =>
             new Faker<Door>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(door => door.Color, faker => faker.Commerce.Color()));

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/EagerLoading/EagerLoadingTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/EagerLoading/EagerLoadingTests.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.EagerLoading
     public sealed class EagerLoadingTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<EagerLoadingDbContext>, EagerLoadingDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<EagerLoadingDbContext>, EagerLoadingDbContext> _testContext;
-        private readonly EagerLoadingFakers _fakers = new EagerLoadingFakers();
+        private readonly EagerLoadingFakers _fakers = new();
 
         public EagerLoadingTests(ExampleIntegrationTestContext<TestableStartup<EagerLoadingDbContext>, EagerLoadingDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/HostingInIIS/HostingFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/HostingInIIS/HostingFakers.cs
@@ -9,12 +9,12 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.HostingInIIS
 {
     internal sealed class HostingFakers : FakerContainer
     {
-        private readonly Lazy<Faker<ArtGallery>> _lazyArtGalleryFaker = new Lazy<Faker<ArtGallery>>(() =>
+        private readonly Lazy<Faker<ArtGallery>> _lazyArtGalleryFaker = new(() =>
             new Faker<ArtGallery>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(artGallery => artGallery.Theme, faker => faker.Lorem.Word()));
 
-        private readonly Lazy<Faker<Painting>> _lazyPaintingFaker = new Lazy<Faker<Painting>>(() =>
+        private readonly Lazy<Faker<Painting>> _lazyPaintingFaker = new(() =>
             new Faker<Painting>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(painting => painting.Title, faker => faker.Lorem.Sentence()));

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/HostingInIIS/HostingTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/HostingInIIS/HostingTests.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.HostingInIIS
         private const string HostPrefix = "http://localhost";
 
         private readonly ExampleIntegrationTestContext<HostingStartup<HostingDbContext>, HostingDbContext> _testContext;
-        private readonly HostingFakers _fakers = new HostingFakers();
+        private readonly HostingFakers _fakers = new();
 
         public HostingTests(ExampleIntegrationTestContext<HostingStartup<HostingDbContext>, HostingDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/IdObfuscation/IdObfuscationTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/IdObfuscation/IdObfuscationTests.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.IdObfuscation
     public sealed class IdObfuscationTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ObfuscationDbContext>, ObfuscationDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ObfuscationDbContext>, ObfuscationDbContext> _testContext;
-        private readonly ObfuscationFakers _fakers = new ObfuscationFakers();
+        private readonly ObfuscationFakers _fakers = new();
 
         public IdObfuscationTests(ExampleIntegrationTestContext<TestableStartup<ObfuscationDbContext>, ObfuscationDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/IdObfuscation/ObfuscatedIdentifiable.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/IdObfuscation/ObfuscatedIdentifiable.cs
@@ -4,7 +4,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.IdObfuscation
 {
     public abstract class ObfuscatedIdentifiable : Identifiable
     {
-        private static readonly HexadecimalCodec Codec = new HexadecimalCodec();
+        private static readonly HexadecimalCodec Codec = new();
 
         protected override string GetStringId(int value)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/IdObfuscation/ObfuscatedIdentifiableController.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/IdObfuscation/ObfuscatedIdentifiableController.cs
@@ -13,7 +13,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.IdObfuscation
     public abstract class ObfuscatedIdentifiableController<TResource> : BaseJsonApiController<TResource>
         where TResource : class, IIdentifiable<int>
     {
-        private readonly HexadecimalCodec _codec = new HexadecimalCodec();
+        private readonly HexadecimalCodec _codec = new();
 
         protected ObfuscatedIdentifiableController(IJsonApiOptions options, ILoggerFactory loggerFactory, IResourceService<TResource> resourceService)
             : base(options, loggerFactory, resourceService)

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/IdObfuscation/ObfuscationFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/IdObfuscation/ObfuscationFakers.cs
@@ -9,12 +9,12 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.IdObfuscation
 {
     internal sealed class ObfuscationFakers : FakerContainer
     {
-        private readonly Lazy<Faker<BankAccount>> _lazyBankAccountFaker = new Lazy<Faker<BankAccount>>(() =>
+        private readonly Lazy<Faker<BankAccount>> _lazyBankAccountFaker = new(() =>
             new Faker<BankAccount>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(bankAccount => bankAccount.Iban, faker => faker.Finance.Iban()));
 
-        private readonly Lazy<Faker<DebitCard>> _lazyDebitCardFaker = new Lazy<Faker<DebitCard>>(() =>
+        private readonly Lazy<Faker<DebitCard>> _lazyDebitCardFaker = new(() =>
             new Faker<DebitCard>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(debitCard => debitCard.OwnerName, faker => faker.Name.FullName())

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Links/AbsoluteLinksWithNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Links/AbsoluteLinksWithNamespaceTests.cs
@@ -19,7 +19,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Links
         private const string HostPrefix = "http://localhost";
 
         private readonly ExampleIntegrationTestContext<AbsoluteLinksInApiNamespaceStartup<LinksDbContext>, LinksDbContext> _testContext;
-        private readonly LinksFakers _fakers = new LinksFakers();
+        private readonly LinksFakers _fakers = new();
 
         public AbsoluteLinksWithNamespaceTests(ExampleIntegrationTestContext<AbsoluteLinksInApiNamespaceStartup<LinksDbContext>, LinksDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Links/AbsoluteLinksWithoutNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Links/AbsoluteLinksWithoutNamespaceTests.cs
@@ -19,7 +19,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Links
         private const string HostPrefix = "http://localhost";
 
         private readonly ExampleIntegrationTestContext<AbsoluteLinksNoNamespaceStartup<LinksDbContext>, LinksDbContext> _testContext;
-        private readonly LinksFakers _fakers = new LinksFakers();
+        private readonly LinksFakers _fakers = new();
 
         public AbsoluteLinksWithoutNamespaceTests(ExampleIntegrationTestContext<AbsoluteLinksNoNamespaceStartup<LinksDbContext>, LinksDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Links/LinkInclusionTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Links/LinkInclusionTests.cs
@@ -12,7 +12,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Links
     public sealed class LinkInclusionTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<LinksDbContext>, LinksDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<LinksDbContext>, LinksDbContext> _testContext;
-        private readonly LinksFakers _fakers = new LinksFakers();
+        private readonly LinksFakers _fakers = new();
 
         public LinkInclusionTests(ExampleIntegrationTestContext<TestableStartup<LinksDbContext>, LinksDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Links/LinksFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Links/LinksFakers.cs
@@ -9,17 +9,17 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Links
 {
     internal sealed class LinksFakers : FakerContainer
     {
-        private readonly Lazy<Faker<PhotoAlbum>> _lazyPhotoAlbumFaker = new Lazy<Faker<PhotoAlbum>>(() =>
+        private readonly Lazy<Faker<PhotoAlbum>> _lazyPhotoAlbumFaker = new(() =>
             new Faker<PhotoAlbum>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(photoAlbum => photoAlbum.Name, faker => faker.Lorem.Sentence()));
 
-        private readonly Lazy<Faker<Photo>> _lazyPhotoFaker = new Lazy<Faker<Photo>>(() =>
+        private readonly Lazy<Faker<Photo>> _lazyPhotoFaker = new(() =>
             new Faker<Photo>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(photo => photo.Url, faker => faker.Image.PlaceImgUrl()));
 
-        private readonly Lazy<Faker<PhotoLocation>> _lazyPhotoLocationFaker = new Lazy<Faker<PhotoLocation>>(() =>
+        private readonly Lazy<Faker<PhotoLocation>> _lazyPhotoLocationFaker = new(() =>
             new Faker<PhotoLocation>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(photoLocation => photoLocation.PlaceName, faker => faker.Address.FullAddress())

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Links/RelativeLinksWithNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Links/RelativeLinksWithNamespaceTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Links
         : IClassFixture<ExampleIntegrationTestContext<RelativeLinksInApiNamespaceStartup<LinksDbContext>, LinksDbContext>>
     {
         private readonly ExampleIntegrationTestContext<RelativeLinksInApiNamespaceStartup<LinksDbContext>, LinksDbContext> _testContext;
-        private readonly LinksFakers _fakers = new LinksFakers();
+        private readonly LinksFakers _fakers = new();
 
         public RelativeLinksWithNamespaceTests(ExampleIntegrationTestContext<RelativeLinksInApiNamespaceStartup<LinksDbContext>, LinksDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Links/RelativeLinksWithoutNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Links/RelativeLinksWithoutNamespaceTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Links
         : IClassFixture<ExampleIntegrationTestContext<RelativeLinksNoNamespaceStartup<LinksDbContext>, LinksDbContext>>
     {
         private readonly ExampleIntegrationTestContext<RelativeLinksNoNamespaceStartup<LinksDbContext>, LinksDbContext> _testContext;
-        private readonly LinksFakers _fakers = new LinksFakers();
+        private readonly LinksFakers _fakers = new();
 
         public RelativeLinksWithoutNamespaceTests(ExampleIntegrationTestContext<RelativeLinksNoNamespaceStartup<LinksDbContext>, LinksDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Logging/AuditFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Logging/AuditFakers.cs
@@ -9,7 +9,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Logging
 {
     internal sealed class AuditFakers : FakerContainer
     {
-        private readonly Lazy<Faker<AuditEntry>> _lazyAuditEntryFaker = new Lazy<Faker<AuditEntry>>(() =>
+        private readonly Lazy<Faker<AuditEntry>> _lazyAuditEntryFaker = new(() =>
             new Faker<AuditEntry>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(auditEntry => auditEntry.UserName, faker => faker.Internet.UserName())

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Logging/LoggingTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Logging/LoggingTests.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Logging
     public sealed class LoggingTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<AuditDbContext>, AuditDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<AuditDbContext>, AuditDbContext> _testContext;
-        private readonly AuditFakers _fakers = new AuditFakers();
+        private readonly AuditFakers _fakers = new();
 
         public LoggingTests(ExampleIntegrationTestContext<TestableStartup<AuditDbContext>, AuditDbContext> testContext)
         {
@@ -31,7 +31,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Logging
                 options.ClearProviders();
                 options.AddProvider(loggerFactory);
                 options.SetMinimumLevel(LogLevel.Trace);
-                options.AddFilter((_, __) => true);
+                options.AddFilter((_, _) => true);
             });
 
             testContext.ConfigureServicesBeforeStartup(services =>

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Meta/ResourceMetaTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Meta/ResourceMetaTests.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Meta
     public sealed class ResourceMetaTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<SupportDbContext>, SupportDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<SupportDbContext>, SupportDbContext> _testContext;
-        private readonly SupportFakers _fakers = new SupportFakers();
+        private readonly SupportFakers _fakers = new();
 
         public ResourceMetaTests(ExampleIntegrationTestContext<TestableStartup<SupportDbContext>, SupportDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Meta/SupportFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Meta/SupportFakers.cs
@@ -9,12 +9,12 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Meta
 {
     internal sealed class SupportFakers : FakerContainer
     {
-        private readonly Lazy<Faker<ProductFamily>> _lazyProductFamilyFaker = new Lazy<Faker<ProductFamily>>(() =>
+        private readonly Lazy<Faker<ProductFamily>> _lazyProductFamilyFaker = new(() =>
             new Faker<ProductFamily>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(productFamily => productFamily.Name, faker => faker.Commerce.ProductName()));
 
-        private readonly Lazy<Faker<SupportTicket>> _lazySupportTicketFaker = new Lazy<Faker<SupportTicket>>(() =>
+        private readonly Lazy<Faker<SupportTicket>> _lazySupportTicketFaker = new(() =>
             new Faker<SupportTicket>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(supportTicket => supportTicket.Description, faker => faker.Lorem.Paragraph()));

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Meta/TopLevelCountTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Meta/TopLevelCountTests.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Meta
     public sealed class TopLevelCountTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<SupportDbContext>, SupportDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<SupportDbContext>, SupportDbContext> _testContext;
-        private readonly SupportFakers _fakers = new SupportFakers();
+        private readonly SupportFakers _fakers = new();
 
         public TopLevelCountTests(ExampleIntegrationTestContext<TestableStartup<SupportDbContext>, SupportDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ModelStateValidation/ModelStateValidationTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ModelStateValidation/ModelStateValidationTests.cs
@@ -580,7 +580,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ModelStateValidation
                 IsCaseSensitive = false,
                 Subdirectories = new List<SystemDirectory>
                 {
-                    new SystemDirectory
+                    new()
                     {
                         Name = "C#",
                         IsCaseSensitive = false
@@ -588,7 +588,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ModelStateValidation
                 },
                 Files = new List<SystemFile>
                 {
-                    new SystemFile
+                    new()
                     {
                         FileName = "readme.txt"
                     }
@@ -851,11 +851,11 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ModelStateValidation
                 IsCaseSensitive = true,
                 Files = new List<SystemFile>
                 {
-                    new SystemFile
+                    new()
                     {
                         FileName = "Main.cs"
                     },
-                    new SystemFile
+                    new()
                     {
                         FileName = "Program.cs"
                     }
@@ -907,7 +907,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ModelStateValidation
                 IsCaseSensitive = true,
                 Files = new List<SystemFile>
                 {
-                    new SystemFile
+                    new()
                     {
                         FileName = "Main.cs",
                         SizeInBytes = 100

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/NamingConventions/KebabCasingTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/NamingConventions/KebabCasingTests.cs
@@ -12,7 +12,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.NamingConventions
     public sealed class KebabCasingTests : IClassFixture<ExampleIntegrationTestContext<KebabCasingConventionStartup<SwimmingDbContext>, SwimmingDbContext>>
     {
         private readonly ExampleIntegrationTestContext<KebabCasingConventionStartup<SwimmingDbContext>, SwimmingDbContext> _testContext;
-        private readonly SwimmingFakers _fakers = new SwimmingFakers();
+        private readonly SwimmingFakers _fakers = new();
 
         public KebabCasingTests(ExampleIntegrationTestContext<KebabCasingConventionStartup<SwimmingDbContext>, SwimmingDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/NamingConventions/SwimmingFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/NamingConventions/SwimmingFakers.cs
@@ -9,17 +9,17 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.NamingConventions
 {
     internal sealed class SwimmingFakers : FakerContainer
     {
-        private readonly Lazy<Faker<SwimmingPool>> _lazySwimmingPoolFaker = new Lazy<Faker<SwimmingPool>>(() =>
+        private readonly Lazy<Faker<SwimmingPool>> _lazySwimmingPoolFaker = new(() =>
             new Faker<SwimmingPool>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(swimmingPool => swimmingPool.IsIndoor, faker => faker.Random.Bool()));
 
-        private readonly Lazy<Faker<WaterSlide>> _lazyWaterSlideFaker = new Lazy<Faker<WaterSlide>>(() =>
+        private readonly Lazy<Faker<WaterSlide>> _lazyWaterSlideFaker = new(() =>
             new Faker<WaterSlide>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(waterSlide => waterSlide.LengthInMeters, faker => faker.Random.Decimal(3, 100)));
 
-        private readonly Lazy<Faker<DivingBoard>> _lazyDivingBoardFaker = new Lazy<Faker<DivingBoard>>(() =>
+        private readonly Lazy<Faker<DivingBoard>> _lazyDivingBoardFaker = new(() =>
             new Faker<DivingBoard>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(divingBoard => divingBoard.HeightInMeters, faker => faker.Random.Decimal(1, 15)));

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/NonJsonApiControllers/NonJsonApiControllerTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/NonJsonApiControllers/NonJsonApiControllerTests.cs
@@ -32,7 +32,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.NonJsonApiControllers
 
             // Assert
             httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
-            httpResponse.Content.Headers.ContentType.ToString().Should().Be("application/json; charset=utf-8");
+            httpResponse.Content.Headers.ContentType!.ToString().Should().Be("application/json; charset=utf-8");
 
             string responseText = await httpResponse.Content.ReadAsStringAsync();
             responseText.Should().Be("[\"Welcome!\"]");
@@ -60,7 +60,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.NonJsonApiControllers
 
             // Assert
             httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
-            httpResponse.Content.Headers.ContentType.ToString().Should().Be("text/plain; charset=utf-8");
+            httpResponse.Content.Headers.ContentType!.ToString().Should().Be("text/plain; charset=utf-8");
 
             string responseText = await httpResponse.Content.ReadAsStringAsync();
             responseText.Should().Be("Hello, Jack");
@@ -79,7 +79,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.NonJsonApiControllers
 
             // Assert
             httpResponse.Should().HaveStatusCode(HttpStatusCode.BadRequest);
-            httpResponse.Content.Headers.ContentType.ToString().Should().Be("text/plain; charset=utf-8");
+            httpResponse.Content.Headers.ContentType!.ToString().Should().Be("text/plain; charset=utf-8");
 
             string responseText = await httpResponse.Content.ReadAsStringAsync();
             responseText.Should().Be("Please send your name.");
@@ -107,7 +107,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.NonJsonApiControllers
 
             // Assert
             httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
-            httpResponse.Content.Headers.ContentType.ToString().Should().Be("text/plain; charset=utf-8");
+            httpResponse.Content.Headers.ContentType!.ToString().Should().Be("text/plain; charset=utf-8");
 
             string responseText = await httpResponse.Content.ReadAsStringAsync();
             responseText.Should().Be("Hi, Jane");
@@ -126,7 +126,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.NonJsonApiControllers
 
             // Assert
             httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
-            httpResponse.Content.Headers.ContentType.ToString().Should().Be("text/plain; charset=utf-8");
+            httpResponse.Content.Headers.ContentType!.ToString().Should().Be("text/plain; charset=utf-8");
 
             string responseText = await httpResponse.Content.ReadAsStringAsync();
             responseText.Should().Be("Good day, Janice");
@@ -145,7 +145,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.NonJsonApiControllers
 
             // Assert
             httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
-            httpResponse.Content.Headers.ContentType.ToString().Should().Be("text/plain; charset=utf-8");
+            httpResponse.Content.Headers.ContentType!.ToString().Should().Be("text/plain; charset=utf-8");
 
             string responseText = await httpResponse.Content.ReadAsStringAsync();
             responseText.Should().Be("Bye.");

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Filtering/FilterDepthTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Filtering/FilterDepthTests.cs
@@ -28,9 +28,6 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Filtering
 
             var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
             options.EnableLegacyFilterNotation = false;
-
-            options.DisableTopPagination = false;
-            options.DisableChildrenPagination = false;
         }
 
         [Fact]
@@ -326,11 +323,6 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Filtering
                 dbContext.Posts.AddRange(posts);
                 await dbContext.SaveChangesAsync();
             });
-
-            // Workaround for https://github.com/dotnet/efcore/issues/21026
-            var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
-            options.DisableTopPagination = false;
-            options.DisableChildrenPagination = true;
 
             const string route = "/blogPosts?include=labels&filter[labels]=equals(name,'Hot')";
 

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Filtering/FilterDepthTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Filtering/FilterDepthTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Filtering
     public sealed class FilterDepthTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> _testContext;
-        private readonly QueryStringFakers _fakers = new QueryStringFakers();
+        private readonly QueryStringFakers _fakers = new();
 
         public FilterDepthTests(ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> testContext)
         {
@@ -207,7 +207,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Filtering
 
             posts[1].BlogPostLabels = new HashSet<BlogPostLabel>
             {
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 }
@@ -300,7 +300,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Filtering
 
             posts[0].BlogPostLabels = new HashSet<BlogPostLabel>
             {
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 }
@@ -308,7 +308,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Filtering
 
             posts[1].BlogPostLabels = new HashSet<BlogPostLabel>
             {
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Filtering/FilterOperatorTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Filtering/FilterOperatorTests.cs
@@ -466,7 +466,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Filtering
             {
                 Children = new List<FilterableResource>
                 {
-                    new FilterableResource()
+                    new()
                 }
             };
 
@@ -497,8 +497,8 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Filtering
             {
                 Children = new List<FilterableResource>
                 {
-                    new FilterableResource(),
-                    new FilterableResource()
+                    new(),
+                    new()
                 }
             };
 

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Filtering/FilterTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Filtering/FilterTests.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Filtering
     public sealed class FilterTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> _testContext;
-        private readonly QueryStringFakers _fakers = new QueryStringFakers();
+        private readonly QueryStringFakers _fakers = new();
 
         public FilterTests(ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Includes/IncludeTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Includes/IncludeTests.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Includes
     public sealed class IncludeTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> _testContext;
-        private readonly QueryStringFakers _fakers = new QueryStringFakers();
+        private readonly QueryStringFakers _fakers = new();
 
         public IncludeTests(ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> testContext)
         {
@@ -234,7 +234,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Includes
 
             post.BlogPostLabels = new HashSet<BlogPostLabel>
             {
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 }
@@ -272,7 +272,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Includes
 
             post.BlogPostLabels = new HashSet<BlogPostLabel>
             {
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Pagination/PaginationWithTotalCountTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Pagination/PaginationWithTotalCountTests.cs
@@ -36,9 +36,6 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Pagination
             options.MaximumPageSize = null;
             options.MaximumPageNumber = null;
             options.AllowUnknownQueryStringParameters = true;
-
-            options.DisableTopPagination = false;
-            options.DisableChildrenPagination = false;
         }
 
         [Fact]
@@ -302,11 +299,6 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Pagination
                 dbContext.Posts.AddRange(posts);
                 await dbContext.SaveChangesAsync();
             });
-
-            // Workaround for https://github.com/dotnet/efcore/issues/21026
-            var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
-            options.DisableTopPagination = true;
-            options.DisableChildrenPagination = false;
 
             const string route = "/blogPosts?include=labels&page[number]=labels:2&page[size]=labels:1";
 

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Pagination/PaginationWithTotalCountTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Pagination/PaginationWithTotalCountTests.cs
@@ -20,7 +20,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Pagination
         private const int DefaultPageSize = 5;
 
         private readonly ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> _testContext;
-        private readonly QueryStringFakers _fakers = new QueryStringFakers();
+        private readonly QueryStringFakers _fakers = new();
 
         public PaginationWithTotalCountTests(ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> testContext)
         {
@@ -271,11 +271,11 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Pagination
 
             posts[0].BlogPostLabels = new HashSet<BlogPostLabel>
             {
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 },
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 }
@@ -283,11 +283,11 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Pagination
 
             posts[1].BlogPostLabels = new HashSet<BlogPostLabel>
             {
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 },
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 }
@@ -330,11 +330,11 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Pagination
 
             post.BlogPostLabels = new HashSet<BlogPostLabel>
             {
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 },
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Pagination/PaginationWithoutTotalCountTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Pagination/PaginationWithoutTotalCountTests.cs
@@ -19,7 +19,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Pagination
         private const int DefaultPageSize = 5;
 
         private readonly ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> _testContext;
-        private readonly QueryStringFakers _fakers = new QueryStringFakers();
+        private readonly QueryStringFakers _fakers = new();
 
         public PaginationWithoutTotalCountTests(ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Pagination/RangeValidationTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Pagination/RangeValidationTests.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Pagination
     {
         private const int DefaultPageSize = 5;
         private readonly ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> _testContext;
-        private readonly QueryStringFakers _fakers = new QueryStringFakers();
+        private readonly QueryStringFakers _fakers = new();
 
         public RangeValidationTests(ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/QueryStringFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/QueryStringFakers.cs
@@ -9,31 +9,31 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings
 {
     internal sealed class QueryStringFakers : FakerContainer
     {
-        private readonly Lazy<Faker<Blog>> _lazyBlogFaker = new Lazy<Faker<Blog>>(() =>
+        private readonly Lazy<Faker<Blog>> _lazyBlogFaker = new(() =>
             new Faker<Blog>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(blog => blog.Title, faker => faker.Lorem.Word())
                 .RuleFor(blog => blog.PlatformName, faker => faker.Company.CompanyName()));
 
-        private readonly Lazy<Faker<BlogPost>> _lazyBlogPostFaker = new Lazy<Faker<BlogPost>>(() =>
+        private readonly Lazy<Faker<BlogPost>> _lazyBlogPostFaker = new(() =>
             new Faker<BlogPost>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(blogPost => blogPost.Caption, faker => faker.Lorem.Sentence())
                 .RuleFor(blogPost => blogPost.Url, faker => faker.Internet.Url()));
 
-        private readonly Lazy<Faker<Label>> _lazyLabelFaker = new Lazy<Faker<Label>>(() =>
+        private readonly Lazy<Faker<Label>> _lazyLabelFaker = new(() =>
             new Faker<Label>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(label => label.Name, faker => faker.Lorem.Word())
                 .RuleFor(label => label.Color, faker => faker.PickRandom<LabelColor>()));
 
-        private readonly Lazy<Faker<Comment>> _lazyCommentFaker = new Lazy<Faker<Comment>>(() =>
+        private readonly Lazy<Faker<Comment>> _lazyCommentFaker = new(() =>
             new Faker<Comment>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(comment => comment.Text, faker => faker.Lorem.Paragraph())
                 .RuleFor(comment => comment.CreatedAt, faker => faker.Date.Past()));
 
-        private readonly Lazy<Faker<WebAccount>> _lazyWebAccountFaker = new Lazy<Faker<WebAccount>>(() =>
+        private readonly Lazy<Faker<WebAccount>> _lazyWebAccountFaker = new(() =>
             new Faker<WebAccount>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(webAccount => webAccount.UserName, faker => faker.Person.UserName)
@@ -42,18 +42,18 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings
                 .RuleFor(webAccount => webAccount.DateOfBirth, faker => faker.Person.DateOfBirth)
                 .RuleFor(webAccount => webAccount.EmailAddress, faker => faker.Internet.Email()));
 
-        private readonly Lazy<Faker<AccountPreferences>> _lazyAccountPreferencesFaker = new Lazy<Faker<AccountPreferences>>(() =>
+        private readonly Lazy<Faker<AccountPreferences>> _lazyAccountPreferencesFaker = new(() =>
             new Faker<AccountPreferences>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(accountPreferences => accountPreferences.UseDarkTheme, faker => faker.Random.Bool()));
 
-        private readonly Lazy<Faker<Calendar>> _lazyCalendarFaker = new Lazy<Faker<Calendar>>(() =>
+        private readonly Lazy<Faker<Calendar>> _lazyCalendarFaker = new(() =>
             new Faker<Calendar>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(calendar => calendar.TimeZone, faker => faker.Date.TimeZoneString())
                 .RuleFor(calendar => calendar.DefaultAppointmentDurationInMinutes, faker => faker.PickRandom(15, 30, 45, 60)));
 
-        private readonly Lazy<Faker<Appointment>> _lazyAppointmentFaker = new Lazy<Faker<Appointment>>(() =>
+        private readonly Lazy<Faker<Appointment>> _lazyAppointmentFaker = new(() =>
             new Faker<Appointment>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(appointment => appointment.Title, faker => faker.Random.Word())

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/SerializerDefaultValueHandlingTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/SerializerDefaultValueHandlingTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> _testContext;
-        private readonly QueryStringFakers _fakers = new QueryStringFakers();
+        private readonly QueryStringFakers _fakers = new();
 
         public SerializerDefaultValueHandlingTests(ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/SerializerNullValueHandlingTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/SerializerNullValueHandlingTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> _testContext;
-        private readonly QueryStringFakers _fakers = new QueryStringFakers();
+        private readonly QueryStringFakers _fakers = new();
 
         public SerializerNullValueHandlingTests(ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Sorting/SortTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/Sorting/SortTests.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Sorting
     public sealed class SortTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> _testContext;
-        private readonly QueryStringFakers _fakers = new QueryStringFakers();
+        private readonly QueryStringFakers _fakers = new();
 
         public SortTests(ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> testContext)
         {
@@ -180,7 +180,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Sorting
 
             posts[0].BlogPostLabels = new HashSet<BlogPostLabel>
             {
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 }
@@ -188,11 +188,11 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Sorting
 
             posts[1].BlogPostLabels = new HashSet<BlogPostLabel>
             {
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 },
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 }
@@ -293,15 +293,15 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.Sorting
 
             post.BlogPostLabels = new HashSet<BlogPostLabel>
             {
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 },
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 },
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/SparseFieldSets/ResourceCaptureStore.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/SparseFieldSets/ResourceCaptureStore.cs
@@ -5,7 +5,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.SparseFiel
 {
     public sealed class ResourceCaptureStore
     {
-        internal List<IIdentifiable> Resources { get; } = new List<IIdentifiable>();
+        internal List<IIdentifiable> Resources { get; } = new();
 
         internal void Add(IEnumerable<IIdentifiable> resources)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/SparseFieldSets/SparseFieldSetTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/QueryStrings/SparseFieldSets/SparseFieldSetTests.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.SparseFiel
     public sealed class SparseFieldSetTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> _testContext;
-        private readonly QueryStringFakers _fakers = new QueryStringFakers();
+        private readonly QueryStringFakers _fakers = new();
 
         public SparseFieldSetTests(ExampleIntegrationTestContext<TestableStartup<QueryStringDbContext>, QueryStringDbContext> testContext)
         {
@@ -385,7 +385,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.QueryStrings.SparseFiel
 
             post.BlogPostLabels = new HashSet<BlogPostLabel>
             {
-                new BlogPostLabel
+                new()
                 {
                     Label = _fakers.Label.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceTests.cs
@@ -20,7 +20,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
     public sealed class CreateResourceTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public CreateResourceTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithClientGeneratedIdTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithClientGeneratedIdTests.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public CreateResourceWithClientGeneratedIdTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToManyRelationshipTests.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public CreateResourceWithToManyRelationshipTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToOneRelationshipTests.cs
@@ -19,7 +19,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Creating
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public CreateResourceWithToOneRelationshipTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Deleting/DeleteResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Deleting/DeleteResourceTests.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Deleting
     public sealed class DeleteResourceTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public DeleteResourceTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Fetching/FetchRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Fetching/FetchRelationshipTests.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Fetching
     public sealed class FetchRelationshipTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public FetchRelationshipTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {
@@ -138,11 +138,11 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Fetching
 
             workItem.WorkItemTags = new List<WorkItemTag>
             {
-                new WorkItemTag
+                new()
                 {
                     Tag = _fakers.WorkTag.Generate()
                 },
-                new WorkItemTag
+                new()
                 {
                     Tag = _fakers.WorkTag.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Fetching/FetchResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Fetching/FetchResourceTests.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Fetching
     public sealed class FetchResourceTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public FetchResourceTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {
@@ -262,11 +262,11 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Fetching
 
             workItem.WorkItemTags = new List<WorkItemTag>
             {
-                new WorkItemTag
+                new()
                 {
                     Tag = _fakers.WorkTag.Generate()
                 },
-                new WorkItemTag
+                new()
                 {
                     Tag = _fakers.WorkTag.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/ReadWriteFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/ReadWriteFakers.cs
@@ -9,32 +9,32 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite
 {
     internal sealed class ReadWriteFakers : FakerContainer
     {
-        private readonly Lazy<Faker<WorkItem>> _lazyWorkItemFaker = new Lazy<Faker<WorkItem>>(() =>
+        private readonly Lazy<Faker<WorkItem>> _lazyWorkItemFaker = new(() =>
             new Faker<WorkItem>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(workItem => workItem.Description, faker => faker.Lorem.Sentence())
                 .RuleFor(workItem => workItem.DueAt, faker => faker.Date.Future())
                 .RuleFor(workItem => workItem.Priority, faker => faker.PickRandom<WorkItemPriority>()));
 
-        private readonly Lazy<Faker<WorkTag>> _lazyWorkTagFaker = new Lazy<Faker<WorkTag>>(() =>
+        private readonly Lazy<Faker<WorkTag>> _lazyWorkTagFaker = new(() =>
             new Faker<WorkTag>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(workTag => workTag.Text, faker => faker.Lorem.Word())
                 .RuleFor(workTag => workTag.IsBuiltIn, faker => faker.Random.Bool()));
 
-        private readonly Lazy<Faker<UserAccount>> _lazyUserAccountFaker = new Lazy<Faker<UserAccount>>(() =>
+        private readonly Lazy<Faker<UserAccount>> _lazyUserAccountFaker = new(() =>
             new Faker<UserAccount>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(userAccount => userAccount.FirstName, faker => faker.Name.FirstName())
                 .RuleFor(userAccount => userAccount.LastName, faker => faker.Name.LastName()));
 
-        private readonly Lazy<Faker<WorkItemGroup>> _lazyWorkItemGroupFaker = new Lazy<Faker<WorkItemGroup>>(() =>
+        private readonly Lazy<Faker<WorkItemGroup>> _lazyWorkItemGroupFaker = new(() =>
             new Faker<WorkItemGroup>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(group => group.Name, faker => faker.Lorem.Word())
                 .RuleFor(group => group.IsPublic, faker => faker.Random.Bool()));
 
-        private readonly Lazy<Faker<RgbColor>> _lazyRgbColorFaker = new Lazy<Faker<RgbColor>>(() =>
+        private readonly Lazy<Faker<RgbColor>> _lazyRgbColorFaker = new(() =>
             new Faker<RgbColor>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(color => color.Id, faker => faker.Random.Hexadecimal(6))

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Relationships/AddToToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Relationships/AddToToManyRelationshipTests.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Rela
     public sealed class AddToToManyRelationshipTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public AddToToManyRelationshipTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {
@@ -809,7 +809,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Rela
 
             existingWorkItem.RelatedToItems = new List<WorkItemToWorkItem>
             {
-                new WorkItemToWorkItem
+                new()
                 {
                     ToItem = _fakers.WorkItem.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Relationships/RemoveFromToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Relationships/RemoveFromToManyRelationshipTests.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Rela
         : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public RemoveFromToManyRelationshipTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {
@@ -807,7 +807,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Rela
 
             existingWorkItem.RelatedFromItems = new List<WorkItemToWorkItem>
             {
-                new WorkItemToWorkItem
+                new()
                 {
                     FromItem = _fakers.WorkItem.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Relationships/ReplaceToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Relationships/ReplaceToManyRelationshipTests.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Rela
     public sealed class ReplaceToManyRelationshipTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public ReplaceToManyRelationshipTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {
@@ -815,7 +815,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Rela
 
                 existingWorkItem.RelatedFromItems = new List<WorkItemToWorkItem>
                 {
-                    new WorkItemToWorkItem
+                    new()
                     {
                         FromItem = existingWorkItem
                     }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Relationships/UpdateToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Relationships/UpdateToOneRelationshipTests.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Rela
     public sealed class UpdateToOneRelationshipTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public UpdateToOneRelationshipTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Resources/ReplaceToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Resources/ReplaceToManyRelationshipTests.cs
@@ -16,7 +16,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
     public sealed class ReplaceToManyRelationshipTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public ReplaceToManyRelationshipTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {
@@ -935,7 +935,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
 
                 existingWorkItem.RelatedFromItems = new List<WorkItemToWorkItem>
                 {
-                    new WorkItemToWorkItem
+                    new()
                     {
                         FromItem = existingWorkItem
                     }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateResourceTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateResourceTests.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
     public sealed class UpdateResourceTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public UpdateResourceTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {
@@ -1008,7 +1008,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
 
             existingWorkItem.WorkItemTags = new List<WorkItemTag>
             {
-                new WorkItemTag
+                new()
                 {
                     Tag = _fakers.WorkTag.Generate()
                 }
@@ -1122,7 +1122,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
 
             existingWorkItem.RelatedToItems = new List<WorkItemToWorkItem>
             {
-                new WorkItemToWorkItem
+                new()
                 {
                     ToItem = _fakers.WorkItem.Generate()
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateToOneRelationshipTests.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ReadWrite.Updating.Reso
     public sealed class UpdateToOneRelationshipTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> _testContext;
-        private readonly ReadWriteFakers _fakers = new ReadWriteFakers();
+        private readonly ReadWriteFakers _fakers = new();
 
         public UpdateToOneRelationshipTests(ExampleIntegrationTestContext<TestableStartup<ReadWriteDbContext>, ReadWriteDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RequiredRelationships/DefaultBehaviorFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RequiredRelationships/DefaultBehaviorFakers.cs
@@ -9,17 +9,17 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.RequiredRelationships
 {
     internal sealed class DefaultBehaviorFakers : FakerContainer
     {
-        private readonly Lazy<Faker<Order>> _orderFaker = new Lazy<Faker<Order>>(() =>
+        private readonly Lazy<Faker<Order>> _orderFaker = new(() =>
             new Faker<Order>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(order => order.Amount, faker => faker.Finance.Amount()));
 
-        private readonly Lazy<Faker<Customer>> _customerFaker = new Lazy<Faker<Customer>>(() =>
+        private readonly Lazy<Faker<Customer>> _customerFaker = new(() =>
             new Faker<Customer>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(customer => customer.EmailAddress, faker => faker.Person.Email));
 
-        private readonly Lazy<Faker<Shipment>> _shipmentFaker = new Lazy<Faker<Shipment>>(() =>
+        private readonly Lazy<Faker<Shipment>> _shipmentFaker = new(() =>
             new Faker<Shipment>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(shipment => shipment.TrackAndTraceCode, faker => faker.Commerce.Ean13())

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RequiredRelationships/DefaultBehaviorTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RequiredRelationships/DefaultBehaviorTests.cs
@@ -431,7 +431,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.RequiredRelationships
             Error error = responseDocument.Errors[0];
             error.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
             error.Title.Should().Be("An unhandled error occurred while processing this request.");
-            error.Detail.Should().StartWith("The property 'Id' on entity type 'Shipment' is part of a key and so cannot be modified or marked as modified.");
+            error.Detail.Should().StartWith("The property 'Shipment.Id' is part of a key and so cannot be modified or marked as modified.");
         }
 
         [Fact]
@@ -473,7 +473,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.RequiredRelationships
             Error error = responseDocument.Errors[0];
             error.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
             error.Title.Should().Be("An unhandled error occurred while processing this request.");
-            error.Detail.Should().StartWith("The property 'Id' on entity type 'Shipment' is part of a key and so cannot be modified or marked as modified.");
+            error.Detail.Should().StartWith("The property 'Shipment.Id' is part of a key and so cannot be modified or marked as modified.");
         }
     }
 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RequiredRelationships/DefaultBehaviorTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RequiredRelationships/DefaultBehaviorTests.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.RequiredRelationships
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<DefaultBehaviorDbContext>, DefaultBehaviorDbContext> _testContext;
 
-        private readonly DefaultBehaviorFakers _fakers = new DefaultBehaviorFakers();
+        private readonly DefaultBehaviorFakers _fakers = new();
 
         public DefaultBehaviorTests(ExampleIntegrationTestContext<TestableStartup<DefaultBehaviorDbContext>, DefaultBehaviorDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ResourceDefinitions/CallableResourceDefinition.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ResourceDefinitions/CallableResourceDefinition.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
     public sealed class CallableResourceDefinition : JsonApiResourceDefinition<CallableResource>
     {
-        private static readonly PageSize MaxPageSize = new PageSize(5);
+        private static readonly PageSize MaxPageSize = new(5);
         private readonly IUserRolesService _userRolesService;
 
         public CallableResourceDefinition(IResourceGraph resourceGraph, IUserRolesService userRolesService)
@@ -54,9 +54,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
             var isNotDeleted = new ComparisonExpression(ComparisonOperator.Equals, new ResourceFieldChainExpression(isDeletedAttribute),
                 new LiteralConstantExpression(bool.FalseString));
 
-            return existingFilter == null
-                ? (FilterExpression)isNotDeleted
-                : new LogicalExpression(LogicalOperator.And, ArrayFactory.Create(isNotDeleted, existingFilter));
+            return existingFilter == null ? isNotDeleted : new LogicalExpression(LogicalOperator.And, ArrayFactory.Create(isNotDeleted, existingFilter));
         }
 
         public override SortExpression OnApplySort(SortExpression existingSort)
@@ -105,7 +103,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
         {
             // Use case: 'isHighRisk' query string parameter can be used to add extra filter on IQueryable<TResource>.
 
-            return new QueryStringParameterHandlers<CallableResource>
+            return new()
             {
                 ["isHighRisk"] = FilterByHighRisk
             };

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ResourceDefinitions/ResourceDefinitionQueryCallbackTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ResourceDefinitions/ResourceDefinitionQueryCallbackTests.cs
@@ -77,22 +77,22 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
             // Arrange
             var resources = new List<CallableResource>
             {
-                new CallableResource
+                new()
                 {
                     Label = "A",
                     IsDeleted = true
                 },
-                new CallableResource
+                new()
                 {
                     Label = "A",
                     IsDeleted = false
                 },
-                new CallableResource
+                new()
                 {
                     Label = "B",
                     IsDeleted = true
                 },
-                new CallableResource
+                new()
                 {
                     Label = "B",
                     IsDeleted = false
@@ -127,22 +127,22 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
             // Arrange
             var resources = new List<CallableResource>
             {
-                new CallableResource
+                new()
                 {
                     Label = "A",
                     IsDeleted = true
                 },
-                new CallableResource
+                new()
                 {
                     Label = "A",
                     IsDeleted = false
                 },
-                new CallableResource
+                new()
                 {
                     Label = "B",
                     IsDeleted = true
                 },
-                new CallableResource
+                new()
                 {
                     Label = "B",
                     IsDeleted = false
@@ -176,19 +176,19 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
             // Arrange
             var resources = new List<CallableResource>
             {
-                new CallableResource
+                new()
                 {
                     Label = "A",
                     CreatedAt = 1.January(2001),
                     ModifiedAt = 15.January(2001)
                 },
-                new CallableResource
+                new()
                 {
                     Label = "A",
                     CreatedAt = 1.January(2001),
                     ModifiedAt = 15.December(2001)
                 },
-                new CallableResource
+                new()
                 {
                     Label = "B",
                     CreatedAt = 1.February(2001),
@@ -223,19 +223,19 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
             // Arrange
             var resources = new List<CallableResource>
             {
-                new CallableResource
+                new()
                 {
                     Label = "A",
                     CreatedAt = 1.January(2001),
                     ModifiedAt = 15.January(2001)
                 },
-                new CallableResource
+                new()
                 {
                     Label = "A",
                     CreatedAt = 1.January(2001),
                     ModifiedAt = 15.December(2001)
                 },
-                new CallableResource
+                new()
                 {
                     Label = "B",
                     CreatedAt = 1.February(2001),
@@ -422,22 +422,22 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
             // Arrange
             var resources = new List<CallableResource>
             {
-                new CallableResource
+                new()
                 {
                     Label = "A",
                     RiskLevel = 3
                 },
-                new CallableResource
+                new()
                 {
                     Label = "A",
                     RiskLevel = 8
                 },
-                new CallableResource
+                new()
                 {
                     Label = "B",
                     RiskLevel = 3
                 },
-                new CallableResource
+                new()
                 {
                     Label = "B",
                     RiskLevel = 8
@@ -470,22 +470,22 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
             // Arrange
             var resources = new List<CallableResource>
             {
-                new CallableResource
+                new()
                 {
                     Label = "A",
                     RiskLevel = 3
                 },
-                new CallableResource
+                new()
                 {
                     Label = "A",
                     RiskLevel = 8
                 },
-                new CallableResource
+                new()
                 {
                     Label = "B",
                     RiskLevel = 3
                 },
-                new CallableResource
+                new()
                 {
                     Label = "B",
                     RiskLevel = 8
@@ -520,11 +520,11 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceDefinitions
                 RiskLevel = 3,
                 Children = new List<CallableResource>
                 {
-                    new CallableResource
+                    new()
                     {
                         RiskLevel = 3
                     },
-                    new CallableResource
+                    new()
                     {
                         RiskLevel = 8
                     }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ResourceHooks/ResourceHookTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ResourceHooks/ResourceHookTests.cs
@@ -47,10 +47,6 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceHooks
 
                 services.AddScoped(typeof(IResourceChangeTracker<>), typeof(NeverSameResourceChangeTracker<>));
             });
-
-            var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
-            options.DisableTopPagination = false;
-            options.DisableChildrenPagination = false;
         }
 
         [Fact]
@@ -334,11 +330,6 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceHooks
                 dbContext.Articles.Add(article);
                 await dbContext.SaveChangesAsync();
             });
-
-            // Workaround for https://github.com/dotnet/efcore/issues/21026
-            var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
-            options.DisableTopPagination = false;
-            options.DisableChildrenPagination = true;
 
             const string route = "/api/v1/articles?include=tags";
 

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ResourceHooks/ResourceHookTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ResourceHooks/ResourceHookTests.cs
@@ -24,7 +24,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceHooks
     public sealed class ResourceHookTests : IClassFixture<ExampleIntegrationTestContext<ResourceHooksStartup<AppDbContext>, AppDbContext>>
     {
         private readonly ExampleIntegrationTestContext<ResourceHooksStartup<AppDbContext>, AppDbContext> _testContext;
-        private readonly ExampleFakers _fakers = new ExampleFakers();
+        private readonly ExampleFakers _fakers = new();
 
         public ResourceHookTests(ExampleIntegrationTestContext<ResourceHooksStartup<AppDbContext>, AppDbContext> testContext)
         {
@@ -315,11 +315,11 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ResourceHooks
 
             article.ArticleTags = new HashSet<ArticleTag>
             {
-                new ArticleTag
+                new()
                 {
                     Tag = tags[0]
                 },
-                new ArticleTag
+                new()
                 {
                     Tag = tags[1]
                 }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RestrictedControllers/HttpReadOnlyTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RestrictedControllers/HttpReadOnlyTests.cs
@@ -12,7 +12,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.RestrictedControllers
     public sealed class HttpReadOnlyTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext> _testContext;
-        private readonly RestrictionFakers _fakers = new RestrictionFakers();
+        private readonly RestrictionFakers _fakers = new();
 
         public HttpReadOnlyTests(ExampleIntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RestrictedControllers/NoHttpDeleteTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RestrictedControllers/NoHttpDeleteTests.cs
@@ -12,7 +12,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.RestrictedControllers
     public sealed class NoHttpDeleteTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext> _testContext;
-        private readonly RestrictionFakers _fakers = new RestrictionFakers();
+        private readonly RestrictionFakers _fakers = new();
 
         public NoHttpDeleteTests(ExampleIntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RestrictedControllers/NoHttpPatchTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RestrictedControllers/NoHttpPatchTests.cs
@@ -12,7 +12,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.RestrictedControllers
     public sealed class NoHttpPatchTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext> _testContext;
-        private readonly RestrictionFakers _fakers = new RestrictionFakers();
+        private readonly RestrictionFakers _fakers = new();
 
         public NoHttpPatchTests(ExampleIntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RestrictedControllers/NoHttpPostTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RestrictedControllers/NoHttpPostTests.cs
@@ -12,7 +12,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.RestrictedControllers
     public sealed class NoHttpPostTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext> _testContext;
-        private readonly RestrictionFakers _fakers = new RestrictionFakers();
+        private readonly RestrictionFakers _fakers = new();
 
         public NoHttpPostTests(ExampleIntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RestrictedControllers/RestrictionFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/RestrictedControllers/RestrictionFakers.cs
@@ -9,19 +9,19 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.RestrictedControllers
 {
     internal sealed class RestrictionFakers : FakerContainer
     {
-        private readonly Lazy<Faker<Table>> _lazyTableFaker = new Lazy<Faker<Table>>(() =>
+        private readonly Lazy<Faker<Table>> _lazyTableFaker = new(() =>
             new Faker<Table>()
                 .UseSeed(GetFakerSeed()));
 
-        private readonly Lazy<Faker<Chair>> _lazyChairFaker = new Lazy<Faker<Chair>>(() =>
+        private readonly Lazy<Faker<Chair>> _lazyChairFaker = new(() =>
             new Faker<Chair>()
                 .UseSeed(GetFakerSeed()));
 
-        private readonly Lazy<Faker<Sofa>> _lazySofaFaker = new Lazy<Faker<Sofa>>(() =>
+        private readonly Lazy<Faker<Sofa>> _lazySofaFaker = new(() =>
             new Faker<Sofa>()
                 .UseSeed(GetFakerSeed()));
 
-        private readonly Lazy<Faker<Bed>> _lazyBedFaker = new Lazy<Faker<Bed>>(() =>
+        private readonly Lazy<Faker<Bed>> _lazyBedFaker = new(() =>
             new Faker<Bed>()
                 .UseSeed(GetFakerSeed()));
 

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Serialization/Meeting.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Serialization/Meeting.cs
@@ -24,7 +24,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Serialization
         public MeetingLocation Location
         {
             get =>
-                new MeetingLocation
+                new()
                 {
                     Latitude = Latitude,
                     Longitude = Longitude

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Serialization/SerializationFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Serialization/SerializationFakers.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Serialization
             TimeSpan.FromMinutes(60)
         };
 
-        private readonly Lazy<Faker<Meeting>> _lazyMeetingFaker = new Lazy<Faker<Meeting>>(() =>
+        private readonly Lazy<Faker<Meeting>> _lazyMeetingFaker = new(() =>
             new Faker<Meeting>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(meeting => meeting.Title, faker => faker.Lorem.Word())
@@ -26,7 +26,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Serialization
                 .RuleFor(meeting => meeting.Latitude, faker => faker.Address.Latitude())
                 .RuleFor(meeting => meeting.Longitude, faker => faker.Address.Longitude()));
 
-        private readonly Lazy<Faker<MeetingAttendee>> _lazyMeetingAttendeeFaker = new Lazy<Faker<MeetingAttendee>>(() =>
+        private readonly Lazy<Faker<MeetingAttendee>> _lazyMeetingAttendeeFaker = new(() =>
             new Faker<MeetingAttendee>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(attendee => attendee.DisplayName, faker => faker.Random.Utf16String()));

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Serialization/SerializationTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/Serialization/SerializationTests.cs
@@ -20,7 +20,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.Serialization
     public sealed class SerializationTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<SerializationDbContext>, SerializationDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<SerializationDbContext>, SerializationDbContext> _testContext;
-        private readonly SerializationFakers _fakers = new SerializationFakers();
+        private readonly SerializationFakers _fakers = new();
 
         public SerializationTests(ExampleIntegrationTestContext<TestableStartup<SerializationDbContext>, SerializationDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/SoftDeletionResourceDefinition.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/SoftDeletionResourceDefinition.cs
@@ -31,7 +31,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
                 new LiteralConstantExpression("false"));
 
             return existingFilter == null
-                ? (FilterExpression)isNotSoftDeleted
+                ? isNotSoftDeleted
                 : new LogicalExpression(LogicalOperator.And, ArrayFactory.Create(isNotSoftDeleted, existingFilter));
         }
     }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/SoftDeletionTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/SoftDeletion/SoftDeletionTests.cs
@@ -37,12 +37,12 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
             // Arrange
             var departments = new List<Department>
             {
-                new Department
+                new()
                 {
                     Name = "Sales",
                     IsSoftDeleted = true
                 },
-                new Department
+                new()
                 {
                     Name = "Marketing"
                 }
@@ -73,16 +73,16 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
             // Arrange
             var departments = new List<Department>
             {
-                new Department
+                new()
                 {
                     Name = "Support"
                 },
-                new Department
+                new()
                 {
                     Name = "Sales",
                     IsSoftDeleted = true
                 },
-                new Department
+                new()
                 {
                     Name = "Marketing"
                 }
@@ -148,12 +148,12 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
             {
                 Departments = new List<Department>
                 {
-                    new Department
+                    new()
                     {
                         Name = "Sales",
                         IsSoftDeleted = true
                     },
-                    new Department
+                    new()
                     {
                         Name = "Marketing"
                     }
@@ -187,7 +187,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
                 IsSoftDeleted = true,
                 Departments = new List<Department>
                 {
-                    new Department
+                    new()
                     {
                         Name = "Marketing"
                     }
@@ -223,28 +223,28 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
             // Arrange
             var companies = new List<Company>
             {
-                new Company
+                new()
                 {
                     Name = "Acme Corporation",
                     IsSoftDeleted = true,
                     Departments = new List<Department>
                     {
-                        new Department
+                        new()
                         {
                             Name = "Recruitment"
                         }
                     }
                 },
-                new Company
+                new()
                 {
                     Name = "AdventureWorks",
                     Departments = new List<Department>
                     {
-                        new Department
+                        new()
                         {
                             Name = "Reception"
                         },
-                        new Department
+                        new()
                         {
                             Name = "Sales",
                             IsSoftDeleted = true
@@ -285,12 +285,12 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
             {
                 Departments = new List<Department>
                 {
-                    new Department
+                    new()
                     {
                         Name = "Sales",
                         IsSoftDeleted = true
                     },
-                    new Department
+                    new()
                     {
                         Name = "Marketing"
                     }
@@ -324,7 +324,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
                 IsSoftDeleted = true,
                 Departments = new List<Department>
                 {
-                    new Department
+                    new()
                     {
                         Name = "Marketing"
                     }
@@ -408,7 +408,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.SoftDeletion
                 IsSoftDeleted = true,
                 Departments = new List<Department>
                 {
-                    new Department
+                    new()
                     {
                         Name = "Marketing"
                     }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ZeroKeys/EmptyGuidAsKeyTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ZeroKeys/EmptyGuidAsKeyTests.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ZeroKeys
     public sealed class EmptyGuidAsKeyTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ZeroKeyDbContext>, ZeroKeyDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ZeroKeyDbContext>, ZeroKeyDbContext> _testContext;
-        private readonly ZeroKeyFakers _fakers = new ZeroKeyFakers();
+        private readonly ZeroKeyFakers _fakers = new();
 
         public EmptyGuidAsKeyTests(ExampleIntegrationTestContext<TestableStartup<ZeroKeyDbContext>, ZeroKeyDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ZeroKeys/ZeroAsKeyTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ZeroKeys/ZeroAsKeyTests.cs
@@ -17,7 +17,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ZeroKeys
     public sealed class ZeroAsKeyTests : IClassFixture<ExampleIntegrationTestContext<TestableStartup<ZeroKeyDbContext>, ZeroKeyDbContext>>
     {
         private readonly ExampleIntegrationTestContext<TestableStartup<ZeroKeyDbContext>, ZeroKeyDbContext> _testContext;
-        private readonly ZeroKeyFakers _fakers = new ZeroKeyFakers();
+        private readonly ZeroKeyFakers _fakers = new();
 
         public ZeroAsKeyTests(ExampleIntegrationTestContext<TestableStartup<ZeroKeyDbContext>, ZeroKeyDbContext> testContext)
         {

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ZeroKeys/ZeroKeyFakers.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/ZeroKeys/ZeroKeyFakers.cs
@@ -9,18 +9,18 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.ZeroKeys
 {
     internal sealed class ZeroKeyFakers : FakerContainer
     {
-        private readonly Lazy<Faker<Game>> _lazyGameFaker = new Lazy<Faker<Game>>(() =>
+        private readonly Lazy<Faker<Game>> _lazyGameFaker = new(() =>
             new Faker<Game>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(game => game.Title, faker => faker.Random.Words()));
 
-        private readonly Lazy<Faker<Player>> _lazyPlayerFaker = new Lazy<Faker<Player>>(() =>
+        private readonly Lazy<Faker<Player>> _lazyPlayerFaker = new(() =>
             new Faker<Player>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(player => player.Id, faker => faker.Person.UserName)
                 .RuleFor(player => player.EmailAddress, faker => faker.Person.Email));
 
-        private readonly Lazy<Faker<Map>> _lazyMapFaker = new Lazy<Faker<Map>>(() =>
+        private readonly Lazy<Faker<Map>> _lazyMapFaker = new(() =>
             new Faker<Map>()
                 .UseSeed(GetFakerSeed())
                 .RuleFor(map => map.Id, faker => faker.Random.Guid())

--- a/test/TestBuildingBlocks/BaseIntegrationTestContext.cs
+++ b/test/TestBuildingBlocks/BaseIntegrationTestContext.cs
@@ -31,7 +31,7 @@ namespace TestBuildingBlocks
         where TDbContext : DbContext
     {
         private readonly Lazy<WebApplicationFactory<TRemoteStartup>> _lazyFactory;
-        private readonly TestControllerProvider _testControllerProvider = new TestControllerProvider();
+        private readonly TestControllerProvider _testControllerProvider = new();
         private Action<ILoggingBuilder> _loggingConfiguration;
         private Action<IServiceCollection> _beforeServicesConfiguration;
         private Action<IServiceCollection> _afterServicesConfiguration;

--- a/test/TestBuildingBlocks/FakeLoggerFactory.cs
+++ b/test/TestBuildingBlocks/FakeLoggerFactory.cs
@@ -31,7 +31,7 @@ namespace TestBuildingBlocks
 
         public sealed class FakeLogger : ILogger
         {
-            private readonly ConcurrentBag<FakeLogMessage> _messages = new ConcurrentBag<FakeLogMessage>();
+            private readonly ConcurrentBag<FakeLogMessage> _messages = new();
 
             public IReadOnlyCollection<FakeLogMessage> Messages => _messages;
 

--- a/test/TestBuildingBlocks/FakerContainer.cs
+++ b/test/TestBuildingBlocks/FakerContainer.cs
@@ -22,7 +22,7 @@ namespace TestBuildingBlocks
         {
             var stackTrace = new StackTrace();
 
-            MethodBase testMethod = stackTrace.GetFrames().Select(stackFrame => stackFrame?.GetMethod()).FirstOrDefault(IsTestMethod);
+            MethodBase testMethod = stackTrace.GetFrames().Select(stackFrame => stackFrame.GetMethod()).FirstOrDefault(IsTestMethod);
 
             if (testMethod == null)
             {

--- a/test/TestBuildingBlocks/FrozenSystemClock.cs
+++ b/test/TestBuildingBlocks/FrozenSystemClock.cs
@@ -5,7 +5,7 @@ namespace TestBuildingBlocks
 {
     public sealed class FrozenSystemClock : ISystemClock
     {
-        private static readonly DateTimeOffset DefaultTime = new DateTimeOffset(new DateTime(2000, 1, 1, 1, 1, 1), TimeSpan.FromHours(1));
+        private static readonly DateTimeOffset DefaultTime = new(new DateTime(2000, 1, 1, 1, 1, 1), TimeSpan.FromHours(1));
 
         public DateTimeOffset UtcNow { get; set; } = DefaultTime;
     }

--- a/test/TestBuildingBlocks/HttpResponseMessageExtensions.cs
+++ b/test/TestBuildingBlocks/HttpResponseMessageExtensions.cs
@@ -14,7 +14,7 @@ namespace TestBuildingBlocks
     {
         public static HttpResponseMessageAssertions Should(this HttpResponseMessage instance)
         {
-            return new HttpResponseMessageAssertions(instance);
+            return new(instance);
         }
 
         public sealed class HttpResponseMessageAssertions : ReferenceTypeAssertions<HttpResponseMessage, HttpResponseMessageAssertions>

--- a/test/TestBuildingBlocks/IntegrationTest.cs
+++ b/test/TestBuildingBlocks/IntegrationTest.cs
@@ -13,7 +13,7 @@ namespace TestBuildingBlocks
     /// </summary>
     public abstract class IntegrationTest
     {
-        private static readonly IntegrationTestConfiguration IntegrationTestConfiguration = new IntegrationTestConfiguration();
+        private static readonly IntegrationTestConfiguration IntegrationTestConfiguration = new();
 
         public async Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecuteGetAsync<TResponseDocument>(string requestUrl,
             IEnumerable<MediaTypeWithQualityHeaderValue> acceptHeaders = null)

--- a/test/TestBuildingBlocks/IntegrationTestConfiguration.cs
+++ b/test/TestBuildingBlocks/IntegrationTestConfiguration.cs
@@ -6,7 +6,7 @@ namespace TestBuildingBlocks
     {
         // Because our tests often deserialize incoming responses into weakly-typed string-to-object dictionaries (as part of ResourceObject),
         // Newtonsoft.JSON is unable to infer the target type in such cases. So we steer a bit using explicit configuration.
-        public readonly JsonSerializerSettings DeserializationSettings = new JsonSerializerSettings
+        public readonly JsonSerializerSettings DeserializationSettings = new()
         {
             // Choosing between DateTime and DateTimeOffset is impossible: it depends on how the resource properties are declared.
             // So instead we leave them as strings and let the test itself deal with the conversion.

--- a/test/TestBuildingBlocks/ObjectAssertionsExtensions.cs
+++ b/test/TestBuildingBlocks/ObjectAssertionsExtensions.cs
@@ -13,7 +13,7 @@ namespace TestBuildingBlocks
     {
         private const decimal NumericPrecision = 0.00000000001M;
 
-        private static readonly JsonSerializerSettings DeserializationSettings = new JsonSerializerSettings
+        private static readonly JsonSerializerSettings DeserializationSettings = new()
         {
             Formatting = Formatting.Indented
         };

--- a/test/TestBuildingBlocks/TestBuildingBlocks.csproj
+++ b/test/TestBuildingBlocks/TestBuildingBlocks.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)" PrivateAssets="All" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0-preview.3.21201.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlPostgreSQLVersion)" />
     <PackageReference Include="xunit" Version="$(XUnitVersion)" />

--- a/test/UnitTests/Middleware/JsonApiMiddlewareTests.cs
+++ b/test/UnitTests/Middleware/JsonApiMiddlewareTests.cs
@@ -159,7 +159,7 @@ namespace UnitTests.Middleware
                 ControllerTypeInfo = (TypeInfo)typeof(object)
             };
 
-            context.SetEndpoint(new Endpoint(null, new EndpointMetadataCollection(controllerActionDescriptor), null));
+            context.SetEndpoint(new Endpoint(null!, new EndpointMetadataCollection(controllerActionDescriptor), null));
             return context;
         }
 
@@ -192,12 +192,12 @@ namespace UnitTests.Middleware
 
         private sealed class InvokeConfiguration
         {
-            public JsonApiMiddleware MiddleWare { get; set; }
-            public HttpContext HttpContext { get; set; }
-            public Mock<IControllerResourceMapping> ControllerResourceMapping { get; set; }
-            public Mock<IJsonApiOptions> Options { get; set; }
-            public JsonApiRequest Request { get; set; }
-            public Mock<IResourceGraph> ResourceGraph { get; set; }
+            public JsonApiMiddleware MiddleWare { get; init; }
+            public HttpContext HttpContext { get; init; }
+            public Mock<IControllerResourceMapping> ControllerResourceMapping { get; init; }
+            public Mock<IJsonApiOptions> Options { get; init; }
+            public JsonApiRequest Request { get; init; }
+            public Mock<IResourceGraph> ResourceGraph { get; init; }
         }
     }
 }

--- a/test/UnitTests/Middleware/JsonApiRequestTests.cs
+++ b/test/UnitTests/Middleware/JsonApiRequestTests.cs
@@ -106,7 +106,7 @@ namespace UnitTests.Middleware
                 ControllerTypeInfo = (TypeInfo)typeof(object)
             };
 
-            httpContext.SetEndpoint(new Endpoint(null, new EndpointMetadataCollection(controllerActionDescriptor), null));
+            httpContext.SetEndpoint(new Endpoint(null!, new EndpointMetadataCollection(controllerActionDescriptor), null));
         }
     }
 }

--- a/test/UnitTests/Models/RelationshipDataTests.cs
+++ b/test/UnitTests/Models/RelationshipDataTests.cs
@@ -15,7 +15,7 @@ namespace UnitTests.Models
 
             var relationships = new List<ResourceIdentifierObject>
             {
-                new ResourceIdentifierObject
+                new()
                 {
                     Id = "9",
                     Type = "authors"

--- a/test/UnitTests/ResourceHooks/Executor/Update/BeforeUpdateWithDbValuesTests.cs
+++ b/test/UnitTests/ResourceHooks/Executor/Update/BeforeUpdateWithDbValuesTests.cs
@@ -122,7 +122,7 @@ namespace UnitTests.ResourceHooks.Executor.Update
             // Act
             var todoList = new List<TodoItem>
             {
-                new TodoItem
+                new()
                 {
                     Id = _todoList[0].Id
                 }

--- a/test/UnitTests/ResourceHooks/HooksTestsSetup.cs
+++ b/test/UnitTests/ResourceHooks/HooksTestsSetup.cs
@@ -23,8 +23,8 @@ namespace UnitTests.ResourceHooks
 {
     public class HooksTestsSetup : HooksDummyData
     {
-        private static readonly IncludeChainConverter IncludeChainConverter = new IncludeChainConverter();
-        private static readonly HooksObjectFactory ObjectFactory = new HooksObjectFactory();
+        private static readonly IncludeChainConverter IncludeChainConverter = new();
+        private static readonly HooksObjectFactory ObjectFactory = new();
 
         private TestMocks CreateMocks()
         {
@@ -174,7 +174,7 @@ namespace UnitTests.ResourceHooks
 
             resourceDefinition
                 .Setup(rd => rd.BeforeUpdateRelationship(It.IsAny<HashSet<string>>(), It.IsAny<IRelationshipsDictionary<TModel>>(),
-                    It.IsAny<ResourcePipeline>())).Returns<IEnumerable<string>, IRelationshipsDictionary<TModel>, ResourcePipeline>((ids, _, __) => ids)
+                    It.IsAny<ResourcePipeline>())).Returns<IEnumerable<string>, IRelationshipsDictionary<TModel>, ResourcePipeline>((ids, _, _) => ids)
                 .Verifiable();
 
             resourceDefinition.Setup(rd => rd.BeforeImplicitUpdateRelationship(It.IsAny<IRelationshipsDictionary<TModel>>(), It.IsAny<ResourcePipeline>()))
@@ -283,7 +283,7 @@ namespace UnitTests.ResourceHooks
         {
             var expressionsInScope = new List<ExpressionInScope>
             {
-                new ExpressionInScope(null, includeExpression)
+                new(null, includeExpression)
             };
 
             var mock = new Mock<IQueryConstraintProvider>();

--- a/test/UnitTests/ResourceHooks/RelationshipDictionaryTests.cs
+++ b/test/UnitTests/ResourceHooks/RelationshipDictionaryTests.cs
@@ -6,6 +6,8 @@ using JsonApiDotNetCore.Hooks.Internal.Execution;
 using JsonApiDotNetCore.Resources.Annotations;
 using Xunit;
 
+// ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
+
 namespace UnitTests.ResourceHooks
 {
     public sealed class RelationshipDictionaryTests
@@ -14,9 +16,9 @@ namespace UnitTests.ResourceHooks
         private readonly HasOneAttribute _secondToOneAttr;
         private readonly HasManyAttribute _toManyAttr;
 
-        private readonly Dictionary<RelationshipAttribute, HashSet<Dummy>> _relationships = new Dictionary<RelationshipAttribute, HashSet<Dummy>>();
+        private readonly Dictionary<RelationshipAttribute, HashSet<Dummy>> _relationships = new();
 
-        private readonly HashSet<Dummy> _firstToOnesResources = new HashSet<Dummy>
+        private readonly HashSet<Dummy> _firstToOnesResources = new()
         {
             new Dummy
             {
@@ -32,7 +34,7 @@ namespace UnitTests.ResourceHooks
             }
         };
 
-        private readonly HashSet<Dummy> _secondToOnesResources = new HashSet<Dummy>
+        private readonly HashSet<Dummy> _secondToOnesResources = new()
         {
             new Dummy
             {
@@ -48,7 +50,7 @@ namespace UnitTests.ResourceHooks
             }
         };
 
-        private readonly HashSet<Dummy> _toManiesResources = new HashSet<Dummy>
+        private readonly HashSet<Dummy> _toManiesResources = new()
         {
             new Dummy
             {
@@ -64,7 +66,7 @@ namespace UnitTests.ResourceHooks
             }
         };
 
-        private readonly HashSet<Dummy> _noRelationshipsResources = new HashSet<Dummy>
+        private readonly HashSet<Dummy> _noRelationshipsResources = new()
         {
             new Dummy
             {

--- a/test/UnitTests/Serialization/Client/RequestSerializerTests.cs
+++ b/test/UnitTests/Serialization/Client/RequestSerializerTests.cs
@@ -156,7 +156,7 @@ namespace UnitTests.Serialization.Client
                 },
                 PopulatedToManies = new HashSet<OneToManyDependent>
                 {
-                    new OneToManyDependent
+                    new()
                     {
                         Id = 20
                     }
@@ -216,13 +216,13 @@ namespace UnitTests.Serialization.Client
             // Arrange
             var resources = new List<TestResource>
             {
-                new TestResource
+                new()
                 {
                     Id = 1,
                     StringField = "value1",
                     NullableIntField = 123
                 },
-                new TestResource
+                new()
                 {
                     Id = 2,
                     StringField = "value2",

--- a/test/UnitTests/Serialization/Client/ResponseDeserializerTests.cs
+++ b/test/UnitTests/Serialization/Client/ResponseDeserializerTests.cs
@@ -12,7 +12,7 @@ namespace UnitTests.Serialization.Client
 {
     public sealed class ResponseDeserializerTests : DeserializerTestsSetup
     {
-        private readonly Dictionary<string, string> _linkValues = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> _linkValues = new();
         private readonly ResponseDeserializer _deserializer;
 
         public ResponseDeserializerTests()
@@ -135,7 +135,7 @@ namespace UnitTests.Serialization.Client
 
             content.Included = new List<ResourceObject>
             {
-                new ResourceObject
+                new()
                 {
                     Type = "oneToOneDependents",
                     Id = "10",
@@ -144,7 +144,7 @@ namespace UnitTests.Serialization.Client
                         ["attributeMember"] = toOneAttributeValue
                     }
                 },
-                new ResourceObject
+                new()
                 {
                     Type = "oneToManyDependents",
                     Id = "10",
@@ -186,7 +186,7 @@ namespace UnitTests.Serialization.Client
 
             content.Included = new List<ResourceObject>
             {
-                new ResourceObject
+                new()
                 {
                     Type = "oneToOnePrincipals",
                     Id = "10",
@@ -195,7 +195,7 @@ namespace UnitTests.Serialization.Client
                         ["attributeMember"] = toOneAttributeValue
                     }
                 },
-                new ResourceObject
+                new()
                 {
                     Type = "oneToManyPrincipals",
                     Id = "10",
@@ -233,7 +233,7 @@ namespace UnitTests.Serialization.Client
 
             content.Included = new List<ResourceObject>
             {
-                new ResourceObject
+                new()
                 {
                     Type = "oneToManyDependents",
                     Id = "10",
@@ -246,7 +246,7 @@ namespace UnitTests.Serialization.Client
                         ["principal"] = CreateRelationshipData("oneToManyPrincipals")
                     }
                 },
-                new ResourceObject
+                new()
                 {
                     Type = "oneToManyPrincipals",
                     Id = "10",
@@ -287,7 +287,7 @@ namespace UnitTests.Serialization.Client
 
             content.Included = new List<ResourceObject>
             {
-                new ResourceObject
+                new()
                 {
                     Type = "multiPrincipals",
                     Id = "10",
@@ -300,7 +300,7 @@ namespace UnitTests.Serialization.Client
                         ["populatedToManies"] = CreateRelationshipData("oneToManyDependents", true)
                     }
                 },
-                new ResourceObject
+                new()
                 {
                     Type = "oneToManyDependents",
                     Id = "10",
@@ -313,7 +313,7 @@ namespace UnitTests.Serialization.Client
                         ["principal"] = CreateRelationshipData("oneToManyPrincipals")
                     }
                 },
-                new ResourceObject
+                new()
                 {
                     Type = "oneToManyPrincipals",
                     Id = "10",
@@ -362,7 +362,7 @@ namespace UnitTests.Serialization.Client
 
             content.Included = new List<ResourceObject>
             {
-                new ResourceObject
+                new()
                 {
                     Type = "multiPrincipals",
                     Id = "10",
@@ -375,7 +375,7 @@ namespace UnitTests.Serialization.Client
                         ["populatedToManies"] = CreateRelationshipData("oneToManyDependents", true)
                     }
                 },
-                new ResourceObject
+                new()
                 {
                     Type = "oneToManyDependents",
                     Id = "10",
@@ -388,7 +388,7 @@ namespace UnitTests.Serialization.Client
                         ["principal"] = CreateRelationshipData("oneToManyPrincipals")
                     }
                 },
-                new ResourceObject
+                new()
                 {
                     Type = "oneToManyPrincipals",
                     Id = "10",
@@ -429,7 +429,7 @@ namespace UnitTests.Serialization.Client
 
             content.Included = new List<ResourceObject>
             {
-                new ResourceObject
+                new()
                 {
                     Type = "firstDerivedModels",
                     Id = "10",
@@ -438,7 +438,7 @@ namespace UnitTests.Serialization.Client
                         ["firstProperty"] = "true"
                     }
                 },
-                new ResourceObject
+                new()
                 {
                     Type = "secondDerivedModels",
                     Id = "11",
@@ -447,7 +447,7 @@ namespace UnitTests.Serialization.Client
                         ["secondProperty"] = "false"
                     }
                 },
-                new ResourceObject
+                new()
                 {
                     Type = "firstDerivedModels",
                     Id = "20",

--- a/test/UnitTests/Serialization/Common/BaseDocumentParserTests.cs
+++ b/test/UnitTests/Serialization/Common/BaseDocumentParserTests.cs
@@ -65,7 +65,7 @@ namespace UnitTests.Serialization.Common
             {
                 Data = new List<ResourceObject>
                 {
-                    new ResourceObject
+                    new()
                     {
                         Type = "testResource",
                         Id = "1"
@@ -270,7 +270,7 @@ namespace UnitTests.Serialization.Common
             {
                 Data = new List<ResourceIdentifierObject>
                 {
-                    new ResourceIdentifierObject
+                    new()
                     {
                         Type = "Dependent",
                         Id = "1"

--- a/test/UnitTests/Serialization/Common/ResourceObjectBuilderTests.cs
+++ b/test/UnitTests/Serialization/Common/ResourceObjectBuilderTests.cs
@@ -131,7 +131,7 @@ namespace UnitTests.Serialization.Common
                 },
                 PopulatedToManies = new HashSet<OneToManyDependent>
                 {
-                    new OneToManyDependent
+                    new()
                     {
                         Id = 20
                     }

--- a/test/UnitTests/Serialization/DeserializerTestsSetup.cs
+++ b/test/UnitTests/Serialization/DeserializerTestsSetup.cs
@@ -30,7 +30,7 @@ namespace UnitTests.Serialization
 
         protected Document CreateDocumentWithRelationships(string primaryType)
         {
-            return new Document
+            return new()
             {
                 Data = new ResourceObject
                 {
@@ -67,7 +67,7 @@ namespace UnitTests.Serialization
 
         protected Document CreateTestResourceDocument()
         {
-            return new Document
+            return new()
             {
                 Data = new ResourceObject
                 {

--- a/test/UnitTests/Serialization/SerializerTestsSetup.cs
+++ b/test/UnitTests/Serialization/SerializerTestsSetup.cs
@@ -16,7 +16,7 @@ namespace UnitTests.Serialization
 {
     public class SerializerTestsSetup : SerializationTestsSetupBase
     {
-        private static readonly IncludeChainConverter IncludeChainConverter = new IncludeChainConverter();
+        private static readonly IncludeChainConverter IncludeChainConverter = new();
 
         protected readonly TopLevelLinks DummyTopLevelLinks;
         protected readonly ResourceLinks DummyResourceLinks;

--- a/test/UnitTests/Serialization/Server/RequestDeserializerTests.cs
+++ b/test/UnitTests/Serialization/Server/RequestDeserializerTests.cs
@@ -15,8 +15,8 @@ namespace UnitTests.Serialization.Server
     public sealed class RequestDeserializerTests : DeserializerTestsSetup
     {
         private readonly RequestDeserializer _deserializer;
-        private readonly Mock<ITargetedFields> _fieldsManagerMock = new Mock<ITargetedFields>();
-        private readonly Mock<IJsonApiRequest> _requestMock = new Mock<IJsonApiRequest>();
+        private readonly Mock<ITargetedFields> _fieldsManagerMock = new();
+        private readonly Mock<IJsonApiRequest> _requestMock = new();
 
         public RequestDeserializerTests()
         {

--- a/test/UnitTests/Serialization/Server/ResponseResourceObjectBuilderTests.cs
+++ b/test/UnitTests/Serialization/Server/ResponseResourceObjectBuilderTests.cs
@@ -70,7 +70,7 @@ namespace UnitTests.Serialization.Server
                 Id = 10,
                 Dependents = new HashSet<OneToManyDependent>
                 {
-                    new OneToManyDependent
+                    new()
                     {
                         Id = 20
                     }
@@ -98,7 +98,7 @@ namespace UnitTests.Serialization.Server
                 Id = 10,
                 Dependents = new HashSet<OneToManyDependent>
                 {
-                    new OneToManyDependent
+                    new()
                     {
                         Id = 20
                     }

--- a/test/UnitTests/Serialization/Server/ResponseSerializerTests.cs
+++ b/test/UnitTests/Serialization/Server/ResponseSerializerTests.cs
@@ -102,7 +102,7 @@ namespace UnitTests.Serialization.Server
                 },
                 PopulatedToManies = new HashSet<OneToManyDependent>
                 {
-                    new OneToManyDependent
+                    new()
                     {
                         Id = 20
                     }

--- a/test/UnitTests/TestScopedServiceProvider.cs
+++ b/test/UnitTests/TestScopedServiceProvider.cs
@@ -8,7 +8,7 @@ namespace UnitTests
     public sealed class TestScopedServiceProvider : IRequestScopedServiceProvider
     {
         private readonly IServiceProvider _serviceProvider;
-        private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+        private readonly Mock<IHttpContextAccessor> _httpContextAccessorMock = new();
 
         public TestScopedServiceProvider(IServiceProvider serviceProvider)
         {


### PR DESCRIPTION
This PR shows that using EF Core 6 Preview 3, all of our existing tests succeed with the workaround for https://github.com/dotnet/efcore/issues/21026 removed.

This PR is not meant to be merged.