### PR TITLE
Replaced references to Error in docs, which was renamed to ErrorObject

### DIFF
--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -1,13 +1,13 @@
 # Errors
 
-Errors returned will contain only the properties that are set on the `Error` class. Custom fields can be added through `Error.Meta`.
-You can create a custom error by throwing a `JsonApiException` (which accepts an `Error` instance), or returning an `Error` instance from an `ActionResult` in a controller.
-Please keep in mind that JSON:API requires Title to be a generic message, while Detail should contain information about the specific problem occurence.
+Errors returned will contain only the properties that are set on the `ErrorObject` class. Custom fields can be added through `ErrorObject.Meta`.
+You can create a custom error by throwing a `JsonApiException` (which accepts an `ErrorObject` instance), or returning an `ErrorObject` instance from an `ActionResult` in a controller.
+Please keep in mind that JSON:API requires `Title` to be a generic message, while `Detail` should contain information about the specific problem occurence.
 
 From a controller method:
 
 ```c#
-return Conflict(new Error(HttpStatusCode.Conflict)
+return Conflict(new ErrorObject(HttpStatusCode.Conflict)
 {
     Title = "Target resource was modified by another user.",
     Detail = $"User {userName} changed the {resourceField} field on {resourceName} resource."
@@ -17,7 +17,7 @@ return Conflict(new Error(HttpStatusCode.Conflict)
 From other code:
 
 ```c#
-throw new JsonApiException(new Error(HttpStatusCode.Conflict)
+throw new JsonApiException(new ErrorObject(HttpStatusCode.Conflict)
 {
     Title = "Target resource was modified by another user.",
     Detail = $"User {userName} changed the {resourceField} field on {resourceName} resource."
@@ -75,7 +75,7 @@ public class CustomExceptionHandler : ExceptionHandler
         {
             return new[]
             {
-                new Error(HttpStatusCode.Conflict)
+                new ErrorObject(HttpStatusCode.Conflict)
                 {
                     Title = "Product is temporarily available.",
                     Detail = $"Product {productOutOfStock.ProductId} " +

--- a/docs/usage/extensibility/resource-definitions.md
+++ b/docs/usage/extensibility/resource-definitions.md
@@ -200,7 +200,7 @@ public class EmployeeDefinition : JsonApiResourceDefinition<Employee, int>
         if (existingIncludes.Any(include =>
             include.Relationship.Property.Name == nameof(Employee.Manager)))
         {
-            throw new JsonApiException(new Error(HttpStatusCode.BadRequest)
+            throw new JsonApiException(new ErrorObject(HttpStatusCode.BadRequest)
             {
                 Title = "Including the manager of employees is not permitted."
             });


### PR DESCRIPTION

#### QUALITY CHECKLIST
- N/A: Changes implemented in code
- N/A: Complies with our [contributing guidelines](./.github/CONTRIBUTING.md)
- N/A: Adapted tests
- [x] Documentation updated
