### PR TITLE
Updated roadmap for v5.x

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,13 +26,13 @@ Aside from the list above, we have interest in the following topics. It's too so
 
 - Optimized delete to-many [#1030](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1030)
 - Improved paging links [#1010](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1010)
-- Extract annotations into separate package [#730](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/730)
-- Fluent API [#776](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/776)
 - Auto-generated controllers [#732](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/732) [#365](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/365)
 - Configuration validation [#170](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/170)
 - Optimistic concurrency [#1004](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1004)
-- Resource inheritance [#844](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/844)
+- Extract annotations into separate package [#730](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/730)
 - OpenAPI (Swagger) [#259](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/259)
+- Fluent API [#776](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/776)
+- Resource inheritance [#844](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/844)
 - Idempotency
 
 ## Feedback

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,28 +5,35 @@ This document provides an overview of the direction this project is heading and 
 > Disclaimer: This is an open source project. The available time of our contributors varies and therefore we do not plan release dates. This document expresses our current intent, which may change over time.
 
 ## v4.x
-In December 2020, we released v4.0 stable after a long time. From now on, we'd like to release new features and bugfixes often.
-In subsequent v4.x releases, we intend to implement the next features in non-breaking ways.
 
-- Codebase improvements (refactor tests [#715](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/715), coding guidelines [#835](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/835) [#290](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/290), cibuild [#908](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/908))
-- Bulk/batch support (atomic:operations) [#936](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/936)
-- Write callbacks [#934](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/934)
-- ETags [#933](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/933)
-- Optimistic Concurrency [#350](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/350)
-- Configuration validation [#414](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/414) [#170](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/170)
+We've completed active development on v4.x, but we'll still fix important bugs or add small enhancements on request that don't require breaking changes nor lots of testing.
 
-## vNext
-We have interest in the following topics for future versions.
-Some cannot be done in v4.x the way we'd like without introducing breaking changes.
-Others require more exploration first, or depend on other features.
+## v5.x
 
-- Resource inheritance [#844](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/844)
-- Split into multiple NuGet packages [#730](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/730) [#661](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/661) [#292](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/292)
-- System.Text.Json [#664](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/664)
-- EF Core 5 Many-to-many relationships [#935](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/935)
+The need for breaking changes has blocked several efforts in the v4.x release, so now that we're starting work on v5, we're going to catch up.
+
+- Remove Resource Hooks [#1025](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1025)
+- Update to .NET/EFCORE 5 [#1026](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1026)
+- Native many-to-many [#935](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/935)
+- Refactorings [#1027](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1027) [#944](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/944)
+- Instrumentation [#1032](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1032)
+- Support System.Text.Json [#664](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/664) [#999](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/999) [#233](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/233)
+- Optimize IIdentifiable to ResourceObject conversion [#1028](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1028) [#1024](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1024)
+- Nullable reference types [#1029](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1029)
+- Tweak trace logging [#1033](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1033)
+
+Aside from the list above, we have interest in the following topics. It's too soon yet to decide whether they'll make it into v5.x or in a later major version.
+
+- Optimized delete to-many [#1030](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1030)
+- Improved paging links [#1010](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1010)
+- Extract annotations into separate package [#730](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/730)
 - Fluent API [#776](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/776)
 - Auto-generated controllers [#732](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/732) [#365](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/365)
-- Serialization, discovery and documentation [#661](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/661) [#259](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/259)
+- Configuration validation [#170](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/170)
+- Optimistic concurrency [#1004](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1004)
+- Resource inheritance [#844](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/844)
+- OpenAPI (Swagger) [#259](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/259)
+- Idempotency
 
 ## Feedback
 


### PR DESCRIPTION
This PR contains our current plans for JsonApiDotNetCore v5.x. We're closing active development on v4.x. This means we're not going to deliver the next issues for v4.x anymore:

- #1004 because we suspect we can provide a better experience by making breaking changes.
- #414 because it is closely related to planned work for nullable reference types.
- #170 because it was a low-impact, non-breaking change, but we feel it can wait, in favor of more important work.
