### PR TITLE
Fixes error when using EagerLoad on a relationship

### DIFF
--- a/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/SelectClauseBuilder.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryableBuilding/SelectClauseBuilder.cs
@@ -133,6 +133,14 @@ namespace JsonApiDotNetCore.Queries.Internal.QueryableBuilding
             foreach (EagerLoadAttribute eagerLoad in resourceContext.EagerLoads)
             {
                 var propertySelector = new PropertySelector(eagerLoad.Property);
+
+                // When an entity navigation property is decorated with both EagerLoadAttribute and RelationshipAttribute,
+                // it may already exist with a sub-layer. So do not overwrite in that case.
+                if (!propertySelectors.ContainsKey(propertySelector.Property))
+                {
+                    propertySelectors[propertySelector.Property] = propertySelector;
+                }
+
                 propertySelectors[propertySelector.Property] = propertySelector;
             }
 


### PR DESCRIPTION
Fixes #988.

I intentionally haven't added tests, because `[EagerLoad]` was never meant to be combined with relationship attributes. This PR does not make that a supported feature. Instead this fix is solely to unblock a user that ran into a problem while trying to do so. In that process, additional problems may surface and we'll see how to deal with them on a case-by-case basis.

A few tests exist in unmerged #990, which was used to reproduce the problem.