### PR TITLE
Updated PostgreSQL  to v13.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,9 @@ for:
     - image: Visual Studio 2019
   services:
   - postgresql134
+  # https://help.appveyor.com/discussions/problems/30239-postgres-fails-to-connect-after-version-change
+  init:
+  - net start postgresql-x64-13
   # REF: https://github.com/docascode/docfx-seed/blob/master/appveyor.yml
   before_build:
     - pwsh: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image:
 
 version: '{build}'
 
-stack: postgresql
+stack: postgresql 13.4
 
 environment:
   PGUSER: postgres
@@ -34,7 +34,7 @@ for:
     only:
     - image: Visual Studio 2019
   services:
-  - postgresql101
+  - postgresql134
   # REF: https://github.com/docascode/docfx-seed/blob/master/appveyor.yml
   before_build:
     - pwsh: |
@@ -92,7 +92,18 @@ for:
       appveyor_repo_tag: true
 
 build_script:
-- pwsh: dotnet --version
-- pwsh: .\Build.ps1
+- pwsh: |
+    Write-Output ".NET version:"
+    dotnet --version
+
+    Write-Output "PostgreSQL version:"
+    if ($IsWindows) {
+        . "${env:ProgramFiles}\PostgreSQL\13\bin\psql" --version
+    }
+    else {
+        psql --version
+    }
+
+    .\Build.ps1
 
 test: off

--- a/run-docker-postgres.ps1
+++ b/run-docker-postgres.ps1
@@ -9,4 +9,4 @@ docker run --rm --name jsonapi-dotnet-core-testing       `
  -e POSTGRES_USER=postgres                               `
  -e POSTGRES_PASSWORD=postgres                           `
  -p 5432:5432                                            `
- postgres:12.0
+ postgres:13.4


### PR DESCRIPTION
Based on https://www.appveyor.com/docs/services-databases/#postgresql, I always assumed AppVeyor did not ship with recent PostgreSQL  versions. Until I subscribed to its newsletter, which announced images updates to the latest versions. Trying them out in this PR.