### PR TITLE
Fixed: Sorting by ID from a lambda expression fails with error

### DIFF
--- a/src/JsonApiDotNetCore/Resources/SortExpressionLambdaConverter.cs
+++ b/src/JsonApiDotNetCore/Resources/SortExpressionLambdaConverter.cs
@@ -116,7 +116,10 @@ internal sealed class SortExpressionLambdaConverter
     {
         if (expression is MemberExpression memberExpression)
         {
-            ResourceType resourceType = _resourceGraph.GetResourceType(memberExpression.Member.DeclaringType!);
+            ResourceType resourceType = memberExpression.Member.Name == nameof(Identifiable<object>.Id) && memberExpression.Expression != null
+                ? _resourceGraph.GetResourceType(memberExpression.Expression.Type)
+                : _resourceGraph.GetResourceType(memberExpression.Member.DeclaringType!);
+
             AttrAttribute? attribute = resourceType.FindAttributeByPropertyName(memberExpression.Member.Name);
 
             if (attribute != null)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/WheelSortDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/WheelSortDefinition.cs
@@ -43,6 +43,7 @@ public sealed class WheelSortDefinition : JsonApiResourceDefinition<Wheel, long>
     {
         AttrAttribute paintColorAttribute = ResourceGraph.GetResourceType<ChromeWheel>().GetAttributeByPropertyName(nameof(ChromeWheel.PaintColor));
         AttrAttribute hasTubeAttribute = ResourceGraph.GetResourceType<CarbonWheel>().GetAttributeByPropertyName(nameof(CarbonWheel.HasTube));
+        AttrAttribute idAttribute = ResourceGraph.GetResourceType<Wheel>().GetAttributeByPropertyName(nameof(Wheel.Id));
 
         var cylinderCountChain = new ResourceFieldChainExpression(ImmutableArray.Create<ResourceFieldAttribute>(
             ResourceGraph.GetResourceType<Wheel>().GetRelationshipByPropertyName(nameof(Wheel.Vehicle)),
@@ -53,7 +54,8 @@ public sealed class WheelSortDefinition : JsonApiResourceDefinition<Wheel, long>
         {
             new SortElementExpression(new ResourceFieldChainExpression(paintColorAttribute), true),
             new SortElementExpression(new ResourceFieldChainExpression(hasTubeAttribute), false),
-            new SortElementExpression(new CountExpression(cylinderCountChain), true)
+            new SortElementExpression(new CountExpression(cylinderCountChain), true),
+            new SortElementExpression(new ResourceFieldChainExpression(idAttribute), true)
         }.ToImmutableArray());
     }
 
@@ -63,7 +65,8 @@ public sealed class WheelSortDefinition : JsonApiResourceDefinition<Wheel, long>
         {
             (wheel => (wheel as ChromeWheel)!.PaintColor, ListSortDirection.Ascending),
             (wheel => ((CarbonWheel)wheel).HasTube, ListSortDirection.Descending),
-            (wheel => ((GasolineEngine)((Car)wheel.Vehicle!).Engine).Cylinders.Count, ListSortDirection.Ascending)
+            (wheel => ((GasolineEngine)((Car)wheel.Vehicle!).Engine).Cylinders.Count, ListSortDirection.Ascending),
+            (wheel => wheel.Id, ListSortDirection.Ascending)
         });
     }
 }


### PR DESCRIPTION
Fixed: Sorting by ID from a lambda expression in a resource definition fails with error:

```
Type 'JsonApiDotNetCore.Resources.Identifiable`1[System.Int64]' does not exist in the resource graph.
```

The reason for failure is that in an expression like `book => book.Id`, the `Id` property is declared on `Identifiable<>`. The fix is to look at the type of the containing expression (which is `Book` in this case) when the `Id` property is used.

Affected versions: v5.0

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](./.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
