### PR TITLE
Secondary paging

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,10 +22,10 @@ The need for breaking changes has blocked several efforts in the v4.x release, s
 - [x] Support System.Text.Json [#664](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/664) [#999](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/999) [1077](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1077) [1078](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1078)
 - [x] Optimize IIdentifiable to ResourceObject conversion [#1028](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1028) [#1024](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1024) [#233](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/233)
 - [x] Nullable reference types [#1029](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1029)
+- [x] Improved paging links [#1010](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1010)
 
 Aside from the list above, we have interest in the following topics. It's too soon yet to decide whether they'll make it into v5.x or in a later major version.
 
-- Improved paging links [#1010](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1010)
 - Auto-generated controllers [#732](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/732) [#365](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/365)
 - Configuration validation [#170](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/170)
 - Optimistic concurrency [#1004](https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1004)

--- a/benchmarks/Serialization/ResourceSerializationBenchmarks.cs
+++ b/benchmarks/Serialization/ResourceSerializationBenchmarks.cs
@@ -129,7 +129,7 @@ namespace Benchmarks.Serialization
             RelationshipAttribute multi4 = resourceAType.GetRelationshipByPropertyName(nameof(OutgoingResource.Multi4));
             RelationshipAttribute multi5 = resourceAType.GetRelationshipByPropertyName(nameof(OutgoingResource.Multi5));
 
-            ImmutableArray<ResourceFieldAttribute> chain = ArrayFactory.Create<ResourceFieldAttribute>(single2, single3, multi4, multi5).ToImmutableArray();
+            ImmutableArray<ResourceFieldAttribute> chain = ImmutableArray.Create<ResourceFieldAttribute>(single2, single3, multi4, multi5);
             IEnumerable<ResourceFieldChainExpression> chains = new ResourceFieldChainExpression(chain).AsEnumerable();
 
             var converter = new IncludeChainConverter();

--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -39,6 +39,9 @@ options.MaximumPageNumber = new PageNumber(50);
 options.IncludeTotalResourceCount = true;
 ```
 
+To retrieve the total number of resources on secondary and relationship endpoints, the reverse of the relationship must to be available. For example, in `GET /customers/1/orders`, both the relationships `[HasMany] Customer.Orders` and `[HasOne] Order.Customer` must be defined.
+If `IncludeTotalResourceCount` is set to `false` (or the inverse relationship is unavailable on a non-primary endpoint), best-effort paging links are returned instead. This means no `last` link and the `next` link only occurs when the current page is full.
+
 ## Relative Links
 
 All links are absolute by default. However, you can configure relative links.

--- a/docs/usage/resources/nullability.md
+++ b/docs/usage/resources/nullability.md
@@ -2,7 +2,7 @@
 
 Properties on a resource class can be declared as nullable or non-nullable. This affects both ASP.NET ModelState validation and the way Entity Framework Core generates database columns.
 
-ModelState validation is enabled by default since v5.0. In earlier versions, it can be enabled in [options](~/usage/options.md#enable-modelstate-validation).
+ModelState validation is enabled by default since v5.0. In earlier versions, it can be enabled in [options](~/usage/options.md#modelstate-validation).
 
 # Value types
 

--- a/src/JsonApiDotNetCore/CollectionExtensions.cs
+++ b/src/JsonApiDotNetCore/CollectionExtensions.cs
@@ -76,6 +76,13 @@ namespace JsonApiDotNetCore
             return source ?? Enumerable.Empty<T>();
         }
 
+        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source)
+        {
+#pragma warning disable AV1250 // Evaluate LINQ query before returning it
+            return source.Where(element => element is not null)!;
+#pragma warning restore AV1250 // Evaluate LINQ query before returning it
+        }
+
         public static void AddRange<T>(this ICollection<T> source, IEnumerable<T> itemsToAdd)
         {
             ArgumentGuard.NotNull(source, nameof(source));

--- a/src/JsonApiDotNetCore/Queries/Expressions/LogicalExpression.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/LogicalExpression.cs
@@ -34,6 +34,15 @@ namespace JsonApiDotNetCore.Queries.Expressions
             Terms = terms;
         }
 
+        public static FilterExpression? Compose(LogicalOperator @operator, params FilterExpression?[] filters)
+        {
+            ArgumentGuard.NotNull(filters, nameof(filters));
+
+            ImmutableArray<FilterExpression> terms = filters.WhereNotNull().ToImmutableArray();
+
+            return terms.Length > 1 ? new LogicalExpression(@operator, terms) : terms.FirstOrDefault();
+        }
+
         public override TResult Accept<TArgument, TResult>(QueryExpressionVisitor<TArgument, TResult> visitor, TArgument argument)
         {
             return visitor.VisitLogical(this, argument);

--- a/src/JsonApiDotNetCore/Queries/IQueryLayerComposer.cs
+++ b/src/JsonApiDotNetCore/Queries/IQueryLayerComposer.cs
@@ -12,9 +12,14 @@ namespace JsonApiDotNetCore.Queries
     public interface IQueryLayerComposer
     {
         /// <summary>
-        /// Builds a top-level filter from constraints, used to determine total resource count.
+        /// Builds a filter from constraints, used to determine total resource count on a primary collection endpoint.
         /// </summary>
-        FilterExpression? GetTopFilterFromConstraints(ResourceType primaryResourceType);
+        FilterExpression? GetPrimaryFilterFromConstraints(ResourceType primaryResourceType);
+
+        /// <summary>
+        /// Builds a filter from constraints, used to determine total resource count on a secondary collection endpoint.
+        /// </summary>
+        FilterExpression? GetSecondaryFilterFromConstraints<TId>(TId primaryId, HasManyAttribute hasManyRelationship);
 
         /// <summary>
         /// Collects constraints and builds a <see cref="QueryLayer" /> out of them, used to retrieve the actual resources.

--- a/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
+++ b/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
@@ -85,11 +85,11 @@ namespace JsonApiDotNetCore.Repositories
         }
 
         /// <inheritdoc />
-        public virtual async Task<int> CountAsync(FilterExpression? topFilter, CancellationToken cancellationToken)
+        public virtual async Task<int> CountAsync(FilterExpression? filter, CancellationToken cancellationToken)
         {
             _traceWriter.LogMethodStart(new
             {
-                topFilter
+                filter
             });
 
             using (CodeTimingSessionManager.Current.Measure("Repository - Count resources"))
@@ -98,7 +98,7 @@ namespace JsonApiDotNetCore.Repositories
 
                 var layer = new QueryLayer(resourceType)
                 {
-                    Filter = topFilter
+                    Filter = filter
                 };
 
                 IQueryable<TResource> query = ApplyQueryLayer(layer);

--- a/src/JsonApiDotNetCore/Repositories/IResourceReadRepository.cs
+++ b/src/JsonApiDotNetCore/Repositories/IResourceReadRepository.cs
@@ -27,8 +27,8 @@ namespace JsonApiDotNetCore.Repositories
         Task<IReadOnlyCollection<TResource>> GetAsync(QueryLayer queryLayer, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Executes a read query using the specified top-level filter and returns the top-level count of matching resources.
+        /// Executes a read query using the specified filter and returns the count of matching resources.
         /// </summary>
-        Task<int> CountAsync(FilterExpression? topFilter, CancellationToken cancellationToken);
+        Task<int> CountAsync(FilterExpression? filter, CancellationToken cancellationToken);
     }
 }

--- a/src/JsonApiDotNetCore/Repositories/IResourceRepositoryAccessor.cs
+++ b/src/JsonApiDotNetCore/Repositories/IResourceRepositoryAccessor.cs
@@ -27,8 +27,7 @@ namespace JsonApiDotNetCore.Repositories
         /// <summary>
         /// Invokes <see cref="IResourceReadRepository{TResource,TId}.CountAsync" /> for the specified resource type.
         /// </summary>
-        Task<int> CountAsync<TResource>(FilterExpression? topFilter, CancellationToken cancellationToken)
-            where TResource : class, IIdentifiable;
+        Task<int> CountAsync(ResourceType resourceType, FilterExpression? filter, CancellationToken cancellationToken);
 
         /// <summary>
         /// Invokes <see cref="IResourceWriteRepository{TResource,TId}.GetForCreateAsync" />.

--- a/src/JsonApiDotNetCore/Repositories/ResourceRepositoryAccessor.cs
+++ b/src/JsonApiDotNetCore/Repositories/ResourceRepositoryAccessor.cs
@@ -50,11 +50,10 @@ namespace JsonApiDotNetCore.Repositories
         }
 
         /// <inheritdoc />
-        public async Task<int> CountAsync<TResource>(FilterExpression? topFilter, CancellationToken cancellationToken)
-            where TResource : class, IIdentifiable
+        public async Task<int> CountAsync(ResourceType resourceType, FilterExpression? filter, CancellationToken cancellationToken)
         {
-            dynamic repository = ResolveReadRepository(typeof(TResource));
-            return (int)await repository.CountAsync(topFilter, cancellationToken);
+            dynamic repository = ResolveReadRepository(resourceType);
+            return (int)await repository.CountAsync(filter, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/JsonApiDotNetCore/Serialization/Response/LinkBuilder.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/LinkBuilder.cs
@@ -114,6 +114,7 @@ namespace JsonApiDotNetCore.Serialization.Response
 
         private string GetLinkForTopLevelSelf()
         {
+            // Note: in tests, this does not properly escape special characters due to WebApplicationFactory short-circuiting.
             return _options.UseRelativeLinks ? HttpContext.Request.GetEncodedPathAndQuery() : HttpContext.Request.GetEncodedUrl();
         }
 
@@ -223,13 +224,7 @@ namespace JsonApiDotNetCore.Serialization.Response
                 parameters[PageNumberParameterName] = pageOffset.ToString();
             }
 
-            string queryStringValue = QueryString.Create(parameters).Value ?? string.Empty;
-            return DecodeSpecialCharacters(queryStringValue);
-        }
-
-        private static string DecodeSpecialCharacters(string uri)
-        {
-            return uri.Replace("%5B", "[").Replace("%5D", "]").Replace("%27", "'").Replace("%3A", ":");
+            return QueryString.Create(parameters).Value ?? string.Empty;
         }
 
         /// <inheritdoc />

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Archiving/TelevisionBroadcastDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Archiving/TelevisionBroadcastDefinition.cs
@@ -48,7 +48,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Archiving
 
                     FilterExpression isUnarchived = new ComparisonExpression(ComparisonOperator.Equals, archivedAtChain, NullConstantExpression.Instance);
 
-                    return existingFilter == null ? isUnarchived : new LogicalExpression(LogicalOperator.And, existingFilter, isUnarchived);
+                    return LogicalExpression.Compose(LogicalOperator.And, existingFilter, isUnarchived);
                 }
             }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Archiving/TelevisionBroadcastDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Archiving/TelevisionBroadcastDefinition.cs
@@ -52,7 +52,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Archiving
                 }
             }
 
-            return base.OnApplyFilter(existingFilter);
+            return existingFilter;
         }
 
         private bool IsReturningCollectionOfTelevisionBroadcasts()
@@ -119,7 +119,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Archiving
                 _storedArchivedAt = broadcast.ArchivedAt;
             }
 
-            return base.OnPrepareWriteAsync(broadcast, writeOperation, cancellationToken);
+            return Task.CompletedTask;
         }
 
         public override async Task OnWritingAsync(TelevisionBroadcast broadcast, WriteOperationKind writeOperation, CancellationToken cancellationToken)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithClientGeneratedIdTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithClientGeneratedIdTests.cs
@@ -29,6 +29,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Creating
             testContext.ConfigureServicesAfterStartup(services =>
             {
                 services.AddResourceDefinition<ImplicitlyChangingTextLanguageDefinition>();
+
+                services.AddSingleton<ResourceDefinitionHitCounter>();
             });
 
             var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ImplicitlyChangingTextLanguageDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ImplicitlyChangingTextLanguageDefinition.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Middleware;
-using JsonApiDotNetCore.Resources;
 using Microsoft.EntityFrameworkCore;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations
@@ -13,20 +12,22 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations
     /// Used to simulate side effects that occur in the database while saving, typically caused by database triggers.
     /// </summary>
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-    public class ImplicitlyChangingTextLanguageDefinition : JsonApiResourceDefinition<TextLanguage, Guid>
+    public class ImplicitlyChangingTextLanguageDefinition : HitCountingResourceDefinition<TextLanguage, Guid>
     {
         internal const string Suffix = " (changed)";
 
         private readonly OperationsDbContext _dbContext;
 
-        public ImplicitlyChangingTextLanguageDefinition(IResourceGraph resourceGraph, OperationsDbContext dbContext)
-            : base(resourceGraph)
+        public ImplicitlyChangingTextLanguageDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter, OperationsDbContext dbContext)
+            : base(resourceGraph, hitCounter)
         {
             _dbContext = dbContext;
         }
 
         public override async Task OnWriteSucceededAsync(TextLanguage resource, WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
+            await base.OnWriteSucceededAsync(resource, writeOperation, cancellationToken);
+
             if (writeOperation is not WriteOperationKind.DeleteResource)
             {
                 string statement = $"Update \"TextLanguages\" SET \"IsoCode\" = '{resource.IsoCode}{Suffix}' WHERE \"Id\" = '{resource.StringId}'";

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/AtomicResourceMetaTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/AtomicResourceMetaTests.cs
@@ -111,8 +111,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Meta
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(MusicTrack), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(MusicTrack), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(MusicTrack), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(MusicTrack), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -172,7 +172,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Meta
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(TextLanguage), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(TextLanguage), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/AtomicResourceMetaTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/AtomicResourceMetaTests.cs
@@ -111,8 +111,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Meta
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(MusicTrack), ResourceDefinitionHitCounter.ExtensibilityPoint.GetMeta),
-                (typeof(MusicTrack), ResourceDefinitionHitCounter.ExtensibilityPoint.GetMeta)
+                (typeof(MusicTrack), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(MusicTrack), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -172,7 +172,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Meta
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(TextLanguage), ResourceDefinitionHitCounter.ExtensibilityPoint.GetMeta)
+                (typeof(TextLanguage), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/AtomicResponseMetaTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/AtomicResponseMetaTests.cs
@@ -28,6 +28,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Meta
             {
                 services.AddResourceDefinition<ImplicitlyChangingTextLanguageDefinition>();
 
+                services.AddSingleton<ResourceDefinitionHitCounter>();
                 services.AddSingleton<IResponseMeta, AtomicResponseMeta>();
             });
         }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/MusicTrackMetaDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/MusicTrackMetaDefinition.cs
@@ -8,7 +8,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Meta
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
     public sealed class MusicTrackMetaDefinition : HitCountingResourceDefinition<MusicTrack, Guid>
     {
-        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.GetMeta;
+        protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.GetMeta;
 
         public MusicTrackMetaDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter)
             : base(resourceGraph, hitCounter)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/MusicTrackMetaDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/MusicTrackMetaDefinition.cs
@@ -2,24 +2,22 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
-using JsonApiDotNetCore.Resources;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Meta
 {
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-    public sealed class MusicTrackMetaDefinition : JsonApiResourceDefinition<MusicTrack, Guid>
+    public sealed class MusicTrackMetaDefinition : HitCountingResourceDefinition<MusicTrack, Guid>
     {
-        private readonly ResourceDefinitionHitCounter _hitCounter;
+        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.GetMeta;
 
         public MusicTrackMetaDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter)
-            : base(resourceGraph)
+            : base(resourceGraph, hitCounter)
         {
-            _hitCounter = hitCounter;
         }
 
         public override IDictionary<string, object?> GetMeta(MusicTrack resource)
         {
-            _hitCounter.TrackInvocation<MusicTrack>(ResourceDefinitionHitCounter.ExtensibilityPoint.GetMeta);
+            base.GetMeta(resource);
 
             return new Dictionary<string, object?>
             {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/TextLanguageMetaDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/TextLanguageMetaDefinition.cs
@@ -9,17 +9,16 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Meta
     {
         internal const string NoticeText = "See https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes for ISO 639-1 language codes.";
 
-        private readonly ResourceDefinitionHitCounter _hitCounter;
+        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.GetMeta;
 
-        public TextLanguageMetaDefinition(IResourceGraph resourceGraph, OperationsDbContext dbContext, ResourceDefinitionHitCounter hitCounter)
-            : base(resourceGraph, dbContext)
+        public TextLanguageMetaDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter, OperationsDbContext dbContext)
+            : base(resourceGraph, hitCounter, dbContext)
         {
-            _hitCounter = hitCounter;
         }
 
         public override IDictionary<string, object?> GetMeta(TextLanguage resource)
         {
-            _hitCounter.TrackInvocation<TextLanguage>(ResourceDefinitionHitCounter.ExtensibilityPoint.GetMeta);
+            base.GetMeta(resource);
 
             return new Dictionary<string, object?>
             {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/TextLanguageMetaDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/TextLanguageMetaDefinition.cs
@@ -9,7 +9,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Meta
     {
         internal const string NoticeText = "See https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes for ISO 639-1 language codes.";
 
-        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.GetMeta;
+        protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.GetMeta;
 
         public TextLanguageMetaDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter, OperationsDbContext dbContext)
             : base(resourceGraph, hitCounter, dbContext)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicSerializationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicSerializationTests.cs
@@ -27,6 +27,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Mixed
             testContext.ConfigureServicesAfterStartup(services =>
             {
                 services.AddResourceDefinition<ImplicitlyChangingTextLanguageDefinition>();
+
+                services.AddSingleton<ResourceDefinitionHitCounter>();
             });
 
             var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/Serialization/AtomicSerializationResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/Serialization/AtomicSerializationResourceDefinitionTests.cs
@@ -123,10 +123,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefin
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(RecordCompany), ResourceDefinitionHitCounter.ExtensibilityPoint.OnDeserialize),
-                (typeof(RecordCompany), ResourceDefinitionHitCounter.ExtensibilityPoint.OnDeserialize),
-                (typeof(RecordCompany), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize),
-                (typeof(RecordCompany), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize)
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnDeserialize),
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnDeserialize),
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnSerialize),
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -275,10 +275,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefin
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(RecordCompany), ResourceDefinitionHitCounter.ExtensibilityPoint.OnDeserialize),
-                (typeof(RecordCompany), ResourceDefinitionHitCounter.ExtensibilityPoint.OnDeserialize),
-                (typeof(RecordCompany), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize),
-                (typeof(RecordCompany), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize)
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnDeserialize),
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnDeserialize),
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnSerialize),
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/Serialization/AtomicSerializationResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/Serialization/AtomicSerializationResourceDefinitionTests.cs
@@ -123,10 +123,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefin
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnDeserialize),
-                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnDeserialize),
-                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnSerialize),
-                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnSerialize)
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoints.OnDeserialize),
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoints.OnDeserialize),
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoints.OnSerialize),
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoints.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -275,10 +275,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefin
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnDeserialize),
-                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnDeserialize),
-                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnSerialize),
-                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoint.OnSerialize)
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoints.OnDeserialize),
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoints.OnDeserialize),
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoints.OnSerialize),
+                (typeof(RecordCompany), ResourceDefinitionExtensibilityPoints.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/Serialization/RecordCompanyDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/Serialization/RecordCompanyDefinition.cs
@@ -6,7 +6,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefin
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
     public sealed class RecordCompanyDefinition : HitCountingResourceDefinition<RecordCompany, short>
     {
-        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Serialization;
+        protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.Serialization;
 
         public RecordCompanyDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter)
             : base(resourceGraph, hitCounter)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/Serialization/RecordCompanyDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/Serialization/RecordCompanyDefinition.cs
@@ -1,23 +1,21 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
-using JsonApiDotNetCore.Resources;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefinitions.Serialization
 {
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-    public sealed class RecordCompanyDefinition : JsonApiResourceDefinition<RecordCompany, short>
+    public sealed class RecordCompanyDefinition : HitCountingResourceDefinition<RecordCompany, short>
     {
-        private readonly ResourceDefinitionHitCounter _hitCounter;
+        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Serialization;
 
         public RecordCompanyDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter)
-            : base(resourceGraph)
+            : base(resourceGraph, hitCounter)
         {
-            _hitCounter = hitCounter;
         }
 
         public override void OnDeserialize(RecordCompany resource)
         {
-            _hitCounter.TrackInvocation<RecordCompany>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnDeserialize);
+            base.OnDeserialize(resource);
 
             if (!string.IsNullOrEmpty(resource.Name))
             {
@@ -27,7 +25,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefin
 
         public override void OnSerialize(RecordCompany resource)
         {
-            _hitCounter.TrackInvocation<RecordCompany>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize);
+            base.OnSerialize(resource);
 
             if (!string.IsNullOrEmpty(resource.CountryOfResidence))
             {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/SparseFieldSets/AtomicSparseFieldSetResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/SparseFieldSets/AtomicSparseFieldSetResourceDefinitionTests.cs
@@ -105,10 +105,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefin
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet)
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet)
             }, options => options.WithStrictOrdering());
         }
 
@@ -184,10 +184,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefin
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet)
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet)
             }, options => options.WithStrictOrdering());
         }
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/SparseFieldSets/AtomicSparseFieldSetResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/SparseFieldSets/AtomicSparseFieldSetResourceDefinitionTests.cs
@@ -105,10 +105,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefin
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Lyric), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Lyric), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Lyric), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Lyric), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet)
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet)
             }, options => options.WithStrictOrdering());
         }
 
@@ -184,10 +184,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefin
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Lyric), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Lyric), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Lyric), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Lyric), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet)
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Lyric), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet)
             }, options => options.WithStrictOrdering());
         }
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/SparseFieldSets/LyricTextDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/SparseFieldSets/LyricTextDefinition.cs
@@ -9,7 +9,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefin
     {
         private readonly LyricPermissionProvider _lyricPermissionProvider;
 
-        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet;
+        protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet;
 
         public LyricTextDefinition(IResourceGraph resourceGraph, LyricPermissionProvider lyricPermissionProvider, ResourceDefinitionHitCounter hitCounter)
             : base(resourceGraph, hitCounter)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/SparseFieldSets/LyricTextDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/SparseFieldSets/LyricTextDefinition.cs
@@ -1,30 +1,27 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Queries.Expressions;
-using JsonApiDotNetCore.Resources;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.ResourceDefinitions.SparseFieldSets
 {
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-    public sealed class LyricTextDefinition : JsonApiResourceDefinition<Lyric, long>
+    public sealed class LyricTextDefinition : HitCountingResourceDefinition<Lyric, long>
     {
         private readonly LyricPermissionProvider _lyricPermissionProvider;
-        private readonly ResourceDefinitionHitCounter _hitCounter;
+
+        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet;
 
         public LyricTextDefinition(IResourceGraph resourceGraph, LyricPermissionProvider lyricPermissionProvider, ResourceDefinitionHitCounter hitCounter)
-            : base(resourceGraph)
+            : base(resourceGraph, hitCounter)
         {
             _lyricPermissionProvider = lyricPermissionProvider;
-            _hitCounter = hitCounter;
         }
 
         public override SparseFieldSetExpression? OnApplySparseFieldSet(SparseFieldSetExpression? existingSparseFieldSet)
         {
-            _hitCounter.TrackInvocation<Lyric>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet);
+            base.OnApplySparseFieldSet(existingSparseFieldSet);
 
-            return _lyricPermissionProvider.CanViewText
-                ? base.OnApplySparseFieldSet(existingSparseFieldSet)
-                : existingSparseFieldSet.Excluding<Lyric>(lyric => lyric.Text, ResourceGraph);
+            return _lyricPermissionProvider.CanViewText ? existingSparseFieldSet : existingSparseFieldSet.Excluding<Lyric>(lyric => lyric.Text, ResourceGraph);
         }
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Transactions/PerformerRepository.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Transactions/PerformerRepository.cs
@@ -18,7 +18,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Transactions
             throw new NotImplementedException();
         }
 
-        public Task<int> CountAsync(FilterExpression? topFilter, CancellationToken cancellationToken)
+        public Task<int> CountAsync(FilterExpression? filter, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Updating/Resources/AtomicUpdateResourceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Updating/Resources/AtomicUpdateResourceTests.cs
@@ -32,6 +32,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Updating.Reso
             testContext.ConfigureServicesAfterStartup(services =>
             {
                 services.AddResourceDefinition<ImplicitlyChangingTextLanguageDefinition>();
+
+                services.AddSingleton<ResourceDefinitionHitCounter>();
             });
 
             var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/HitCountingResourceDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/HitCountingResourceDefinition.cs
@@ -20,7 +20,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
     {
         private readonly ResourceDefinitionHitCounter _hitCounter;
 
-        protected virtual ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.All;
+        protected virtual ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.All;
 
         protected HitCountingResourceDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter)
             : base(resourceGraph)
@@ -32,9 +32,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
 
         public override IImmutableSet<IncludeElementExpression> OnApplyIncludes(IImmutableSet<IncludeElementExpression> existingIncludes)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnApplyIncludes))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnApplyIncludes))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnApplyIncludes);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnApplyIncludes);
             }
 
             return base.OnApplyIncludes(existingIncludes);
@@ -42,9 +42,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
 
         public override FilterExpression? OnApplyFilter(FilterExpression? existingFilter)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnApplyFilter))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnApplyFilter))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnApplyFilter);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnApplyFilter);
             }
 
             return base.OnApplyFilter(existingFilter);
@@ -52,9 +52,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
 
         public override SortExpression? OnApplySort(SortExpression? existingSort)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnApplySort))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnApplySort))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnApplySort);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnApplySort);
             }
 
             return base.OnApplySort(existingSort);
@@ -62,9 +62,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
 
         public override PaginationExpression? OnApplyPagination(PaginationExpression? existingPagination)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnApplyPagination))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnApplyPagination))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnApplyPagination);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnApplyPagination);
             }
 
             return base.OnApplyPagination(existingPagination);
@@ -72,9 +72,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
 
         public override SparseFieldSetExpression? OnApplySparseFieldSet(SparseFieldSetExpression? existingSparseFieldSet)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet);
             }
 
             return base.OnApplySparseFieldSet(existingSparseFieldSet);
@@ -82,9 +82,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
 
         public override QueryStringParameterHandlers<TResource>? OnRegisterQueryableHandlersForQueryStringParameters()
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnRegisterQueryableHandlersForQueryStringParameters))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnRegisterQueryableHandlersForQueryStringParameters);
             }
 
             return base.OnRegisterQueryableHandlersForQueryStringParameters();
@@ -92,9 +92,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
 
         public override IDictionary<string, object?>? GetMeta(TResource resource)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.GetMeta))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.GetMeta))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.GetMeta);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.GetMeta);
             }
 
             return base.GetMeta(resource);
@@ -102,9 +102,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
 
         public override Task OnPrepareWriteAsync(TResource resource, WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync);
             }
 
             return base.OnPrepareWriteAsync(resource, writeOperation, cancellationToken);
@@ -113,9 +113,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
         public override Task<IIdentifiable?> OnSetToOneRelationshipAsync(TResource leftResource, HasOneAttribute hasOneRelationship,
             IIdentifiable? rightResourceId, WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync);
             }
 
             return base.OnSetToOneRelationshipAsync(leftResource, hasOneRelationship, rightResourceId, writeOperation, cancellationToken);
@@ -124,9 +124,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
         public override Task OnSetToManyRelationshipAsync(TResource leftResource, HasManyAttribute hasManyRelationship, ISet<IIdentifiable> rightResourceIds,
             WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnSetToManyRelationshipAsync))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnSetToManyRelationshipAsync);
             }
 
             return base.OnSetToManyRelationshipAsync(leftResource, hasManyRelationship, rightResourceIds, writeOperation, cancellationToken);
@@ -135,9 +135,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
         public override Task OnAddToRelationshipAsync(TId leftResourceId, HasManyAttribute hasManyRelationship, ISet<IIdentifiable> rightResourceIds,
             CancellationToken cancellationToken)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnAddToRelationshipAsync))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnAddToRelationshipAsync))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnAddToRelationshipAsync);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnAddToRelationshipAsync);
             }
 
             return base.OnAddToRelationshipAsync(leftResourceId, hasManyRelationship, rightResourceIds, cancellationToken);
@@ -146,9 +146,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
         public override Task OnRemoveFromRelationshipAsync(TResource leftResource, HasManyAttribute hasManyRelationship, ISet<IIdentifiable> rightResourceIds,
             CancellationToken cancellationToken)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnRemoveFromRelationshipAsync))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnRemoveFromRelationshipAsync))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnRemoveFromRelationshipAsync);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnRemoveFromRelationshipAsync);
             }
 
             return base.OnRemoveFromRelationshipAsync(leftResource, hasManyRelationship, rightResourceIds, cancellationToken);
@@ -156,9 +156,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
 
         public override Task OnWritingAsync(TResource resource, WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnWritingAsync))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnWritingAsync))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnWritingAsync);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnWritingAsync);
             }
 
             return base.OnWritingAsync(resource, writeOperation, cancellationToken);
@@ -166,9 +166,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
 
         public override Task OnWriteSucceededAsync(TResource resource, WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync);
             }
 
             return base.OnWriteSucceededAsync(resource, writeOperation, cancellationToken);
@@ -176,9 +176,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
 
         public override void OnDeserialize(TResource resource)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnDeserialize))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnDeserialize))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnDeserialize);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnDeserialize);
             }
 
             base.OnDeserialize(resource);
@@ -186,9 +186,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
 
         public override void OnSerialize(TResource resource)
         {
-            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnSerialize))
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoints.OnSerialize))
             {
-                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnSerialize);
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints.OnSerialize);
             }
 
             base.OnSerialize(resource);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/HitCountingResourceDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/HitCountingResourceDefinition.cs
@@ -1,0 +1,197 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using JsonApiDotNetCore;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Middleware;
+using JsonApiDotNetCore.Queries.Expressions;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests
+{
+    /// <summary>
+    /// Tracks invocations on <see cref="IResourceDefinition{TResource,TId}" /> callback methods. This is used solely in our tests, so we can assert which
+    /// calls were made, and in which order.
+    /// </summary>
+    public abstract class HitCountingResourceDefinition<TResource, TId> : JsonApiResourceDefinition<TResource, TId>
+        where TResource : class, IIdentifiable<TId>
+    {
+        private readonly ResourceDefinitionHitCounter _hitCounter;
+
+        protected virtual ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.All;
+
+        protected HitCountingResourceDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter)
+            : base(resourceGraph)
+        {
+            ArgumentGuard.NotNull(hitCounter, nameof(hitCounter));
+
+            _hitCounter = hitCounter;
+        }
+
+        public override IImmutableSet<IncludeElementExpression> OnApplyIncludes(IImmutableSet<IncludeElementExpression> existingIncludes)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnApplyIncludes))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnApplyIncludes);
+            }
+
+            return base.OnApplyIncludes(existingIncludes);
+        }
+
+        public override FilterExpression? OnApplyFilter(FilterExpression? existingFilter)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnApplyFilter))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnApplyFilter);
+            }
+
+            return base.OnApplyFilter(existingFilter);
+        }
+
+        public override SortExpression? OnApplySort(SortExpression? existingSort)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnApplySort))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnApplySort);
+            }
+
+            return base.OnApplySort(existingSort);
+        }
+
+        public override PaginationExpression? OnApplyPagination(PaginationExpression? existingPagination)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnApplyPagination))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnApplyPagination);
+            }
+
+            return base.OnApplyPagination(existingPagination);
+        }
+
+        public override SparseFieldSetExpression? OnApplySparseFieldSet(SparseFieldSetExpression? existingSparseFieldSet)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet);
+            }
+
+            return base.OnApplySparseFieldSet(existingSparseFieldSet);
+        }
+
+        public override QueryStringParameterHandlers<TResource>? OnRegisterQueryableHandlersForQueryStringParameters()
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters);
+            }
+
+            return base.OnRegisterQueryableHandlersForQueryStringParameters();
+        }
+
+        public override IDictionary<string, object?>? GetMeta(TResource resource)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.GetMeta))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.GetMeta);
+            }
+
+            return base.GetMeta(resource);
+        }
+
+        public override Task OnPrepareWriteAsync(TResource resource, WriteOperationKind writeOperation, CancellationToken cancellationToken)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync);
+            }
+
+            return base.OnPrepareWriteAsync(resource, writeOperation, cancellationToken);
+        }
+
+        public override Task<IIdentifiable?> OnSetToOneRelationshipAsync(TResource leftResource, HasOneAttribute hasOneRelationship,
+            IIdentifiable? rightResourceId, WriteOperationKind writeOperation, CancellationToken cancellationToken)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync);
+            }
+
+            return base.OnSetToOneRelationshipAsync(leftResource, hasOneRelationship, rightResourceId, writeOperation, cancellationToken);
+        }
+
+        public override Task OnSetToManyRelationshipAsync(TResource leftResource, HasManyAttribute hasManyRelationship, ISet<IIdentifiable> rightResourceIds,
+            WriteOperationKind writeOperation, CancellationToken cancellationToken)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync);
+            }
+
+            return base.OnSetToManyRelationshipAsync(leftResource, hasManyRelationship, rightResourceIds, writeOperation, cancellationToken);
+        }
+
+        public override Task OnAddToRelationshipAsync(TId leftResourceId, HasManyAttribute hasManyRelationship, ISet<IIdentifiable> rightResourceIds,
+            CancellationToken cancellationToken)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnAddToRelationshipAsync))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnAddToRelationshipAsync);
+            }
+
+            return base.OnAddToRelationshipAsync(leftResourceId, hasManyRelationship, rightResourceIds, cancellationToken);
+        }
+
+        public override Task OnRemoveFromRelationshipAsync(TResource leftResource, HasManyAttribute hasManyRelationship, ISet<IIdentifiable> rightResourceIds,
+            CancellationToken cancellationToken)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnRemoveFromRelationshipAsync))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnRemoveFromRelationshipAsync);
+            }
+
+            return base.OnRemoveFromRelationshipAsync(leftResource, hasManyRelationship, rightResourceIds, cancellationToken);
+        }
+
+        public override Task OnWritingAsync(TResource resource, WriteOperationKind writeOperation, CancellationToken cancellationToken)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnWritingAsync))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnWritingAsync);
+            }
+
+            return base.OnWritingAsync(resource, writeOperation, cancellationToken);
+        }
+
+        public override Task OnWriteSucceededAsync(TResource resource, WriteOperationKind writeOperation, CancellationToken cancellationToken)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync);
+            }
+
+            return base.OnWriteSucceededAsync(resource, writeOperation, cancellationToken);
+        }
+
+        public override void OnDeserialize(TResource resource)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnDeserialize))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnDeserialize);
+            }
+
+            base.OnDeserialize(resource);
+        }
+
+        public override void OnSerialize(TResource resource)
+        {
+            if (ExtensibilityPointsToTrack.HasFlag(ResourceDefinitionExtensibilityPoint.OnSerialize))
+            {
+                _hitCounter.TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint.OnSerialize);
+            }
+
+            base.OnSerialize(resource);
+        }
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/HostingInIIS/HostingTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/HostingInIIS/HostingTests.cs
@@ -49,8 +49,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.HostingInIIS
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().BeNull();
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().Be($"{HostPrefix}{route}");
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 
@@ -117,8 +117,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.HostingInIIS
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().BeNull();
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().Be($"{HostPrefix}{route}");
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/AbsoluteLinksWithNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/AbsoluteLinksWithNamespaceTests.cs
@@ -104,8 +104,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Links
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().BeNull();
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().Be($"{HostPrefix}{route}");
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 
@@ -214,8 +214,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Links
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().BeNull();
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().BeNull();
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 
@@ -296,8 +296,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Links
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().Be($"{HostPrefix}{PathPrefix}/photoAlbums/{album.StringId}/photos");
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().BeNull();
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/AbsoluteLinksWithoutNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/AbsoluteLinksWithoutNamespaceTests.cs
@@ -104,8 +104,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Links
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().BeNull();
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().Be($"{HostPrefix}{route}");
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 
@@ -214,8 +214,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Links
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().BeNull();
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().BeNull();
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 
@@ -296,8 +296,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Links
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().Be($"{HostPrefix}{PathPrefix}/photoAlbums/{album.StringId}/photos");
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().BeNull();
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/RelativeLinksWithNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/RelativeLinksWithNamespaceTests.cs
@@ -104,8 +104,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Links
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().BeNull();
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().Be($"{HostPrefix}{route}");
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 
@@ -214,8 +214,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Links
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().BeNull();
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().BeNull();
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 
@@ -296,8 +296,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Links
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().Be($"{HostPrefix}{PathPrefix}/photoAlbums/{album.StringId}/photos");
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().BeNull();
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/RelativeLinksWithoutNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/RelativeLinksWithoutNamespaceTests.cs
@@ -104,8 +104,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Links
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().BeNull();
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().Be($"{HostPrefix}{route}");
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 
@@ -214,8 +214,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Links
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().BeNull();
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().BeNull();
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 
@@ -296,8 +296,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Links
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.Related.Should().Be($"{HostPrefix}{PathPrefix}/photoAlbums/{album.StringId}/photos");
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.Last.Should().BeNull();
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/ResourceMetaTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/ResourceMetaTests.cs
@@ -65,9 +65,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Meta
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(SupportTicket), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(SupportTicket), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(SupportTicket), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(SupportTicket), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(SupportTicket), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(SupportTicket), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -102,7 +102,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Meta
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(SupportTicket), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(SupportTicket), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/ResourceMetaTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/ResourceMetaTests.cs
@@ -65,9 +65,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Meta
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(SupportTicket), ResourceDefinitionHitCounter.ExtensibilityPoint.GetMeta),
-                (typeof(SupportTicket), ResourceDefinitionHitCounter.ExtensibilityPoint.GetMeta),
-                (typeof(SupportTicket), ResourceDefinitionHitCounter.ExtensibilityPoint.GetMeta)
+                (typeof(SupportTicket), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(SupportTicket), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(SupportTicket), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -102,7 +102,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Meta
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(SupportTicket), ResourceDefinitionHitCounter.ExtensibilityPoint.GetMeta)
+                (typeof(SupportTicket), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/SupportTicketDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/SupportTicketDefinition.cs
@@ -8,7 +8,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Meta
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
     public sealed class SupportTicketDefinition : HitCountingResourceDefinition<SupportTicket, int>
     {
-        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.GetMeta;
+        protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.GetMeta;
 
         public SupportTicketDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter)
             : base(resourceGraph, hitCounter)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/SupportTicketDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/SupportTicketDefinition.cs
@@ -2,24 +2,22 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
-using JsonApiDotNetCore.Resources;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.Meta
 {
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-    public sealed class SupportTicketDefinition : JsonApiResourceDefinition<SupportTicket, int>
+    public sealed class SupportTicketDefinition : HitCountingResourceDefinition<SupportTicket, int>
     {
-        private readonly ResourceDefinitionHitCounter _hitCounter;
+        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.GetMeta;
 
         public SupportTicketDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter)
-            : base(resourceGraph)
+            : base(resourceGraph, hitCounter)
         {
-            _hitCounter = hitCounter;
         }
 
         public override IDictionary<string, object?>? GetMeta(SupportTicket resource)
         {
-            _hitCounter.TrackInvocation<SupportTicket>(ResourceDefinitionHitCounter.ExtensibilityPoint.GetMeta);
+            base.GetMeta(resource);
 
             if (!string.IsNullOrEmpty(resource.Description) && resource.Description.StartsWith("Critical:", StringComparison.Ordinal))
             {
@@ -29,7 +27,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Meta
                 };
             }
 
-            return base.GetMeta(resource);
+            return null;
         }
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetGroupDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetGroupDefinition.cs
@@ -12,7 +12,6 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
     public sealed class FireForgetGroupDefinition : MessagingGroupDefinition
     {
         private readonly MessageBroker _messageBroker;
-        private readonly ResourceDefinitionHitCounter _hitCounter;
         private DomainGroup? _groupToDelete;
 
         public FireForgetGroupDefinition(IResourceGraph resourceGraph, FireForgetDbContext dbContext, MessageBroker messageBroker,
@@ -20,12 +19,11 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
             : base(resourceGraph, dbContext.Users, dbContext.Groups, hitCounter)
         {
             _messageBroker = messageBroker;
-            _hitCounter = hitCounter;
         }
 
         public override async Task OnWritingAsync(DomainGroup group, WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            _hitCounter.TrackInvocation<DomainGroup>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync);
+            await base.OnWritingAsync(group, writeOperation, cancellationToken);
 
             if (writeOperation == WriteOperationKind.DeleteResource)
             {
@@ -33,11 +31,11 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
             }
         }
 
-        public override Task OnWriteSucceededAsync(DomainGroup group, WriteOperationKind writeOperation, CancellationToken cancellationToken)
+        public override async Task OnWriteSucceededAsync(DomainGroup group, WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            _hitCounter.TrackInvocation<DomainGroup>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync);
+            await base.OnWriteSucceededAsync(group, writeOperation, cancellationToken);
 
-            return FinishWriteAsync(group, writeOperation, cancellationToken);
+            await FinishWriteAsync(group, writeOperation, cancellationToken);
         }
 
         protected override Task FlushMessageAsync(OutgoingMessage message, CancellationToken cancellationToken)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.Group.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.Group.cs
@@ -48,9 +48,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -126,10 +126,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToManyRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(3);
@@ -192,9 +192,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -276,10 +276,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToManyRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(3);
@@ -325,8 +325,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -363,8 +363,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -437,10 +437,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToManyRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(3);
@@ -511,9 +511,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnAddToRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnAddToRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -573,9 +573,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnRemoveFromRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnRemoveFromRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.Group.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.Group.cs
@@ -48,9 +48,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -126,10 +126,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnSetToManyRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(3);
@@ -192,9 +192,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -276,10 +276,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnSetToManyRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(3);
@@ -325,8 +325,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -363,8 +363,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -437,10 +437,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnSetToManyRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(3);
@@ -511,9 +511,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnAddToRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnAddToRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -573,9 +573,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnRemoveFromRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnRemoveFromRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.User.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.User.cs
@@ -50,9 +50,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -119,10 +119,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -183,9 +183,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -251,10 +251,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -323,10 +323,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -397,10 +397,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -443,8 +443,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -481,8 +481,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -528,10 +528,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -578,10 +578,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -630,10 +630,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.User.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.User.cs
@@ -50,9 +50,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -119,10 +119,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -183,9 +183,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -251,10 +251,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -323,10 +323,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -397,10 +397,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -443,8 +443,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -481,8 +481,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(2);
@@ -528,10 +528,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -578,10 +578,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);
@@ -630,10 +630,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.cs
@@ -65,7 +65,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.Should().BeEmpty();
@@ -106,8 +106,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.cs
@@ -65,7 +65,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.Should().BeEmpty();
@@ -106,8 +106,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDel
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             messageBroker.SentMessages.ShouldHaveCount(1);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/MessagingGroupDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/MessagingGroupDefinition.cs
@@ -20,7 +20,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices
 
         private string? _beforeGroupName;
 
-        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Writing;
+        protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.Writing;
 
         protected MessagingGroupDefinition(IResourceGraph resourceGraph, DbSet<DomainUser> userSet, DbSet<DomainGroup> groupSet,
             ResourceDefinitionHitCounter hitCounter)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/MessagingGroupDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/MessagingGroupDefinition.cs
@@ -12,27 +12,27 @@ using Microsoft.EntityFrameworkCore;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices
 {
-    public abstract class MessagingGroupDefinition : JsonApiResourceDefinition<DomainGroup, Guid>
+    public abstract class MessagingGroupDefinition : HitCountingResourceDefinition<DomainGroup, Guid>
     {
         private readonly DbSet<DomainUser> _userSet;
         private readonly DbSet<DomainGroup> _groupSet;
-        private readonly ResourceDefinitionHitCounter _hitCounter;
         private readonly List<OutgoingMessage> _pendingMessages = new();
 
         private string? _beforeGroupName;
 
+        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Writing;
+
         protected MessagingGroupDefinition(IResourceGraph resourceGraph, DbSet<DomainUser> userSet, DbSet<DomainGroup> groupSet,
             ResourceDefinitionHitCounter hitCounter)
-            : base(resourceGraph)
+            : base(resourceGraph, hitCounter)
         {
             _userSet = userSet;
             _groupSet = groupSet;
-            _hitCounter = hitCounter;
         }
 
-        public override Task OnPrepareWriteAsync(DomainGroup group, WriteOperationKind writeOperation, CancellationToken cancellationToken)
+        public override async Task OnPrepareWriteAsync(DomainGroup group, WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            _hitCounter.TrackInvocation<DomainGroup>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync);
+            await base.OnPrepareWriteAsync(group, writeOperation, cancellationToken);
 
             if (writeOperation == WriteOperationKind.CreateResource)
             {
@@ -42,14 +42,12 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices
             {
                 _beforeGroupName = group.Name;
             }
-
-            return Task.CompletedTask;
         }
 
         public override async Task OnSetToManyRelationshipAsync(DomainGroup group, HasManyAttribute hasManyRelationship, ISet<IIdentifiable> rightResourceIds,
             WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            _hitCounter.TrackInvocation<DomainGroup>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToManyRelationshipAsync);
+            await base.OnSetToManyRelationshipAsync(group, hasManyRelationship, rightResourceIds, writeOperation, cancellationToken);
 
             if (hasManyRelationship.Property.Name == nameof(DomainGroup.Users))
             {
@@ -90,7 +88,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices
         public override async Task OnAddToRelationshipAsync(Guid groupId, HasManyAttribute hasManyRelationship, ISet<IIdentifiable> rightResourceIds,
             CancellationToken cancellationToken)
         {
-            _hitCounter.TrackInvocation<DomainGroup>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnAddToRelationshipAsync);
+            await base.OnAddToRelationshipAsync(groupId, hasManyRelationship, rightResourceIds, cancellationToken);
 
             if (hasManyRelationship.Property.Name == nameof(DomainGroup.Users))
             {
@@ -121,10 +119,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices
             }
         }
 
-        public override Task OnRemoveFromRelationshipAsync(DomainGroup group, HasManyAttribute hasManyRelationship, ISet<IIdentifiable> rightResourceIds,
+        public override async Task OnRemoveFromRelationshipAsync(DomainGroup group, HasManyAttribute hasManyRelationship, ISet<IIdentifiable> rightResourceIds,
             CancellationToken cancellationToken)
         {
-            _hitCounter.TrackInvocation<DomainGroup>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnRemoveFromRelationshipAsync);
+            await base.OnRemoveFromRelationshipAsync(group, hasManyRelationship, rightResourceIds, cancellationToken);
 
             if (hasManyRelationship.Property.Name == nameof(DomainGroup.Users))
             {
@@ -137,8 +135,6 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices
                     _pendingMessages.Add(message);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
         protected async Task FinishWriteAsync(DomainGroup group, WriteOperationKind writeOperation, CancellationToken cancellationToken)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/MessagingUserDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/MessagingUserDefinition.cs
@@ -19,7 +19,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices
         private string? _beforeLoginName;
         private string? _beforeDisplayName;
 
-        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Writing;
+        protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.Writing;
 
         protected MessagingUserDefinition(IResourceGraph resourceGraph, DbSet<DomainUser> userSet, ResourceDefinitionHitCounter hitCounter)
             : base(resourceGraph, hitCounter)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/MessagingUserDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/MessagingUserDefinition.cs
@@ -11,25 +11,25 @@ using Microsoft.EntityFrameworkCore;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices
 {
-    public abstract class MessagingUserDefinition : JsonApiResourceDefinition<DomainUser, Guid>
+    public abstract class MessagingUserDefinition : HitCountingResourceDefinition<DomainUser, Guid>
     {
         private readonly DbSet<DomainUser> _userSet;
-        private readonly ResourceDefinitionHitCounter _hitCounter;
         private readonly List<OutgoingMessage> _pendingMessages = new();
 
         private string? _beforeLoginName;
         private string? _beforeDisplayName;
 
+        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Writing;
+
         protected MessagingUserDefinition(IResourceGraph resourceGraph, DbSet<DomainUser> userSet, ResourceDefinitionHitCounter hitCounter)
-            : base(resourceGraph)
+            : base(resourceGraph, hitCounter)
         {
             _userSet = userSet;
-            _hitCounter = hitCounter;
         }
 
-        public override Task OnPrepareWriteAsync(DomainUser user, WriteOperationKind writeOperation, CancellationToken cancellationToken)
+        public override async Task OnPrepareWriteAsync(DomainUser user, WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            _hitCounter.TrackInvocation<DomainUser>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync);
+            await base.OnPrepareWriteAsync(user, writeOperation, cancellationToken);
 
             if (writeOperation == WriteOperationKind.CreateResource)
             {
@@ -40,14 +40,12 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices
                 _beforeLoginName = user.LoginName;
                 _beforeDisplayName = user.DisplayName;
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task<IIdentifiable?> OnSetToOneRelationshipAsync(DomainUser user, HasOneAttribute hasOneRelationship, IIdentifiable? rightResourceId,
-            WriteOperationKind writeOperation, CancellationToken cancellationToken)
+        public override async Task<IIdentifiable?> OnSetToOneRelationshipAsync(DomainUser user, HasOneAttribute hasOneRelationship,
+            IIdentifiable? rightResourceId, WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            _hitCounter.TrackInvocation<DomainUser>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync);
+            await base.OnSetToOneRelationshipAsync(user, hasOneRelationship, rightResourceId, writeOperation, cancellationToken);
 
             if (hasOneRelationship.Property.Name == nameof(DomainUser.Group))
             {
@@ -74,7 +72,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices
                 }
             }
 
-            return Task.FromResult(rightResourceId);
+            return rightResourceId;
         }
 
         protected async Task FinishWriteAsync(DomainUser user, WriteOperationKind writeOperation, CancellationToken cancellationToken)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxGroupDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxGroupDefinition.cs
@@ -11,21 +11,19 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
     public sealed class OutboxGroupDefinition : MessagingGroupDefinition
     {
-        private readonly ResourceDefinitionHitCounter _hitCounter;
         private readonly DbSet<OutgoingMessage> _outboxMessageSet;
 
         public OutboxGroupDefinition(IResourceGraph resourceGraph, OutboxDbContext dbContext, ResourceDefinitionHitCounter hitCounter)
             : base(resourceGraph, dbContext.Users, dbContext.Groups, hitCounter)
         {
-            _hitCounter = hitCounter;
             _outboxMessageSet = dbContext.OutboxMessages;
         }
 
-        public override Task OnWritingAsync(DomainGroup group, WriteOperationKind writeOperation, CancellationToken cancellationToken)
+        public override async Task OnWritingAsync(DomainGroup group, WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            _hitCounter.TrackInvocation<DomainGroup>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync);
+            await base.OnWritingAsync(group, writeOperation, cancellationToken);
 
-            return FinishWriteAsync(group, writeOperation, cancellationToken);
+            await FinishWriteAsync(group, writeOperation, cancellationToken);
         }
 
         protected override async Task FlushMessageAsync(OutgoingMessage message, CancellationToken cancellationToken)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.Group.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.Group.cs
@@ -54,9 +54,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             Guid newGroupId = Guid.Parse(responseDocument.Data.SingleValue.Id.ShouldNotBeNull());
@@ -136,10 +136,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnSetToManyRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             Guid newGroupId = Guid.Parse(responseDocument.Data.SingleValue.Id.ShouldNotBeNull());
@@ -206,9 +206,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -294,10 +294,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnSetToManyRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -347,8 +347,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -389,8 +389,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -467,10 +467,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnSetToManyRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -545,9 +545,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnAddToRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnAddToRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -611,9 +611,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnRemoveFromRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnRemoveFromRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.Group.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.Group.cs
@@ -54,8 +54,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             Guid newGroupId = Guid.Parse(responseDocument.Data.SingleValue.Id.ShouldNotBeNull());
@@ -135,9 +136,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToManyRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             Guid newGroupId = Guid.Parse(responseDocument.Data.SingleValue.Id.ShouldNotBeNull());
@@ -204,8 +206,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -291,9 +294,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToManyRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -343,7 +347,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -384,7 +389,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -461,9 +467,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToManyRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnSetToManyRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -538,8 +545,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnAddToRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnAddToRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -603,8 +611,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnRemoveFromRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnRemoveFromRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.User.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.User.cs
@@ -57,8 +57,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             Guid newUserId = Guid.Parse(responseDocument.Data.SingleValue.Id.ShouldNotBeNull());
@@ -129,9 +130,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             Guid newUserId = Guid.Parse(responseDocument.Data.SingleValue.Id.ShouldNotBeNull());
@@ -196,8 +198,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -267,9 +270,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -342,9 +346,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -419,9 +424,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -468,7 +474,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -509,7 +516,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -559,9 +567,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -612,9 +621,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -667,9 +677,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.User.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.User.cs
@@ -57,9 +57,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             Guid newUserId = Guid.Parse(responseDocument.Data.SingleValue.Id.ShouldNotBeNull());
@@ -130,10 +130,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             Guid newUserId = Guid.Parse(responseDocument.Data.SingleValue.Id.ShouldNotBeNull());
@@ -198,9 +198,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -270,10 +270,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -346,10 +346,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -424,10 +424,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -474,8 +474,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -516,8 +516,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -567,10 +567,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -621,10 +621,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -677,10 +677,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnPrepareWriteAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnSetToOneRelationshipAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWritingAsync),
-                (typeof(DomainUser), ResourceDefinitionExtensibilityPoint.OnWriteSucceededAsync)
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnPrepareWriteAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnSetToOneRelationshipAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWritingAsync),
+                (typeof(DomainUser), ResourceDefinitionExtensibilityPoints.OnWriteSucceededAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.cs
@@ -94,8 +94,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnAddToRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnAddToRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoints.OnWritingAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.cs
@@ -94,8 +94,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnAddToRelationshipAsync),
-                (typeof(DomainGroup), ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync)
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnAddToRelationshipAsync),
+                (typeof(DomainGroup), ResourceDefinitionExtensibilityPoint.OnWritingAsync)
             }, options => options.WithStrictOrdering());
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxUserDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxUserDefinition.cs
@@ -11,21 +11,19 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOut
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
     public sealed class OutboxUserDefinition : MessagingUserDefinition
     {
-        private readonly ResourceDefinitionHitCounter _hitCounter;
         private readonly DbSet<OutgoingMessage> _outboxMessageSet;
 
         public OutboxUserDefinition(IResourceGraph resourceGraph, OutboxDbContext dbContext, ResourceDefinitionHitCounter hitCounter)
             : base(resourceGraph, dbContext.Users, hitCounter)
         {
-            _hitCounter = hitCounter;
             _outboxMessageSet = dbContext.OutboxMessages;
         }
 
-        public override Task OnWritingAsync(DomainUser user, WriteOperationKind writeOperation, CancellationToken cancellationToken)
+        public override async Task OnWritingAsync(DomainUser user, WriteOperationKind writeOperation, CancellationToken cancellationToken)
         {
-            _hitCounter.TrackInvocation<DomainUser>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnWritingAsync);
+            await base.OnWritingAsync(user, writeOperation, cancellationToken);
 
-            return FinishWriteAsync(user, writeOperation, cancellationToken);
+            await FinishWriteAsync(user, writeOperation, cancellationToken);
         }
 
         protected override async Task FlushMessageAsync(OutgoingMessage message, CancellationToken cancellationToken)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/MultiTenancyTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/MultiTenancyTests.cs
@@ -43,6 +43,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.MultiTenancy
 
             var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
             options.UseRelativeLinks = true;
+            options.IncludeTotalResourceCount = true;
         }
 
         [Fact]
@@ -1017,8 +1018,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.MultiTenancy
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be(route);
             responseDocument.Links.Related.Should().BeNull();
-            responseDocument.Links.First.Should().Be(route);
-            responseDocument.Links.Last.Should().BeNull();
+            responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Pagination/PaginationWithTotalCountTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Pagination/PaginationWithTotalCountTests.cs
@@ -106,15 +106,18 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
         {
             // Arrange
             Blog blog = _fakers.Blog.Generate();
-            blog.Posts = _fakers.BlogPost.Generate(2);
+            blog.Posts = _fakers.BlogPost.Generate(5);
+
+            Blog otherBlog = _fakers.Blog.Generate();
+            otherBlog.Posts = _fakers.BlogPost.Generate(1);
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
             {
-                dbContext.Blogs.Add(blog);
+                dbContext.Blogs.AddRange(blog, otherBlog);
                 await dbContext.SaveChangesAsync();
             });
 
-            string route = $"/blogs/{blog.StringId}/posts?page[number]=2&page[size]=1";
+            string route = $"/blogs/{blog.StringId}/posts?page[number]=3&page[size]=1";
 
             // Act
             (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
@@ -123,14 +126,46 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
             httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
 
             responseDocument.Data.ManyValue.ShouldHaveCount(1);
-            responseDocument.Data.ManyValue[0].Id.Should().Be(blog.Posts[1].StringId);
+            responseDocument.Data.ManyValue[0].Id.Should().Be(blog.Posts[2].StringId);
 
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.First.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/posts?page%5Bsize%5D=1");
+            responseDocument.Links.Last.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/posts?page%5Bnumber%5D=5&page%5Bsize%5D=1");
+            responseDocument.Links.Prev.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/posts?page%5Bnumber%5D=2&page%5Bsize%5D=1");
+            responseDocument.Links.Next.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/posts?page%5Bnumber%5D=4&page%5Bsize%5D=1");
+        }
+
+        [Fact]
+        public async Task Can_paginate_in_secondary_resources_without_inverse_relationship()
+        {
+            // Arrange
+            WebAccount? account = _fakers.WebAccount.Generate();
+            account.LoginAttempts = _fakers.LoginAttempt.Generate(2);
+
+            await _testContext.RunOnDatabaseAsync(async dbContext =>
+            {
+                dbContext.Accounts.Add(account);
+                await dbContext.SaveChangesAsync();
+            });
+
+            string route = $"/webAccounts/{account.StringId}/loginAttempts?page[number]=2&page[size]=1";
+
+            // Act
+            (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+            // Assert
+            httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
+
+            responseDocument.Data.ManyValue.ShouldHaveCount(1);
+            responseDocument.Data.ManyValue[0].Id.Should().Be(account.LoginAttempts[1].StringId);
+
+            responseDocument.Links.ShouldNotBeNull();
+            responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
+            responseDocument.Links.First.Should().Be($"{HostPrefix}/webAccounts/{account.StringId}/loginAttempts?page%5Bsize%5D=1");
             responseDocument.Links.Last.Should().BeNull();
             responseDocument.Links.Prev.Should().Be(responseDocument.Links.First);
-            responseDocument.Links.Next.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/posts?page%5Bnumber%5D=3&page%5Bsize%5D=1");
+            responseDocument.Links.Next.Should().Be($"{HostPrefix}/webAccounts/{account.StringId}/loginAttempts?page%5Bnumber%5D=3&page%5Bsize%5D=1");
         }
 
         [Fact]
@@ -239,7 +274,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
         {
             // Arrange
             Blog blog = _fakers.Blog.Generate();
-            blog.Posts = _fakers.BlogPost.Generate(2);
+            blog.Posts = _fakers.BlogPost.Generate(4);
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
             {
@@ -261,9 +296,43 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.First.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/relationships/posts?page%5Bsize%5D=1");
+            responseDocument.Links.Last.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/relationships/posts?page%5Bnumber%5D=4&page%5Bsize%5D=1");
+            responseDocument.Links.Prev.Should().Be(responseDocument.Links.First);
+            responseDocument.Links.Next.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/relationships/posts?page%5Bnumber%5D=3&page%5Bsize%5D=1");
+        }
+
+        [Fact]
+        public async Task Can_paginate_OneToMany_relationship_on_relationship_endpoint_without_inverse_relationship()
+        {
+            // Arrange
+            WebAccount? account = _fakers.WebAccount.Generate();
+            account.LoginAttempts = _fakers.LoginAttempt.Generate(2);
+
+            await _testContext.RunOnDatabaseAsync(async dbContext =>
+            {
+                dbContext.Accounts.Add(account);
+                await dbContext.SaveChangesAsync();
+            });
+
+            string route = $"/webAccounts/{account.StringId}/relationships/loginAttempts?page[number]=2&page[size]=1";
+
+            // Act
+            (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+            // Assert
+            httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
+
+            responseDocument.Data.ManyValue.ShouldHaveCount(1);
+            responseDocument.Data.ManyValue[0].Id.Should().Be(account.LoginAttempts[1].StringId);
+
+            string basePath = $"{HostPrefix}/webAccounts/{account.StringId}/relationships/loginAttempts";
+
+            responseDocument.Links.ShouldNotBeNull();
+            responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
+            responseDocument.Links.First.Should().Be(basePath + "?page%5Bsize%5D=1");
             responseDocument.Links.Last.Should().BeNull();
             responseDocument.Links.Prev.Should().Be(responseDocument.Links.First);
-            responseDocument.Links.Next.Should().BeNull();
+            responseDocument.Links.Next.Should().Be(basePath + "?page%5Bnumber%5D=3&page%5Bsize%5D=1");
         }
 
         [Fact]
@@ -313,7 +382,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
         {
             // Arrange
             BlogPost post = _fakers.BlogPost.Generate();
-            post.Labels = _fakers.Label.Generate(2).ToHashSet();
+            post.Labels = _fakers.Label.Generate(4).ToHashSet();
 
             await _testContext.RunOnDatabaseAsync(async dbContext =>
             {
@@ -336,9 +405,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.First.Should().Be($"{HostPrefix}/blogPosts/{post.StringId}/relationships/labels?page%5Bsize%5D=1");
-            responseDocument.Links.Last.Should().BeNull();
+            responseDocument.Links.Last.Should().Be($"{HostPrefix}/blogPosts/{post.StringId}/relationships/labels?page%5Bnumber%5D=4&page%5Bsize%5D=1");
             responseDocument.Links.Prev.Should().Be(responseDocument.Links.First);
-            responseDocument.Links.Next.Should().BeNull();
+            responseDocument.Links.Next.Should().Be($"{HostPrefix}/blogPosts/{post.StringId}/relationships/labels?page%5Bnumber%5D=3&page%5Bsize%5D=1");
         }
 
         [Fact]
@@ -465,9 +534,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
-            responseDocument.Links.Last.Should().BeNull();
+            responseDocument.Links.Last.Should().Be($"{HostPrefix}{route}?page%5Bnumber%5D=2");
             responseDocument.Links.Prev.Should().BeNull();
-            responseDocument.Links.Next.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/posts?page%5Bnumber%5D=2");
+            responseDocument.Links.Next.Should().Be(responseDocument.Links.Last);
         }
 
         [Fact]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Pagination/PaginationWithTotalCountTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Pagination/PaginationWithTotalCountTests.cs
@@ -65,8 +65,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
 
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogPosts?page[size]=1");
-            responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
+            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogPosts?page%5Bsize%5D=1");
+            responseDocument.Links.Last.Should().Be($"{HostPrefix}/blogPosts?page%5Bnumber%5D=2&page%5Bsize%5D=1");
             responseDocument.Links.Prev.Should().Be(responseDocument.Links.First);
             responseDocument.Links.Next.Should().BeNull();
         }
@@ -127,10 +127,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
 
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/posts?page[size]=1");
+            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/posts?page%5Bsize%5D=1");
             responseDocument.Links.Last.Should().BeNull();
             responseDocument.Links.Prev.Should().Be(responseDocument.Links.First);
-            responseDocument.Links.Next.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/posts?page[number]=3&page[size]=1");
+            responseDocument.Links.Next.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/posts?page%5Bnumber%5D=3&page%5Bsize%5D=1");
         }
 
         [Fact]
@@ -194,8 +194,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
 
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogs?include=posts&page[size]=2,posts:1");
-            responseDocument.Links.Last.Should().Be($"{HostPrefix}/blogs?include=posts&page[number]=2&page[size]=2,posts:1");
+            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogs?include=posts&page%5Bsize%5D=2,posts%3A1");
+            responseDocument.Links.Last.Should().Be($"{HostPrefix}/blogs?include=posts&page%5Bnumber%5D=2&page%5Bsize%5D=2,posts%3A1");
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().Be(responseDocument.Links.Last);
         }
@@ -260,7 +260,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
 
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/relationships/posts?page[size]=1");
+            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/relationships/posts?page%5Bsize%5D=1");
             responseDocument.Links.Last.Should().BeNull();
             responseDocument.Links.Prev.Should().Be(responseDocument.Links.First);
             responseDocument.Links.Next.Should().BeNull();
@@ -302,7 +302,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
 
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogPosts?include=labels&page[size]=labels:1");
+            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogPosts?include=labels&page%5Bsize%5D=labels%3A1");
             responseDocument.Links.Last.Should().Be(responseDocument.Links.First);
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
@@ -335,7 +335,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
 
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogPosts/{post.StringId}/relationships/labels?page[size]=1");
+            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogPosts/{post.StringId}/relationships/labels?page%5Bsize%5D=1");
             responseDocument.Links.Last.Should().BeNull();
             responseDocument.Links.Prev.Should().Be(responseDocument.Links.First);
             responseDocument.Links.Next.Should().BeNull();
@@ -384,8 +384,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
 
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.First.Should().Be($"{linkPrefix}&page[size]=1,owner.posts:1,owner.posts.comments:1");
-            responseDocument.Links.Last.Should().Be($"{linkPrefix}&page[size]=1,owner.posts:1,owner.posts.comments:1&page[number]=2");
+            responseDocument.Links.First.Should().Be($"{linkPrefix}&page%5Bsize%5D=1,owner.posts%3A1,owner.posts.comments%3A1");
+            responseDocument.Links.Last.Should().Be($"{linkPrefix}&page%5Bsize%5D=1,owner.posts%3A1,owner.posts.comments%3A1&page%5Bnumber%5D=2");
             responseDocument.Links.Prev.Should().Be(responseDocument.Links.First);
             responseDocument.Links.Next.Should().BeNull();
         }
@@ -467,7 +467,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
             responseDocument.Links.First.Should().Be(responseDocument.Links.Self);
             responseDocument.Links.Last.Should().BeNull();
             responseDocument.Links.Prev.Should().BeNull();
-            responseDocument.Links.Next.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/posts?page[number]=2");
+            responseDocument.Links.Next.Should().Be($"{HostPrefix}/blogs/{blog.StringId}/posts?page%5Bnumber%5D=2");
         }
 
         [Fact]
@@ -587,7 +587,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
 
             static string SetPageNumberInUrl(string url, int pageNumber)
             {
-                return pageNumber != 1 ? $"{url}&page[number]={pageNumber}" : url;
+                string link = pageNumber != 1 ? $"{url}&page[number]={pageNumber}" : url;
+                return link.Replace("[", "%5B").Replace("]", "%5D").Replace("'", "%27");
             }
         }
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Pagination/PaginationWithoutTotalCountTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Pagination/PaginationWithoutTotalCountTests.cs
@@ -78,7 +78,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
 
             responseDocument.Links.ShouldNotBeNull();
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
-            responseDocument.Links.First.Should().Be($"{HostPrefix}{route}");
+            responseDocument.Links.First.Should().Be($"{HostPrefix}/blogPosts?page%5Bsize%5D=8&foo=bar");
             responseDocument.Links.Last.Should().BeNull();
             responseDocument.Links.Prev.Should().BeNull();
             responseDocument.Links.Next.Should().BeNull();
@@ -137,7 +137,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.First.Should().Be($"{HostPrefix}/blogPosts?foo=bar");
             responseDocument.Links.Last.Should().BeNull();
-            responseDocument.Links.Prev.Should().Be($"{HostPrefix}/blogPosts?foo=bar&page[number]=2");
+            responseDocument.Links.Prev.Should().Be($"{HostPrefix}/blogPosts?foo=bar&page%5Bnumber%5D=2");
             responseDocument.Links.Next.Should().BeNull();
         }
 
@@ -168,8 +168,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.First.Should().Be($"{HostPrefix}/blogPosts?foo=bar");
             responseDocument.Links.Last.Should().BeNull();
-            responseDocument.Links.Prev.Should().Be($"{HostPrefix}/blogPosts?page[number]=2&foo=bar");
-            responseDocument.Links.Next.Should().Be($"{HostPrefix}/blogPosts?page[number]=4&foo=bar");
+            responseDocument.Links.Prev.Should().Be($"{HostPrefix}/blogPosts?page%5Bnumber%5D=2&foo=bar");
+            responseDocument.Links.Next.Should().Be($"{HostPrefix}/blogPosts?page%5Bnumber%5D=4&foo=bar");
         }
 
         [Fact]
@@ -199,8 +199,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.First.Should().Be($"{HostPrefix}/webAccounts/{account.StringId}/posts?foo=bar");
             responseDocument.Links.Last.Should().BeNull();
-            responseDocument.Links.Prev.Should().Be($"{HostPrefix}/webAccounts/{account.StringId}/posts?page[number]=2&foo=bar");
-            responseDocument.Links.Next.Should().Be($"{HostPrefix}/webAccounts/{account.StringId}/posts?page[number]=4&foo=bar");
+            responseDocument.Links.Prev.Should().Be($"{HostPrefix}/webAccounts/{account.StringId}/posts?page%5Bnumber%5D=2&foo=bar");
+            responseDocument.Links.Next.Should().Be($"{HostPrefix}/webAccounts/{account.StringId}/posts?page%5Bnumber%5D=4&foo=bar");
         }
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Pagination/PaginationWithoutTotalCountTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Pagination/PaginationWithoutTotalCountTests.cs
@@ -106,7 +106,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Pagination
             responseDocument.Links.Self.Should().Be($"{HostPrefix}{route}");
             responseDocument.Links.First.Should().Be($"{HostPrefix}/blogPosts?foo=bar");
             responseDocument.Links.Last.Should().BeNull();
-            responseDocument.Links.Prev.Should().Be($"{HostPrefix}/blogPosts?foo=bar");
+            responseDocument.Links.Prev.Should().Be(responseDocument.Links.First);
             responseDocument.Links.Next.Should().BeNull();
         }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitionExtensibilityPoint.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitionExtensibilityPoint.cs
@@ -1,0 +1,39 @@
+using System;
+using JsonApiDotNetCore.Resources;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests
+{
+    /// <summary>
+    /// Lists the various extensibility points on <see cref="IResourceDefinition{TResource,TId}" />.
+    /// </summary>
+    [Flags]
+    public enum ResourceDefinitionExtensibilityPoint
+    {
+        OnApplyIncludes = 1,
+        OnApplyFilter = 1 << 1,
+        OnApplySort = 1 << 2,
+        OnApplyPagination = 1 << 3,
+        OnApplySparseFieldSet = 1 << 4,
+        OnRegisterQueryableHandlersForQueryStringParameters = 1 << 5,
+        GetMeta = 1 << 6,
+        OnPrepareWriteAsync = 1 << 7,
+        OnSetToOneRelationshipAsync = 1 << 8,
+        OnSetToManyRelationshipAsync = 1 << 9,
+        OnAddToRelationshipAsync = 1 << 10,
+        OnRemoveFromRelationshipAsync = 1 << 11,
+        OnWritingAsync = 1 << 12,
+        OnWriteSucceededAsync = 1 << 13,
+        OnDeserialize = 1 << 14,
+        OnSerialize = 1 << 15,
+
+        Reading = OnApplyIncludes | OnApplyFilter | OnApplySort | OnApplyPagination | OnApplySparseFieldSet |
+            OnRegisterQueryableHandlersForQueryStringParameters | GetMeta,
+
+        Writing = OnPrepareWriteAsync | OnSetToOneRelationshipAsync | OnSetToManyRelationshipAsync | OnAddToRelationshipAsync | OnRemoveFromRelationshipAsync |
+            OnWritingAsync | OnWriteSucceededAsync,
+
+        Serialization = OnDeserialize | OnSerialize,
+
+        All = Reading | Writing | Serialization
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitionExtensibilityPoints.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitionExtensibilityPoints.cs
@@ -7,7 +7,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
     /// Lists the various extensibility points on <see cref="IResourceDefinition{TResource,TId}" />.
     /// </summary>
     [Flags]
-    public enum ResourceDefinitionExtensibilityPoint
+    public enum ResourceDefinitionExtensibilityPoints
     {
         OnApplyIncludes = 1,
         OnApplyFilter = 1 << 1,

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitionHitCounter.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitionHitCounter.cs
@@ -9,9 +9,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
     /// </summary>
     public sealed class ResourceDefinitionHitCounter
     {
-        internal IList<(Type, ResourceDefinitionExtensibilityPoint)> HitExtensibilityPoints { get; } = new List<(Type, ResourceDefinitionExtensibilityPoint)>();
+        internal IList<(Type, ResourceDefinitionExtensibilityPoints)> HitExtensibilityPoints { get; } =
+            new List<(Type, ResourceDefinitionExtensibilityPoints)>();
 
-        internal void TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint extensibilityPoint)
+        internal void TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoints extensibilityPoint)
             where TResource : IIdentifiable
         {
             HitExtensibilityPoints.Add((typeof(TResource), extensibilityPoint));

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitionHitCounter.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitionHitCounter.cs
@@ -5,13 +5,13 @@ using JsonApiDotNetCore.Resources;
 namespace JsonApiDotNetCoreTests.IntegrationTests
 {
     /// <summary>
-    /// This is used solely in our tests, so we can assert which calls were made.
+    /// Used to keep track of invocations on <see cref="IResourceDefinition{TResource,TId}" /> callback methods.
     /// </summary>
     public sealed class ResourceDefinitionHitCounter
     {
-        internal IList<(Type, ExtensibilityPoint)> HitExtensibilityPoints { get; } = new List<(Type, ExtensibilityPoint)>();
+        internal IList<(Type, ResourceDefinitionExtensibilityPoint)> HitExtensibilityPoints { get; } = new List<(Type, ResourceDefinitionExtensibilityPoint)>();
 
-        internal void TrackInvocation<TResource>(ExtensibilityPoint extensibilityPoint)
+        internal void TrackInvocation<TResource>(ResourceDefinitionExtensibilityPoint extensibilityPoint)
             where TResource : IIdentifiable
         {
             HitExtensibilityPoints.Add((typeof(TResource), extensibilityPoint));
@@ -20,26 +20,6 @@ namespace JsonApiDotNetCoreTests.IntegrationTests
         internal void Reset()
         {
             HitExtensibilityPoints.Clear();
-        }
-
-        internal enum ExtensibilityPoint
-        {
-            OnApplyIncludes,
-            OnApplyFilter,
-            OnApplySort,
-            OnApplyPagination,
-            OnApplySparseFieldSet,
-            OnRegisterQueryableHandlersForQueryStringParameters,
-            GetMeta,
-            OnPrepareWriteAsync,
-            OnSetToOneRelationshipAsync,
-            OnSetToManyRelationshipAsync,
-            OnAddToRelationshipAsync,
-            OnRemoveFromRelationshipAsync,
-            OnWritingAsync,
-            OnWriteSucceededAsync,
-            OnDeserialize,
-            OnSerialize
         }
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/MoonDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/MoonDefinition.cs
@@ -10,24 +10,24 @@ using Microsoft.Extensions.Primitives;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 {
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-    public sealed class MoonDefinition : JsonApiResourceDefinition<Moon, int>
+    public sealed class MoonDefinition : HitCountingResourceDefinition<Moon, int>
     {
         private readonly IClientSettingsProvider _clientSettingsProvider;
-        private readonly ResourceDefinitionHitCounter _hitCounter;
+
+        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Reading;
 
         public MoonDefinition(IResourceGraph resourceGraph, IClientSettingsProvider clientSettingsProvider, ResourceDefinitionHitCounter hitCounter)
-            : base(resourceGraph)
+            : base(resourceGraph, hitCounter)
         {
             // This constructor will be resolved from the container, which means
             // you can take on any dependency that is also defined in the container.
 
             _clientSettingsProvider = clientSettingsProvider;
-            _hitCounter = hitCounter;
         }
 
         public override IImmutableSet<IncludeElementExpression> OnApplyIncludes(IImmutableSet<IncludeElementExpression> existingIncludes)
         {
-            _hitCounter.TrackInvocation<Moon>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyIncludes);
+            base.OnApplyIncludes(existingIncludes);
 
             if (!_clientSettingsProvider.IsMoonOrbitingPlanetAutoIncluded ||
                 existingIncludes.Any(include => include.Relationship.Property.Name == nameof(Moon.OrbitsAround)))
@@ -42,7 +42,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
         public override QueryStringParameterHandlers<Moon> OnRegisterQueryableHandlersForQueryStringParameters()
         {
-            _hitCounter.TrackInvocation<Moon>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters);
+            base.OnRegisterQueryableHandlersForQueryStringParameters();
 
             return new QueryStringParameterHandlers<Moon>
             {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/MoonDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/MoonDefinition.cs
@@ -14,7 +14,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
     {
         private readonly IClientSettingsProvider _clientSettingsProvider;
 
-        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Reading;
+        protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.Reading;
 
         public MoonDefinition(IResourceGraph resourceGraph, IClientSettingsProvider clientSettingsProvider, ResourceDefinitionHitCounter hitCounter)
             : base(resourceGraph, hitCounter)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/PlanetDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/PlanetDefinition.cs
@@ -5,31 +5,30 @@ using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Errors;
 using JsonApiDotNetCore.Queries.Expressions;
-using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 using JsonApiDotNetCore.Serialization.Objects;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 {
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-    public sealed class PlanetDefinition : JsonApiResourceDefinition<Planet, int>
+    public sealed class PlanetDefinition : HitCountingResourceDefinition<Planet, int>
     {
         private readonly IClientSettingsProvider _clientSettingsProvider;
-        private readonly ResourceDefinitionHitCounter _hitCounter;
+
+        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Reading;
 
         public PlanetDefinition(IResourceGraph resourceGraph, IClientSettingsProvider clientSettingsProvider, ResourceDefinitionHitCounter hitCounter)
-            : base(resourceGraph)
+            : base(resourceGraph, hitCounter)
         {
             // This constructor will be resolved from the container, which means
             // you can take on any dependency that is also defined in the container.
 
             _clientSettingsProvider = clientSettingsProvider;
-            _hitCounter = hitCounter;
         }
 
         public override IImmutableSet<IncludeElementExpression> OnApplyIncludes(IImmutableSet<IncludeElementExpression> existingIncludes)
         {
-            _hitCounter.TrackInvocation<Planet>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyIncludes);
+            base.OnApplyIncludes(existingIncludes);
 
             if (_clientSettingsProvider.IsIncludePlanetMoonsBlocked &&
                 existingIncludes.Any(include => include.Relationship.Property.Name == nameof(Planet.Moons)))
@@ -45,7 +44,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
         public override FilterExpression? OnApplyFilter(FilterExpression? existingFilter)
         {
-            _hitCounter.TrackInvocation<Planet>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyFilter);
+            base.OnApplyFilter(existingFilter);
 
             if (_clientSettingsProvider.ArePlanetsWithPrivateNameHidden)
             {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/PlanetDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/PlanetDefinition.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
     {
         private readonly IClientSettingsProvider _clientSettingsProvider;
 
-        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Reading;
+        protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.Reading;
 
         public PlanetDefinition(IResourceGraph resourceGraph, IClientSettingsProvider clientSettingsProvider, ResourceDefinitionHitCounter hitCounter)
             : base(resourceGraph, hitCounter)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/PlanetDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/PlanetDefinition.cs
@@ -53,7 +53,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
                 FilterExpression hasNoPrivateName = new ComparisonExpression(ComparisonOperator.Equals, new ResourceFieldChainExpression(privateNameAttribute),
                     NullConstantExpression.Instance);
 
-                return existingFilter == null ? hasNoPrivateName : new LogicalExpression(LogicalOperator.And, hasNoPrivateName, existingFilter);
+                return LogicalExpression.Compose(LogicalOperator.And, hasNoPrivateName, existingFilter);
             }
 
             return existingFilter;

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ResourceDefinitionReadTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ResourceDefinitionReadTests.cs
@@ -81,12 +81,12 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes)
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyIncludes)
             }, options => options.WithStrictOrdering());
         }
 
@@ -133,17 +133,17 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -190,21 +190,21 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -248,15 +248,15 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -307,14 +307,14 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -359,18 +359,18 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -415,16 +415,16 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter)
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter)
             }, options => options.WithStrictOrdering());
         }
 
@@ -467,16 +467,16 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -519,16 +519,16 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -559,18 +559,18 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -604,13 +604,13 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -645,13 +645,13 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -685,13 +685,13 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -725,13 +725,13 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -769,16 +769,16 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnRegisterQueryableHandlersForQueryStringParameters),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnRegisterQueryableHandlersForQueryStringParameters),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -826,16 +826,16 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySort),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.GetMeta)
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnRegisterQueryableHandlersForQueryStringParameters),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnRegisterQueryableHandlersForQueryStringParameters),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySort),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -873,7 +873,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters)
+                (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnRegisterQueryableHandlersForQueryStringParameters)
             }, options => options.WithStrictOrdering());
         }
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ResourceDefinitionReadTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ResourceDefinitionReadTests.cs
@@ -81,9 +81,12 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyIncludes)
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes)
             }, options => options.WithStrictOrdering());
         }
 
@@ -130,8 +133,17 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Moon), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyIncludes),
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyIncludes)
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -178,10 +190,21 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyIncludes),
-                (typeof(Moon), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyIncludes),
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyIncludes)
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -225,9 +248,15 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyIncludes)
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -278,9 +307,14 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyFilter),
-                (typeof(Planet), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyIncludes)
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Planet), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -323,10 +357,16 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet)
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -369,10 +409,16 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet)
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -403,10 +449,18 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet)
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -440,10 +494,13 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet)
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -478,10 +535,13 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet)
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -515,10 +575,13 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet)
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -552,10 +615,13 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyPagination),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySort),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet),
-                (typeof(Star), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet)
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Star), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -593,9 +659,16 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Moon), ResourceDefinitionHitCounter.ExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters),
-                (typeof(Moon), ResourceDefinitionHitCounter.ExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters),
-                (typeof(Moon), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyIncludes)
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -643,9 +716,16 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Moon), ResourceDefinitionHitCounter.ExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters),
-                (typeof(Moon), ResourceDefinitionHitCounter.ExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters),
-                (typeof(Moon), ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyIncludes)
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyPagination),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyFilter),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySort),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplyIncludes),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnApplySparseFieldSet),
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.GetMeta)
             }, options => options.WithStrictOrdering());
         }
 
@@ -683,7 +763,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Moon), ResourceDefinitionHitCounter.ExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters)
+                (typeof(Moon), ResourceDefinitionExtensibilityPoint.OnRegisterQueryableHandlersForQueryStringParameters)
             }, options => options.WithStrictOrdering());
         }
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/StarDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/StarDefinition.cs
@@ -8,7 +8,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
     public sealed class StarDefinition : HitCountingResourceDefinition<Star, int>
     {
-        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Reading;
+        protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.Reading;
 
         public StarDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter)
             : base(resourceGraph, hitCounter)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/StarDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/StarDefinition.cs
@@ -2,27 +2,24 @@ using System.ComponentModel;
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Queries.Expressions;
-using JsonApiDotNetCore.Resources;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 {
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-    public sealed class StarDefinition : JsonApiResourceDefinition<Star, int>
+    public sealed class StarDefinition : HitCountingResourceDefinition<Star, int>
     {
-        private readonly ResourceDefinitionHitCounter _hitCounter;
+        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Reading;
 
         public StarDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter)
-            : base(resourceGraph)
+            : base(resourceGraph, hitCounter)
         {
             // This constructor will be resolved from the container, which means
             // you can take on any dependency that is also defined in the container.
-
-            _hitCounter = hitCounter;
         }
 
         public override SortExpression OnApplySort(SortExpression? existingSort)
         {
-            _hitCounter.TrackInvocation<Star>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySort);
+            base.OnApplySort(existingSort);
 
             return existingSort ?? GetDefaultSortOrder();
         }
@@ -38,7 +35,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
         public override PaginationExpression OnApplyPagination(PaginationExpression? existingPagination)
         {
-            _hitCounter.TrackInvocation<Star>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplyPagination);
+            base.OnApplyPagination(existingPagination);
 
             var maxPageSize = new PageSize(5);
 
@@ -53,7 +50,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading
 
         public override SparseFieldSetExpression? OnApplySparseFieldSet(SparseFieldSetExpression? existingSparseFieldSet)
         {
-            _hitCounter.TrackInvocation<Star>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnApplySparseFieldSet);
+            base.OnApplySparseFieldSet(existingSparseFieldSet);
 
             // @formatter:keep_existing_linebreaks true
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/ResourceDefinitionSerializationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/ResourceDefinitionSerializationTests.cs
@@ -83,8 +83,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize),
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -152,10 +152,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize),
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize),
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize),
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -194,7 +194,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -242,8 +242,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize),
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -283,7 +283,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -325,7 +325,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -381,8 +381,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnDeserialize),
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnDeserialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -450,7 +450,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -511,8 +511,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnDeserialize),
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnDeserialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -596,8 +596,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize),
-                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoints.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/ResourceDefinitionSerializationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/ResourceDefinitionSerializationTests.cs
@@ -83,8 +83,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize),
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -152,10 +152,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize),
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize),
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize),
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -194,7 +194,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -242,8 +242,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize),
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -283,7 +283,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -325,7 +325,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -381,8 +381,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnDeserialize),
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnDeserialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -450,7 +450,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -511,8 +511,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnDeserialize),
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnDeserialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 
@@ -596,8 +596,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
             hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
             {
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize),
-                (typeof(Student), ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize)
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize),
+                (typeof(Student), ResourceDefinitionExtensibilityPoint.OnSerialize)
             }, options => options.WithStrictOrdering());
         }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/StudentDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/StudentDefinition.cs
@@ -8,7 +8,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
     {
         private readonly IEncryptionService _encryptionService;
 
-        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Serialization;
+        protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.Serialization;
 
         public StudentDefinition(IResourceGraph resourceGraph, IEncryptionService encryptionService, ResourceDefinitionHitCounter hitCounter)
             : base(resourceGraph, hitCounter)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/StudentDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/StudentDefinition.cs
@@ -1,28 +1,27 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
-using JsonApiDotNetCore.Resources;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serialization
 {
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-    public sealed class StudentDefinition : JsonApiResourceDefinition<Student, int>
+    public sealed class StudentDefinition : HitCountingResourceDefinition<Student, int>
     {
         private readonly IEncryptionService _encryptionService;
-        private readonly ResourceDefinitionHitCounter _hitCounter;
+
+        protected override ResourceDefinitionExtensibilityPoint ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoint.Serialization;
 
         public StudentDefinition(IResourceGraph resourceGraph, IEncryptionService encryptionService, ResourceDefinitionHitCounter hitCounter)
-            : base(resourceGraph)
+            : base(resourceGraph, hitCounter)
         {
             // This constructor will be resolved from the container, which means
             // you can take on any dependency that is also defined in the container.
 
             _encryptionService = encryptionService;
-            _hitCounter = hitCounter;
         }
 
         public override void OnDeserialize(Student resource)
         {
-            _hitCounter.TrackInvocation<Student>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnDeserialize);
+            base.OnDeserialize(resource);
 
             if (!string.IsNullOrEmpty(resource.SocialSecurityNumber))
             {
@@ -32,7 +31,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serializat
 
         public override void OnSerialize(Student resource)
         {
-            _hitCounter.TrackInvocation<Student>(ResourceDefinitionHitCounter.ExtensibilityPoint.OnSerialize);
+            base.OnSerialize(resource);
 
             if (!string.IsNullOrEmpty(resource.SocialSecurityNumber))
             {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/SerializationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/SerializationTests.cs
@@ -37,6 +37,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization
             options.IncludeExceptionStackTraceInErrors = false;
             options.AllowClientGeneratedIds = true;
             options.IncludeJsonApiVersion = false;
+            options.IncludeTotalResourceCount = true;
 
             if (!options.SerializerOptions.Converters.Any(converter => converter is JsonTimeSpanConverter))
             {
@@ -111,7 +112,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization
             responseDocument.Should().BeJson(@"{
   ""links"": {
     ""self"": ""http://localhost/meetings?include=attendees"",
-    ""first"": ""http://localhost/meetings?include=attendees""
+    ""first"": ""http://localhost/meetings?include=attendees"",
+    ""last"": ""http://localhost/meetings?include=attendees""
   },
   ""data"": [
     {
@@ -164,7 +166,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization
         ""self"": ""http://localhost/meetingAttendees/" + meeting.Attendees[0].StringId + @"""
       }
     }
-  ]
+  ],
+  ""meta"": {
+    ""total"": 1
+  }
 }");
         }
 
@@ -239,7 +244,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization
             responseDocument.Should().BeJson(@"{
   ""links"": {
     ""self"": ""http://localhost/meetings/?include=attendees"",
-    ""first"": ""http://localhost/meetings/?include=attendees""
+    ""first"": ""http://localhost/meetings/?include=attendees"",
+    ""last"": ""http://localhost/meetings/?include=attendees""
   },
   ""data"": [
     {
@@ -268,7 +274,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization
       }
     }
   ],
-  ""included"": []
+  ""included"": [],
+  ""meta"": {
+    ""total"": 1
+  }
 }");
         }
 
@@ -458,7 +467,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization
             responseDocument.Should().BeJson(@"{
   ""links"": {
     ""self"": ""http://localhost/meetings/" + meeting.StringId + @"/attendees"",
-    ""first"": ""http://localhost/meetings/" + meeting.StringId + @"/attendees""
+    ""first"": ""http://localhost/meetings/" + meeting.StringId + @"/attendees"",
+    ""last"": ""http://localhost/meetings/" + meeting.StringId + @"/attendees""
   },
   ""data"": [
     {
@@ -479,7 +489,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization
         ""self"": ""http://localhost/meetingAttendees/" + meeting.Attendees[0].StringId + @"""
       }
     }
-  ]
+  ],
+  ""meta"": {
+    ""total"": 1
+  }
 }");
         }
 
@@ -508,7 +521,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization
     ""self"": ""http://localhost/meetings/" + meeting.StringId + @"/attendees"",
     ""first"": ""http://localhost/meetings/" + meeting.StringId + @"/attendees""
   },
-  ""data"": []
+  ""data"": [],
+  ""meta"": {
+    ""total"": 0
+  }
 }");
         }
 
@@ -572,7 +588,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization
   ""links"": {
     ""self"": ""http://localhost/meetings/" + meeting.StringId + @"/relationships/attendees"",
     ""related"": ""http://localhost/meetings/" + meeting.StringId + @"/attendees"",
-    ""first"": ""http://localhost/meetings/" + meeting.StringId + @"/relationships/attendees""
+    ""first"": ""http://localhost/meetings/" + meeting.StringId + @"/relationships/attendees"",
+    ""last"": ""http://localhost/meetings/" + meeting.StringId + @"/relationships/attendees""
   },
   ""data"": [
     {
@@ -583,7 +600,10 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization
       ""type"": ""meetingAttendees"",
       ""id"": """ + meetingIds[1] + @"""
     }
-  ]
+  ],
+  ""meta"": {
+    ""total"": 2
+  }
 }");
         }
 

--- a/test/UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/test/UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -314,7 +314,7 @@ namespace UnitTests.Extensions
                 throw new NotImplementedException();
             }
 
-            public Task<int> CountAsync(FilterExpression? topFilter, CancellationToken cancellationToken)
+            public Task<int> CountAsync(FilterExpression? filter, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }
@@ -369,7 +369,7 @@ namespace UnitTests.Extensions
                 throw new NotImplementedException();
             }
 
-            public Task<int> CountAsync(FilterExpression? topFilter, CancellationToken cancellationToken)
+            public Task<int> CountAsync(FilterExpression? filter, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
Sets `last`/`next` paging links and adds `meta.total` on secondary/relationship endpoint responses when `options.IncludeTotalResourceCount` is set to `true`. Supports both one-to-many and many-to-many relationships.

Fixes JSON:API spec compliance by not un-escaping square brackets in response links.
Bugfix: `links.next` was not set on full page at relationship endpoint.

Fixes #1010.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](./.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
- [ ] N/A: Created issue to update [Templates](https://github.com/json-api-dotnet/Templates/issues/new): {ISSUE_NUMBER}
