### PR TITLE
Pinned versions of dependent packages for the next major release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <EFCoreVersion>6.0.*</EFCoreVersion>
     <EFCorePostgresVersion>6.0.*</EFCorePostgresVersion>
     <MicrosoftCodeAnalysisVersion>4.1.*</MicrosoftCodeAnalysisVersion>
-    <HumanizerVersion>2.*</HumanizerVersion>
+    <HumanizerVersion>2.14.1</HumanizerVersion>
     <JsonApiDotNetCoreVersionPrefix>5.0.0</JsonApiDotNetCoreVersionPrefix>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodingGuidelines.ruleset</CodeAnalysisRuleSet>
     <WarningLevel>9999</WarningLevel>

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -39,8 +39,8 @@
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="Humanizer.Core" Version="$(HumanizerVersion)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="SauceControl.InheritDoc" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/test/TestBuildingBlocks/TestBuildingBlocks.csproj
+++ b/test/TestBuildingBlocks/TestBuildingBlocks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(TargetFrameworkName)</TargetFramework>
   </PropertyGroup>
@@ -12,6 +12,7 @@
     <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)" PrivateAssets="All" />
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(AspNetVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(EFCorePostgresVersion)" />


### PR DESCRIPTION
This prevents future minor/patch releases from unintendedly requiring higher versions of dependent packages, caused by ongoing package updates in the JADNC solution.

How NuGet package dependencies in .NET work:
- Package references are transient, which means that projects inherit package references from their dependent projects. Therefore there's no need to repeat dependencies in child project files. For example, when project X references package P, and project Y depends on project X, then project Y implicitly references package P (except when P was referenced using PrivateAssets in X).
- To use the latest version of a dependent package, it must be referenced explicitly. For example, when package A v1.0.3 references package B v1.0.0, while the latest version of package B is v1.0.2, package B must be referenced explicitly to use its latest version.

The rationale here is as follows:
- JsonApiDotNetCore* projects (our NuGets) require a pinned version of dependent packages. Currently, these are Microsoft.EntityFrameworkCore and Humanizer.Core. The rest are dev-only dependencies.
- Example and test projects explicitly depend on the latest release of EF Core and Npgsql, so we're always building against the latest versions. This enables us to notice breaking changes in patch releases of dependent packages before we release a new version.
- Because Microsoft.EntityFrameworkCore* packages are always published together, there's no need to explicitly reference its core package. For example, by referencing just Microsoft.EntityFrameworkCore.Sqlite v6.0.3, we can trust that it depends on Microsoft.EntityFrameworkCore v6.0.3 and nothing else, so there's no reason to explicitly reference Microsoft.EntityFrameworkCore as well.
- Npgsql.EntityFrameworkCore.PostgreSQL is maintained by another team, and there's usually a small window of divergence. Therefore we do reference both Microsoft.EntityFrameworkCore* and Npgsql.EntityFrameworkCore.PostgreSQL explicitly.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](./.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
