### PR TITLE
Serialization/compression example

### DIFF
--- a/src/Examples/GettingStarted/Controllers/BooksController.cs
+++ b/src/Examples/GettingStarted/Controllers/BooksController.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using GettingStarted.Models;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Serialization.Objects;
+using JsonApiDotNetCore.Serialization.Response;
+using JsonApiDotNetCore.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GettingStarted.Controllers;
+
+partial class BooksController
+{
+    private readonly IJsonApiOptions _options;
+    private readonly IResourceService<Book, int> _resourceService;
+    private readonly IResponseModelAdapter _responseModelAdapter;
+
+    [ActivatorUtilitiesConstructor]
+    public BooksController(IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IResourceService<Book, int> resourceService,
+        IResponseModelAdapter responseModelAdapter)
+        : base(options, resourceGraph, loggerFactory, resourceService)
+    {
+        _options = options;
+        _resourceService = resourceService;
+        _responseModelAdapter = responseModelAdapter;
+    }
+
+    // Here we can use all the JSON:API features in the export, such as includes, sorting and sparse fieldsets.
+    // http://localhost:14141/api/books/exportZip?include=author&sort=author.name&fields[books]=title,author
+
+    [HttpGet("exportZip")]
+    public async Task<IActionResult> GetZipFileAsync(CancellationToken cancellationToken)
+    {
+        IReadOnlyCollection<Book> books = await _resourceService.GetAsync(cancellationToken);
+
+        var zipFileBuilder = new ZipFileBuilder();
+
+        await WriteResourcesToZipFileAsync(books, zipFileBuilder);
+
+        Stream zipStream = zipFileBuilder.Build();
+        return File(zipStream, "application/zip", "Export.zip");
+    }
+
+    private async Task WriteResourcesToZipFileAsync<TResource>(IEnumerable<TResource> resources, ZipFileBuilder zipFileBuilder)
+        where TResource : class, IIdentifiable
+    {
+        const string fileName = "books.json";
+        string json = ResourcesToJson(resources);
+
+        await zipFileBuilder.IncludeFileAsync(fileName, json);
+    }
+
+    private string ResourcesToJson<TResource>(IEnumerable<TResource> resources)
+        where TResource : class, IIdentifiable
+    {
+        Document document = _responseModelAdapter.Convert(resources);
+        return JsonSerializer.Serialize(document, _options.SerializerOptions);
+    }
+}

--- a/src/Examples/GettingStarted/Controllers/ExportsController.cs
+++ b/src/Examples/GettingStarted/Controllers/ExportsController.cs
@@ -1,0 +1,187 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using GettingStarted.Data;
+using GettingStarted.Models;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Middleware;
+using JsonApiDotNetCore.Queries.Expressions;
+using JsonApiDotNetCore.Queries.Internal;
+using JsonApiDotNetCore.QueryStrings;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+using JsonApiDotNetCore.Serialization.Objects;
+using JsonApiDotNetCore.Serialization.Response;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GettingStarted.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public sealed class ExportsController : ControllerBase
+{
+    private readonly SampleDbContext _dbContext;
+    private readonly IJsonApiOptions _options;
+    private readonly IResourceGraph _resourceGraph;
+    private readonly IMetaBuilder _metaBuilder;
+    private readonly IResourceDefinitionAccessor _resourceDefinitionAccessor;
+
+    public ExportsController(SampleDbContext dbContext, IJsonApiOptions options, IResourceGraph resourceGraph, IMetaBuilder metaBuilder,
+        IResourceDefinitionAccessor resourceDefinitionAccessor)
+    {
+        _dbContext = dbContext;
+        _options = options;
+        _resourceGraph = resourceGraph;
+        _metaBuilder = metaBuilder;
+        _resourceDefinitionAccessor = resourceDefinitionAccessor;
+    }
+
+    /// <summary>
+    /// Returns a JSON:API response, containing all books and their associated authors.
+    /// </summary>
+    [HttpGet("asJson")]
+    public async Task<IActionResult> GetJsonAsync(CancellationToken cancellationToken)
+    {
+        List<Book> booksWithAuthors = await _dbContext.Books.Include(book => book.Author).ToListAsync(cancellationToken);
+
+        ResourceType bookType = _resourceGraph.GetResourceType<Book>();
+        RelationshipAttribute bookAuthorRelationship = bookType.GetRelationshipByPropertyName(nameof(Book.Author));
+
+        var includeExpression =
+            new IncludeExpression(ImmutableHashSet<IncludeElementExpression>.Empty.Add(new IncludeElementExpression(bookAuthorRelationship)));
+
+        string json = ResourcesToJson(booksWithAuthors, includeExpression);
+        return Ok(json);
+    }
+
+    /// <summary>
+    /// Exports all books and all people to individual .json files and returns a .zip file containing them.
+    /// </summary>
+    [HttpGet("asZipFile")]
+    public async Task<IActionResult> GetZipFileAsync(CancellationToken cancellationToken)
+    {
+        List<Book> books = await _dbContext.Books.ToListAsync(cancellationToken);
+        List<Person> people = await _dbContext.People.ToListAsync(cancellationToken);
+
+        var zipFileBuilder = new ZipFileBuilder();
+
+        await WriteResourcesToZipFileAsync(books, zipFileBuilder);
+        await WriteResourcesToZipFileAsync(people, zipFileBuilder);
+
+        Stream zipStream = zipFileBuilder.Build();
+        return File(zipStream, "application/zip", "Export.zip");
+    }
+
+    private async Task WriteResourcesToZipFileAsync<TResource>(IEnumerable<TResource> resources, ZipFileBuilder zipFileBuilder)
+        where TResource : class, IIdentifiable
+    {
+        string json = ResourcesToJson(resources, null);
+
+        ResourceType resourceType = _resourceGraph.GetResourceType<TResource>();
+        string fileName = $"{resourceType}.json";
+
+        await zipFileBuilder.IncludeFileAsync(fileName, json);
+    }
+
+    private string ResourcesToJson<TResource>(IEnumerable<TResource> resources, IncludeExpression? include)
+        where TResource : class, IIdentifiable
+    {
+        ResourceType resourceType = _resourceGraph.GetResourceType<TResource>();
+
+        var request = new JsonApiRequest
+        {
+            Kind = EndpointKind.Primary,
+            PrimaryResourceType = resourceType,
+            IsCollection = true,
+            IsReadOnly = true
+        };
+
+        var linksBuilder = new HiddenLinksBuilder();
+        var includeCache = new IncludeCache(include);
+        var sparseFieldSetCache = new EveryFieldCache();
+        var queryStringAccessor = new EmptyQueryStringAccessor();
+
+        var adapter = new ResponseModelAdapter(request, _options, linksBuilder, _metaBuilder, _resourceDefinitionAccessor, includeCache, sparseFieldSetCache,
+            queryStringAccessor);
+
+        Document document = adapter.Convert(resources);
+        return JsonSerializer.Serialize(document, _options.SerializerOptions);
+    }
+
+    /// <summary>
+    /// Enables to explicitly set the inclusion chain to use, which is normally based on the '?include=' query string parameter.
+    /// </summary>
+    private sealed class IncludeCache : IEvaluatedIncludeCache
+    {
+        private IncludeExpression? _include;
+
+        public IncludeCache(IncludeExpression? include)
+        {
+            _include = include;
+        }
+
+        public void Set(IncludeExpression include)
+        {
+            _include = include;
+        }
+
+        public IncludeExpression? Get()
+        {
+            return _include;
+        }
+    }
+
+    /// <summary>
+    /// Hides all JSON:API links.
+    /// </summary>
+    private sealed class HiddenLinksBuilder : ILinkBuilder
+    {
+        public TopLevelLinks? GetTopLevelLinks()
+        {
+            return null;
+        }
+
+        public ResourceLinks? GetResourceLinks(ResourceType resourceType, IIdentifiable resource)
+        {
+            return null;
+        }
+
+        public RelationshipLinks? GetRelationshipLinks(RelationshipAttribute relationship, IIdentifiable leftResource)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Forces to return all fields (attributes and relationships), which is normally based on the '?fields=' query string parameter.
+    /// </summary>
+    private sealed class EveryFieldCache : ISparseFieldSetCache
+    {
+        public IImmutableSet<ResourceFieldAttribute> GetSparseFieldSetForQuery(ResourceType resourceType)
+        {
+            return resourceType.Fields.ToImmutableHashSet();
+        }
+
+        public IImmutableSet<AttrAttribute> GetIdAttributeSetForRelationshipQuery(ResourceType resourceType)
+        {
+            return resourceType.Attributes.ToImmutableHashSet();
+        }
+
+        public IImmutableSet<ResourceFieldAttribute> GetSparseFieldSetForSerializer(ResourceType resourceType)
+        {
+            return resourceType.Fields.ToImmutableHashSet();
+        }
+
+        public void Reset()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Ignores any incoming query string parameters.
+    /// </summary>
+    private sealed class EmptyQueryStringAccessor : IRequestQueryStringAccessor
+    {
+        public IQueryCollection Query { get; } = new QueryCollection();
+    }
+}

--- a/src/Examples/GettingStarted/Data/SampleDbContext.cs
+++ b/src/Examples/GettingStarted/Data/SampleDbContext.cs
@@ -8,6 +8,7 @@ namespace GettingStarted.Data;
 public class SampleDbContext : DbContext
 {
     public DbSet<Book> Books => Set<Book>();
+    public DbSet<Person> People => Set<Person>();
 
     public SampleDbContext(DbContextOptions<SampleDbContext> options)
         : base(options)

--- a/src/Examples/GettingStarted/Program.cs
+++ b/src/Examples/GettingStarted/Program.cs
@@ -13,8 +13,9 @@ builder.Services.AddJsonApi<SampleDbContext>(options =>
     options.Namespace = "api";
     options.UseRelativeLinks = true;
     options.IncludeTotalResourceCount = true;
+    options.DefaultPageSize = new PageSize(2);
     options.SerializerOptions.WriteIndented = true;
-});
+}, discovery => discovery.AddCurrentAssembly());
 
 WebApplication app = builder.Build();
 

--- a/src/Examples/GettingStarted/Properties/launchSettings.json
+++ b/src/Examples/GettingStarted/Properties/launchSettings.json
@@ -11,7 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "api/people",
+      "launchUrl": "api/exports/asJson",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -19,7 +19,7 @@
     "Kestrel": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/people",
+      "launchUrl": "api/exports/asJson",
       "applicationUrl": "http://localhost:14141",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/Examples/GettingStarted/Repositories/BooksRepository.cs
+++ b/src/Examples/GettingStarted/Repositories/BooksRepository.cs
@@ -1,0 +1,54 @@
+using GettingStarted.Controllers;
+using GettingStarted.Models;
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Queries;
+using JsonApiDotNetCore.Repositories;
+using JsonApiDotNetCore.Resources;
+
+namespace GettingStarted.Repositories;
+
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+public sealed class BooksRepository : EntityFrameworkCoreRepository<Book, int>
+{
+    private static readonly string BooksGetZipFileActionMethod = RemoveAsyncSuffix(nameof(BooksController.GetZipFileAsync));
+
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IPaginationContext _paginationContext;
+
+    private bool DisablePagination
+    {
+        get
+        {
+            RouteData routeData = _httpContextAccessor.HttpContext!.GetRouteData();
+            return routeData.Values["action"]?.ToString() == BooksGetZipFileActionMethod;
+        }
+    }
+
+    public BooksRepository(ITargetedFields targetedFields, IDbContextResolver dbContextResolver, IResourceGraph resourceGraph, IResourceFactory resourceFactory,
+        IEnumerable<IQueryConstraintProvider> constraintProviders, ILoggerFactory loggerFactory, IResourceDefinitionAccessor resourceDefinitionAccessor,
+        IHttpContextAccessor httpContextAccessor, IPaginationContext paginationContext)
+        : base(targetedFields, dbContextResolver, resourceGraph, resourceFactory, constraintProviders, loggerFactory, resourceDefinitionAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _paginationContext = paginationContext;
+    }
+
+    protected override IQueryable<Book> ApplyQueryLayer(QueryLayer queryLayer)
+    {
+        if (DisablePagination)
+        {
+            // Disable pagination when exporting to zip file.
+            queryLayer.Pagination = null;
+            _paginationContext.PageSize = null;
+        }
+
+        return base.ApplyQueryLayer(queryLayer);
+    }
+
+    private static string RemoveAsyncSuffix(string name)
+    {
+        const string asyncSuffix = "Async";
+        return name.EndsWith(asyncSuffix, StringComparison.Ordinal) ? name[..^asyncSuffix.Length] : name;
+    }
+}

--- a/src/Examples/GettingStarted/ZipFileBuilder.cs
+++ b/src/Examples/GettingStarted/ZipFileBuilder.cs
@@ -1,0 +1,31 @@
+﻿using System.IO.Compression;
+
+namespace GettingStarted;
+
+internal sealed class ZipFileBuilder
+{
+    private readonly Stream _zipStream;
+    private readonly ZipArchive _zipArchive;
+
+    public ZipFileBuilder()
+    {
+        _zipStream = new MemoryStream();
+        _zipArchive = new ZipArchive(_zipStream, ZipArchiveMode.Update, true);
+    }
+
+    public async Task IncludeFileAsync(string fileName, string content)
+    {
+        ZipArchiveEntry zipEntry = _zipArchive.CreateEntry(fileName);
+
+        await using Stream entryStream = zipEntry.Open();
+        await using var writer = new StreamWriter(entryStream);
+        await writer.WriteAsync(content);
+    }
+
+    public Stream Build()
+    {
+        _zipArchive.Dispose();
+        _zipStream.Seek(0, SeekOrigin.Begin);
+        return _zipStream;
+    }
+}


### PR DESCRIPTION
This example demonstrates different approaches to serializing resources and compressing the response.

Conversion from controller-level resources (entities) to JSON happens in two phases:
1. Convert resources (entities) to their JSON:API document representation (resource objects, links, attributes, relationships)
2. Convert the JSON:API document to string format

Step 1 heavily depends on the ambient context:
- Application-wide information: JSON:API options, serialization options, the resource graph
- Request-specific information: which controller, route, query string parameters, top-level meta, resource definition callbacks

Step 2 depends on the resource graph. Earlier versions of JADNC used Newtonsoft.Json, which performs a best-guess to convert data types. That feature is unavailable (by design) in System.Text.Json.

Therefore it matters greatly *from where* the serialization process is invoked.

When the ambient context is right (such as a custom action method in a JSON:API controller), the process is simple (see `http://localhost:14141/api/books/exportZip`). In this case, all built-in query string parameters are available to control the export, out of the box. We only need to disable paging. This means a user can request `http://localhost:14141/api/books/exportZip?include=author&sort=author.name&fields[books]=title,author` just as easily.

To run the serialization process independent of the ambient context, we can't simply inject and must set up dependencies ourselves (see http://localhost:14141/api/exports/asJson and http://localhost:14141/api/exports/asZipFile).
Therefore, how routes are formatted and the desired output format (JSON or a zip file) matters greatly in choosing the right solution.