### PR TITLE
Bugfix: hide Self link in included resources for missing controller

### DIFF
--- a/src/JsonApiDotNetCore/Serialization/Response/LinkBuilder.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/LinkBuilder.cs
@@ -255,14 +255,6 @@ public class LinkBuilder : ILinkBuilder
     private string? GetLinkForResourceSelf(ResourceType resourceType, IIdentifiable resource)
     {
         string? controllerName = _controllerResourceMapping.GetControllerNameForResourceType(resourceType);
-
-        if (controllerName == null)
-        {
-            // When passing null to RenderLinkForAction, it uses the controller for the current endpoint. This is incorrect for
-            // included resources of a different resource type: it should hide their Self links when there's no controller for them.
-            return null;
-        }
-
         IDictionary<string, object?> routeValues = GetRouteValues(resource.StringId!, null);
 
         return RenderLinkForAction(controllerName, GetPrimaryControllerActionName, routeValues);
@@ -320,6 +312,13 @@ public class LinkBuilder : ILinkBuilder
 
     protected virtual string? RenderLinkForAction(string? controllerName, string actionName, IDictionary<string, object?> routeValues)
     {
+        if (controllerName == null)
+        {
+            // When passing null to LinkGenerator, it uses the controller for the current endpoint. This is incorrect for
+            // included resources of a different resource type: it should hide its links when there's no controller for them.
+            return null;
+        }
+
         return _options.UseRelativeLinks
             ? _linkGenerator.GetPathByAction(HttpContext, actionName, controllerName, routeValues)
             : _linkGenerator.GetUriByAction(HttpContext, actionName, controllerName, routeValues);

--- a/src/JsonApiDotNetCore/Serialization/Response/LinkBuilder.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/LinkBuilder.cs
@@ -255,6 +255,14 @@ public class LinkBuilder : ILinkBuilder
     private string? GetLinkForResourceSelf(ResourceType resourceType, IIdentifiable resource)
     {
         string? controllerName = _controllerResourceMapping.GetControllerNameForResourceType(resourceType);
+
+        if (controllerName == null)
+        {
+            // When passing null to RenderLinkForAction, it uses the controller for the current endpoint. This is incorrect for
+            // included resources of a different resource type: it should hide their Self links when there's no controller for them.
+            return null;
+        }
+
         IDictionary<string, object?> routeValues = GetRouteValues(resource.StringId!, null);
 
         return RenderLinkForAction(controllerName, GetPrimaryControllerActionName, routeValues);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/LinkInclusionIncludeTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/LinkInclusionIncludeTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using FluentAssertions;
+using JsonApiDotNetCore.Serialization.Objects;
+using TestBuildingBlocks;
+using Xunit;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Links;
+
+public sealed class LinkInclusionIncludeTests : IClassFixture<IntegrationTestContext<TestableStartup<LinksDbContext>, LinksDbContext>>
+{
+    private readonly IntegrationTestContext<TestableStartup<LinksDbContext>, LinksDbContext> _testContext;
+    private readonly LinksFakers _fakers = new();
+
+    public LinkInclusionIncludeTests(IntegrationTestContext<TestableStartup<LinksDbContext>, LinksDbContext> testContext)
+    {
+        _testContext = testContext;
+
+        testContext.UseController<PhotoLocationsController>();
+    }
+
+    [Fact]
+    public async Task Hides_Self_link_in_included_resources_for_unregistered_controllers()
+    {
+        // Arrange
+        PhotoLocation location = _fakers.PhotoLocation.Generate();
+        location.Photo = _fakers.Photo.Generate();
+        location.Album = _fakers.PhotoAlbum.Generate();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            dbContext.PhotoLocations.Add(location);
+            await dbContext.SaveChangesAsync();
+        });
+
+        string route = $"/photoLocations/{location.StringId}?include=photo,album";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
+
+        responseDocument.Included.ShouldHaveCount(2);
+
+        responseDocument.Included.Should().ContainSingle(resource => resource.Type == "photos").Subject.With(resource =>
+        {
+            resource.Links.Should().BeNull();
+
+            resource.Relationships.ShouldContainKey("location").With(value =>
+            {
+                value.ShouldNotBeNull();
+                value.Links.ShouldNotBeNull();
+            });
+        });
+
+        responseDocument.Included.Should().ContainSingle(resource => resource.Type == "photoAlbums").Subject.With(resource =>
+        {
+            resource.Links.Should().BeNull();
+        });
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/LinkInclusionIncludeTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/LinkInclusionIncludeTests.cs
@@ -19,7 +19,7 @@ public sealed class LinkInclusionIncludeTests : IClassFixture<IntegrationTestCon
     }
 
     [Fact]
-    public async Task Hides_Self_link_in_included_resources_for_unregistered_controllers()
+    public async Task Hides_links_for_unregistered_controllers()
     {
         // Arrange
         PhotoLocation location = _fakers.PhotoLocation.Generate();
@@ -40,22 +40,26 @@ public sealed class LinkInclusionIncludeTests : IClassFixture<IntegrationTestCon
         // Assert
         httpResponse.Should().HaveStatusCode(HttpStatusCode.OK);
 
+        responseDocument.Data.SingleValue.ShouldNotBeNull();
+
+        responseDocument.Data.SingleValue.Relationships.ShouldContainKey("photo").With(value =>
+        {
+            value.ShouldNotBeNull();
+            value.Links.ShouldNotBeNull();
+        });
+
         responseDocument.Included.ShouldHaveCount(2);
 
         responseDocument.Included.Should().ContainSingle(resource => resource.Type == "photos").Subject.With(resource =>
         {
             resource.Links.Should().BeNull();
-
-            resource.Relationships.ShouldContainKey("location").With(value =>
-            {
-                value.ShouldNotBeNull();
-                value.Links.ShouldNotBeNull();
-            });
+            resource.Relationships.Should().BeNull();
         });
 
         responseDocument.Included.Should().ContainSingle(resource => resource.Type == "photoAlbums").Subject.With(resource =>
         {
             resource.Links.Should().BeNull();
+            resource.Relationships.Should().BeNull();
         });
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/LinkInclusionTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/LinkInclusionTests.cs
@@ -17,6 +17,7 @@ public sealed class LinkInclusionTests : IClassFixture<IntegrationTestContext<Te
 
         testContext.UseController<PhotosController>();
         testContext.UseController<PhotoLocationsController>();
+        testContext.UseController<PhotoAlbumsController>();
     }
 
     [Fact]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToOneRelationshipTests.cs
@@ -22,6 +22,7 @@ public sealed class CreateResourceWithToOneRelationshipTests : IClassFixture<Int
         testContext.UseController<WorkItemGroupsController>();
         testContext.UseController<WorkItemsController>();
         testContext.UseController<RgbColorsController>();
+        testContext.UseController<UserAccountsController>();
 
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
         options.AllowClientGeneratedIds = true;

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Fetching/FetchResourceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Fetching/FetchResourceTests.cs
@@ -17,6 +17,7 @@ public sealed class FetchResourceTests : IClassFixture<IntegrationTestContext<Te
 
         testContext.UseController<WorkItemsController>();
         testContext.UseController<UserAccountsController>();
+        testContext.UseController<WorkTagsController>();
     }
 
     [Fact]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Resources/ReplaceToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Resources/ReplaceToManyRelationshipTests.cs
@@ -19,6 +19,7 @@ public sealed class ReplaceToManyRelationshipTests : IClassFixture<IntegrationTe
         _testContext = testContext;
 
         testContext.UseController<WorkItemsController>();
+        testContext.UseController<UserAccountsController>();
 
         testContext.ConfigureServicesAfterStartup(services =>
         {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateToOneRelationshipTests.cs
@@ -20,6 +20,7 @@ public sealed class UpdateToOneRelationshipTests : IClassFixture<IntegrationTest
         testContext.UseController<WorkItemsController>();
         testContext.UseController<WorkItemGroupsController>();
         testContext.UseController<RgbColorsController>();
+        testContext.UseController<UserAccountsController>();
 
         testContext.ConfigureServicesAfterStartup(services =>
         {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/WorkTag.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/WorkTag.cs
@@ -5,6 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ReadWrite;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.ReadWrite")]
 public sealed class WorkTag : Identifiable<int>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/UnitTests/Links/LinkInclusionTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Links/LinkInclusionTests.cs
@@ -69,7 +69,10 @@ public sealed class LinkInclusionTests
             PrimaryId = "1",
             IsCollection = true,
             Kind = EndpointKind.Relationship,
-            Relationship = new HasOneAttribute()
+            Relationship = new HasOneAttribute
+            {
+                LeftType = exampleResourceType
+            }
         };
 
         var paginationContext = new PaginationContext

--- a/test/JsonApiDotNetCoreTests/UnitTests/Links/LinkInclusionTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Links/LinkInclusionTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Humanizer;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.Queries;
@@ -386,7 +387,7 @@ public sealed class LinkInclusionTests
 
         public string? GetControllerNameForResourceType(ResourceType? resourceType)
         {
-            return null;
+            return resourceType == null ? null : $"{resourceType.PublicName.Pascalize()}Controller";
         }
     }
 


### PR DESCRIPTION
Bugfix: hide Self link in included resources when there's no registered controller for it. Before, it would use the controller URL from the current request in the Self link, which is wrong.

Example response from `GET /photoLocations`, assuming `PhotoAlbumsController` does not exist:
```json
{
  "data": {
    "type": "photoLocations"
    ...
  },
  "included": [
    {
      "type": "photoAlbums",
      },
      "relationships": {
        "photos": {
          "links": {
            "self": "http://localhost/photoLocations/e8467a26-a8d8-4ba4-934c-646c26dd6ebd/relationships/photos",
            "related": "http://localhost/photoLocations/e8467a26-a8d8-4ba4-934c-646c26dd6ebd/photos"
          }
        }
      }
      "links": {
        "self": "http://localhost/photoLocations/7e15ef84-0182-4fb4-805f-62b1e8f8a6e1" // <-- WRONG
      }
    }
  ]
}
```
After the fix:
```json
{
  "data": {
    "type": "photoLocations"
    ...
  },
  "included": [
    {
      "type": "photoAlbums",
      },
      "relationships": {
        "photos": {
          "links": {
            "self": "http://localhost/photoLocations/e8467a26-a8d8-4ba4-934c-646c26dd6ebd/relationships/photos",
            "related": "http://localhost/photoLocations/e8467a26-a8d8-4ba4-934c-646c26dd6ebd/photos"
          }
        }
      }
    }
  ]
}
```

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](./.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
