### PR TITLE
Fixes auto-discovery when using multiple assemblies

### DIFF
--- a/src/JsonApiDotNetCore/Configuration/ResourceDescriptorAssemblyCache.cs
+++ b/src/JsonApiDotNetCore/Configuration/ResourceDescriptorAssemblyCache.cs
@@ -23,11 +23,18 @@ namespace JsonApiDotNetCore.Configuration
             }
         }
 
-        public IEnumerable<(Assembly assembly, IReadOnlyCollection<ResourceDescriptor> resourceDescriptors)> GetResourceDescriptorsPerAssembly()
+        public IReadOnlyCollection<ResourceDescriptor> GetResourceDescriptors()
         {
             EnsureAssembliesScanned();
 
-            return _resourceDescriptorsPerAssembly.Select(pair => (pair.Key, pair.Value)).ToArray();
+            return _resourceDescriptorsPerAssembly.SelectMany(pair => pair.Value).ToArray();
+        }
+
+        public IReadOnlyCollection<Assembly> GetAssemblies()
+        {
+            EnsureAssembliesScanned();
+
+            return _resourceDescriptorsPerAssembly.Keys;
         }
 
         private void EnsureAssembliesScanned()

--- a/src/JsonApiDotNetCore/Configuration/ServiceDiscoveryFacade.cs
+++ b/src/JsonApiDotNetCore/Configuration/ServiceDiscoveryFacade.cs
@@ -109,7 +109,7 @@ namespace JsonApiDotNetCore.Configuration
 
         internal void DiscoverResources()
         {
-            foreach (ResourceDescriptor resourceDescriptor in _assemblyCache.GetResourceDescriptorsPerAssembly().SelectMany(tuple => tuple.resourceDescriptors))
+            foreach (ResourceDescriptor resourceDescriptor in _assemblyCache.GetResourceDescriptors())
             {
                 AddResource(resourceDescriptor);
             }
@@ -117,10 +117,13 @@ namespace JsonApiDotNetCore.Configuration
 
         internal void DiscoverInjectables()
         {
-            foreach ((Assembly assembly, IReadOnlyCollection<ResourceDescriptor> resourceDescriptors) in _assemblyCache.GetResourceDescriptorsPerAssembly())
+            IReadOnlyCollection<ResourceDescriptor> descriptors = _assemblyCache.GetResourceDescriptors();
+            IReadOnlyCollection<Assembly> assemblies = _assemblyCache.GetAssemblies();
+
+            foreach (Assembly assembly in assemblies)
             {
                 AddDbContextResolvers(assembly);
-                AddInjectables(resourceDescriptors, assembly);
+                AddInjectables(descriptors, assembly);
             }
         }
 

--- a/test/UnitTests/Graph/ResourceDescriptorAssemblyCacheTests.cs
+++ b/test/UnitTests/Graph/ResourceDescriptorAssemblyCacheTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
+using FluentAssertions;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Resources;
 using Xunit;
@@ -20,12 +20,11 @@ namespace UnitTests.Graph
             assemblyCache.RegisterAssembly(resourceType.Assembly);
 
             // Act
-            IEnumerable<(Assembly assembly, IReadOnlyCollection<ResourceDescriptor> resourceDescriptors)> results =
-                assemblyCache.GetResourceDescriptorsPerAssembly();
+            IReadOnlyCollection<ResourceDescriptor> descriptors = assemblyCache.GetResourceDescriptors();
 
             // Assert
-            Assert.Contains(results,
-                result => result.resourceDescriptors != null && result.resourceDescriptors.Any(descriptor => descriptor.ResourceType == resourceType));
+            descriptors.Should().NotBeEmpty();
+            descriptors.Should().ContainSingle(descriptor => descriptor.ResourceType == resourceType);
         }
 
         [Fact]
@@ -38,14 +37,11 @@ namespace UnitTests.Graph
             assemblyCache.RegisterAssembly(resourceType.Assembly);
 
             // Act
-            IEnumerable<(Assembly assembly, IReadOnlyCollection<ResourceDescriptor> resourceDescriptors)> results =
-                assemblyCache.GetResourceDescriptorsPerAssembly();
+            IReadOnlyCollection<ResourceDescriptor> descriptors = assemblyCache.GetResourceDescriptors();
 
             // Assert
-            foreach (ResourceDescriptor resourceDescriptor in results.SelectMany(result => result.resourceDescriptors))
-            {
-                Assert.True(typeof(IIdentifiable).IsAssignableFrom(resourceDescriptor.ResourceType));
-            }
+            descriptors.Should().NotBeEmpty();
+            descriptors.Select(descriptor => descriptor.ResourceType).Should().AllBeAssignableTo<IIdentifiable>();
         }
     }
 }


### PR DESCRIPTION
Fixes auto-discovery when resources, DbContexts and injectables are spread over different assemblies.

Fixes #995.