### PR TITLE
Require IDs to be numeric in request/response JSON

### DIFF
--- a/src/JsonApiDotNetCore/Serialization/JsonConverters/ResourceObjectConverter.cs
+++ b/src/JsonApiDotNetCore/Serialization/JsonConverters/ResourceObjectConverter.cs
@@ -68,15 +68,14 @@ public sealed class ResourceObjectConverter : JsonObjectConverter<ResourceObject
                     {
                         case "id":
                         {
-                            if (reader.TokenType != JsonTokenType.String)
+                            if (reader.TokenType == JsonTokenType.Number)
                             {
-                                // Newtonsoft.Json used to auto-convert number to strings, while System.Text.Json does not. This is so likely
-                                // to hit users during upgrade that we special-case for this and produce a helpful error message.
-                                var jsonElement = ReadSubTree<JsonElement>(ref reader, options);
-                                throw new JsonException($"Failed to convert ID '{jsonElement}' of type '{jsonElement.ValueKind}' to type 'String'.");
+                                resourceObject.NumericId = reader.GetInt64();
                             }
-
-                            resourceObject.Id = reader.GetString();
+                            else
+                            {
+                                resourceObject.Id = reader.GetString();
+                            }
                             break;
                         }
                         case "lid":
@@ -228,9 +227,9 @@ public sealed class ResourceObjectConverter : JsonObjectConverter<ResourceObject
 
         writer.WriteString(TypeText, value.Type);
 
-        if (value.Id != null)
+        if (value.NumericId != default)
         {
-            writer.WriteString(IdText, value.Id);
+            writer.WriteNumber(IdText, value.NumericId);
         }
 
         if (value.Lid != null)

--- a/src/JsonApiDotNetCore/Serialization/Objects/AtomicReference.cs
+++ b/src/JsonApiDotNetCore/Serialization/Objects/AtomicReference.cs
@@ -13,9 +13,15 @@ public sealed class AtomicReference : IResourceIdentity
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public string? Type { get; set; }
 
+    [JsonIgnore]
+    public string? Id
+    {
+        get => NumericId == default ? null : NumericId.ToString();
+        set => NumericId = value == null ? 0 : int.Parse(value);
+    }
+
     [JsonPropertyName("id")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Id { get; set; }
+    public long NumericId { get; set; }
 
     [JsonPropertyName("lid")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/JsonApiDotNetCore/Serialization/Objects/ResourceIdentifierObject.cs
+++ b/src/JsonApiDotNetCore/Serialization/Objects/ResourceIdentifierObject.cs
@@ -13,9 +13,15 @@ public sealed class ResourceIdentifierObject : IResourceIdentity
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public string? Type { get; set; }
 
+    [JsonIgnore]
+    public string? Id
+    {
+        get => NumericId == default ? null : NumericId.ToString();
+        set => NumericId = value == null ? 0 : int.Parse(value);
+    }
+
     [JsonPropertyName("id")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Id { get; set; }
+    public long NumericId { get; set; }
 
     [JsonPropertyName("lid")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/JsonApiDotNetCore/Serialization/Objects/ResourceObject.cs
+++ b/src/JsonApiDotNetCore/Serialization/Objects/ResourceObject.cs
@@ -13,9 +13,15 @@ public sealed class ResourceObject : IResourceIdentity
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public string? Type { get; set; }
 
+    [JsonIgnore]
+    public string? Id
+    {
+        get => NumericId == default ? null : NumericId.ToString();
+        set => NumericId = value == null ? 0 : int.Parse(value);
+    }
+
     [JsonPropertyName("id")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Id { get; set; }
+    public long NumericId { get; set; }
 
     [JsonPropertyName("lid")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]


### PR DESCRIPTION
In response to the question at https://gitter.im/json-api-dotnet-core/Lobby?at=62046a066e4c1e1c84583264:

_"We used to be able to include "id" values as int and have published our openapi spec as such. While testing with v5.0.0-pre1 this is now explicitly disabled. Would it be possible to remove that restriction?"_

The approach taken in this PR is to make the "id" field in request/response bodies numeric. It does not allow string IDs, and therefore using GUIDs is no longer possible.

To make this work, changes to the JADNC source code are required. The easiest way to deal with that is to fork the repo, so future changes can easily be merged in.