### PR TITLE
Filters: allow has() with a condition

### DIFF
--- a/docs/usage/reading/filtering.md
+++ b/docs/usage/reading/filtering.md
@@ -74,6 +74,16 @@ Putting it all together, you can build quite complex filters, such as:
 GET /blogs?include=owner.articles.revisions&filter=and(or(equals(title,'Technology'),has(owner.articles)),not(equals(owner.lastName,null)))&filter[owner.articles]=equals(caption,'Two')&filter[owner.articles.revisions]=greaterThan(publishTime,'2005-05-05') HTTP/1.1
 ```
 
+_since v4.2_
+
+The `has` function takes an optional filter condition as second parameter, for example:
+
+```http
+GET /customers?filter=has(orders,not(equals(status,'Paid'))) HTTP/1.1
+```
+
+Which returns only customers that have at least one unpaid order.
+
 # Legacy filters
 
 The next section describes how filtering worked in versions prior to v4.0. They are always applied on the set of resources being requested (no nesting).

--- a/src/JsonApiDotNetCore/Queries/Expressions/FilterExpression.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/FilterExpression.cs
@@ -1,7 +1,7 @@
 namespace JsonApiDotNetCore.Queries.Expressions
 {
     /// <summary>
-    /// Represents the base type for filter functions.
+    /// Represents the base type for filter functions that return a boolean value.
     /// </summary>
     public abstract class FilterExpression : FunctionExpression
     {

--- a/src/JsonApiDotNetCore/Queries/Expressions/FunctionExpression.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/FunctionExpression.cs
@@ -1,7 +1,7 @@
 namespace JsonApiDotNetCore.Queries.Expressions
 {
     /// <summary>
-    /// Represents the base type for functions.
+    /// Represents the base type for functions that return a value.
     /// </summary>
     public abstract class FunctionExpression : QueryExpression
     {

--- a/src/JsonApiDotNetCore/Queries/Expressions/LogicalExpression.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/LogicalExpression.cs
@@ -14,9 +14,9 @@ namespace JsonApiDotNetCore.Queries.Expressions
     public class LogicalExpression : FilterExpression
     {
         public LogicalOperator Operator { get; }
-        public IReadOnlyCollection<QueryExpression> Terms { get; }
+        public IReadOnlyCollection<FilterExpression> Terms { get; }
 
-        public LogicalExpression(LogicalOperator @operator, IReadOnlyCollection<QueryExpression> terms)
+        public LogicalExpression(LogicalOperator @operator, IReadOnlyCollection<FilterExpression> terms)
         {
             ArgumentGuard.NotNull(terms, nameof(terms));
 

--- a/src/JsonApiDotNetCore/Queries/Expressions/NotExpression.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/NotExpression.cs
@@ -9,9 +9,9 @@ namespace JsonApiDotNetCore.Queries.Expressions
     [PublicAPI]
     public class NotExpression : FilterExpression
     {
-        public QueryExpression Child { get; }
+        public FilterExpression Child { get; }
 
-        public NotExpression(QueryExpression child)
+        public NotExpression(FilterExpression child)
         {
             ArgumentGuard.NotNull(child, nameof(child));
 

--- a/src/JsonApiDotNetCore/Queries/Expressions/QueryExpressionRewriter.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/QueryExpressionRewriter.cs
@@ -54,7 +54,7 @@ namespace JsonApiDotNetCore.Queries.Expressions
         {
             if (expression != null)
             {
-                IReadOnlyCollection<QueryExpression> newTerms = VisitSequence(expression.Terms, argument);
+                IReadOnlyCollection<FilterExpression> newTerms = VisitSequence(expression.Terms, argument);
 
                 if (newTerms.Count == 1)
                 {
@@ -75,9 +75,7 @@ namespace JsonApiDotNetCore.Queries.Expressions
         {
             if (expression != null)
             {
-                QueryExpression newChild = Visit(expression.Child, argument);
-
-                if (newChild != null)
+                if (Visit(expression.Child, argument) is FilterExpression newChild)
                 {
                     var newExpression = new NotExpression(newChild);
                     return newExpression.Equals(expression) ? expression : newExpression;

--- a/src/JsonApiDotNetCore/Queries/Expressions/QueryExpressionRewriter.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/QueryExpressionRewriter.cs
@@ -93,7 +93,9 @@ namespace JsonApiDotNetCore.Queries.Expressions
             {
                 if (Visit(expression.TargetCollection, argument) is ResourceFieldChainExpression newTargetCollection)
                 {
-                    var newExpression = new CollectionNotEmptyExpression(newTargetCollection);
+                    FilterExpression newFilter = expression.Filter != null ? Visit(expression.Filter, argument) as FilterExpression : null;
+
+                    var newExpression = new CollectionNotEmptyExpression(newTargetCollection, newFilter);
                     return newExpression.Equals(expression) ? expression : newExpression;
                 }
             }

--- a/src/JsonApiDotNetCore/Queries/Internal/Parsing/FilterParser.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/Parsing/FilterParser.cs
@@ -106,7 +106,7 @@ namespace JsonApiDotNetCore.Queries.Internal.Parsing
             EatText(operatorName);
             EatSingleCharacterToken(TokenKind.OpenParen);
 
-            var terms = new List<QueryExpression>();
+            var terms = new List<FilterExpression>();
 
             FilterExpression term = ParseFilter();
             terms.Add(term);

--- a/src/JsonApiDotNetCore/Queries/Internal/Parsing/FilterParser.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/Parsing/FilterParser.cs
@@ -14,6 +14,7 @@ namespace JsonApiDotNetCore.Queries.Internal.Parsing
     [PublicAPI]
     public class FilterParser : QueryExpressionParser
     {
+        private readonly IResourceContextProvider _resourceContextProvider;
         private readonly IResourceFactory _resourceFactory;
         private readonly Action<ResourceFieldAttribute, ResourceContext, string> _validateSingleFieldCallback;
         private ResourceContext _resourceContextInScope;
@@ -22,8 +23,10 @@ namespace JsonApiDotNetCore.Queries.Internal.Parsing
             Action<ResourceFieldAttribute, ResourceContext, string> validateSingleFieldCallback = null)
             : base(resourceContextProvider)
         {
+            ArgumentGuard.NotNull(resourceContextProvider, nameof(resourceContextProvider));
             ArgumentGuard.NotNull(resourceFactory, nameof(resourceFactory));
 
+            _resourceContextProvider = resourceContextProvider;
             _resourceFactory = resourceFactory;
             _validateSingleFieldCallback = validateSingleFieldCallback;
         }
@@ -234,10 +237,31 @@ namespace JsonApiDotNetCore.Queries.Internal.Parsing
             EatSingleCharacterToken(TokenKind.OpenParen);
 
             ResourceFieldChainExpression targetCollection = ParseFieldChain(FieldChainRequirements.EndsInToMany, null);
+            FilterExpression filter = null;
+
+            if (TokenStack.TryPeek(out Token nextToken) && nextToken.Kind == TokenKind.Comma)
+            {
+                EatSingleCharacterToken(TokenKind.Comma);
+
+                filter = ParseFilterInHas((HasManyAttribute)targetCollection.Fields.Last());
+            }
 
             EatSingleCharacterToken(TokenKind.CloseParen);
 
-            return new CollectionNotEmptyExpression(targetCollection);
+            return new CollectionNotEmptyExpression(targetCollection, filter);
+        }
+
+        private FilterExpression ParseFilterInHas(HasManyAttribute hasManyRelationship)
+        {
+            ResourceContext outerScopeBackup = _resourceContextInScope;
+
+            Type innerResourceType = hasManyRelationship.RightType;
+            _resourceContextInScope = _resourceContextProvider.GetResourceContext(innerResourceType);
+
+            FilterExpression filter = ParseFilter();
+
+            _resourceContextInScope = outerScopeBackup;
+            return filter;
         }
 
         protected QueryExpression ParseCountOrField(FieldChainRequirements chainRequirements)

--- a/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/QueryableBuilder.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/QueryableBuilder.cs
@@ -93,7 +93,7 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
         {
             using LambdaScope lambdaScope = _lambdaScopeFactory.CreateScope(_elementType);
 
-            var builder = new WhereClauseBuilder(source, lambdaScope, _extensionType);
+            var builder = new WhereClauseBuilder(source, lambdaScope, _extensionType, _nameFactory);
             return builder.ApplyWhere(filter);
         }
 

--- a/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/WhereClauseBuilder.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/WhereClauseBuilder.cs
@@ -301,9 +301,6 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
 
         private static string GetPropertyName(ResourceFieldAttribute field)
         {
-            // TODO: Is this still true when using has() with a filter?
-
-            // In case of a HasManyThrough access (from count() or has() function), we only need to look at the number of entries in the join table.
             return field is HasManyThroughAttribute hasManyThrough ? hasManyThrough.ThroughProperty.Name : field.Property.Name;
         }
     }

--- a/test/JsonApiDotNetCoreExampleTests/IntegrationTests/CompositeKeys/CarExpressionRewriter.cs
+++ b/test/JsonApiDotNetCoreExampleTests/IntegrationTests/CompositeKeys/CarExpressionRewriter.cs
@@ -83,7 +83,7 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.CompositeKeys
 
         private QueryExpression RewriteFilterOnCarStringIds(ResourceFieldChainExpression existingCarIdChain, IEnumerable<string> carStringIds)
         {
-            var outerTerms = new List<QueryExpression>();
+            var outerTerms = new List<FilterExpression>();
 
             foreach (string carStringId in carStringIds)
             {
@@ -92,14 +92,14 @@ namespace JsonApiDotNetCoreExampleTests.IntegrationTests.CompositeKeys
                     StringId = carStringId
                 };
 
-                QueryExpression keyComparison = CreateEqualityComparisonOnCompositeKey(existingCarIdChain, tempCar.RegionId, tempCar.LicensePlate);
+                FilterExpression keyComparison = CreateEqualityComparisonOnCompositeKey(existingCarIdChain, tempCar.RegionId, tempCar.LicensePlate);
                 outerTerms.Add(keyComparison);
             }
 
             return outerTerms.Count == 1 ? outerTerms[0] : new LogicalExpression(LogicalOperator.Or, outerTerms);
         }
 
-        private QueryExpression CreateEqualityComparisonOnCompositeKey(ResourceFieldChainExpression existingCarIdChain, long regionIdValue,
+        private FilterExpression CreateEqualityComparisonOnCompositeKey(ResourceFieldChainExpression existingCarIdChain, long regionIdValue,
             string licensePlateValue)
         {
             ResourceFieldChainExpression regionIdChain = ReplaceLastAttributeInChain(existingCarIdChain, _regionIdAttribute);

--- a/test/JsonApiDotNetCoreExampleTests/UnitTests/QueryStringParameters/FilterParseTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/UnitTests/QueryStringParameters/FilterParseTests.cs
@@ -78,6 +78,7 @@ namespace JsonApiDotNetCoreExampleTests.UnitTests.QueryStringParameters
         [InlineData("filter", "equals(null", "Field 'null' does not exist on resource 'blogs'.")]
         [InlineData("filter", "equals(title,(", "Count function, value between quotes, null or field name expected.")]
         [InlineData("filter", "equals(has(posts),'true')", "Field 'has' does not exist on resource 'blogs'.")]
+        [InlineData("filter", "has(posts,", "Filter function expected.")]
         [InlineData("filter", "contains)", "( expected.")]
         [InlineData("filter", "contains(title,'a','b')", ") expected.")]
         [InlineData("filter", "contains(title,null)", "Value between quotes expected.")]
@@ -125,14 +126,15 @@ namespace JsonApiDotNetCoreExampleTests.UnitTests.QueryStringParameters
         [InlineData("filter[posts.comments]", "greaterThan(createdAt,'2000-01-01')", "posts.comments", "greaterThan(createdAt,'2000-01-01')")]
         [InlineData("filter[posts.comments]", "greaterOrEqual(createdAt,'2000-01-01')", "posts.comments", "greaterOrEqual(createdAt,'2000-01-01')")]
         [InlineData("filter", "has(posts)", null, "has(posts)")]
+        [InlineData("filter", "has(posts,not(equals(url,null)))", null, "has(posts,not(equals(url,null)))")]
         [InlineData("filter", "contains(title,'this')", null, "contains(title,'this')")]
         [InlineData("filter", "startsWith(title,'this')", null, "startsWith(title,'this')")]
         [InlineData("filter", "endsWith(title,'this')", null, "endsWith(title,'this')")]
         [InlineData("filter", "any(title,'this','that','there')", null, "any(title,'this','that','there')")]
         [InlineData("filter", "and(contains(title,'sales'),contains(title,'marketing'),contains(title,'advertising'))", null,
             "and(contains(title,'sales'),contains(title,'marketing'),contains(title,'advertising'))")]
-        [InlineData("filter[posts]", "or(and(not(equals(author.userName,null)),not(equals(author.displayName,null))),not(has(comments)))", "posts",
-            "or(and(not(equals(author.userName,null)),not(equals(author.displayName,null))),not(has(comments)))")]
+        [InlineData("filter[posts]", "or(and(not(equals(author.userName,null)),not(equals(author.displayName,null))),not(has(comments,startsWith(text,'A'))))",
+            "posts", "or(and(not(equals(author.userName,null)),not(equals(author.displayName,null))),not(has(comments,startsWith(text,'A'))))")]
         public void Reader_Read_Succeeds(string parameterName, string parameterValue, string scopeExpected, string valueExpected)
         {
             // Act

--- a/test/JsonApiDotNetCoreExampleTests/UnitTests/QueryStringParameters/FilterParseTests.cs
+++ b/test/JsonApiDotNetCoreExampleTests/UnitTests/QueryStringParameters/FilterParseTests.cs
@@ -113,6 +113,7 @@ namespace JsonApiDotNetCoreExampleTests.UnitTests.QueryStringParameters
 
         [Theory]
         [InlineData("filter", "equals(title,'Brian O''Quote')", null, "equals(title,'Brian O''Quote')")]
+        [InlineData("filter", "equals(title,'!@#$%^&*()-_=+\"''[]{}<>()/|\\:;.,`~')", null, "equals(title,'!@#$%^&*()-_=+\"''[]{}<>()/|\\:;.,`~')")]
         [InlineData("filter", "equals(title,'')", null, "equals(title,'')")]
         [InlineData("filter[posts]", "equals(caption,'this, that & more')", "posts", "equals(caption,'this, that & more')")]
         [InlineData("filter[owner.posts]", "equals(caption,'some')", "owner.posts", "equals(caption,'some')")]


### PR DESCRIPTION
Adds support for an optional condition in the `has` function within filter query strings.
Also added EBNF grammar for filters to documentation and narrowed some types in the filter parse tree.

Closes #985.
