### PR TITLE
Fixed crash in sort lambda from generic resource definition

### DIFF
--- a/src/JsonApiDotNetCore/Resources/SortExpressionLambdaConverter.cs
+++ b/src/JsonApiDotNetCore/Resources/SortExpressionLambdaConverter.cs
@@ -114,12 +114,9 @@ internal sealed class SortExpressionLambdaConverter
 
     private Expression? ReadAttribute(Expression expression)
     {
-        if (expression is MemberExpression memberExpression)
+        if (expression is MemberExpression { Expression: { } } memberExpression)
         {
-            ResourceType resourceType = memberExpression.Member.Name == nameof(Identifiable<object>.Id) && memberExpression.Expression != null
-                ? _resourceGraph.GetResourceType(memberExpression.Expression.Type)
-                : _resourceGraph.GetResourceType(memberExpression.Member.DeclaringType!);
-
+            ResourceType resourceType = _resourceGraph.GetResourceType(memberExpression.Expression.Type);
             AttrAttribute? attribute = resourceType.FindAttributeByPropertyName(memberExpression.Member.Name);
 
             if (attribute != null)

--- a/test/JsonApiDotNetCoreTests/UnitTests/ResourceDefinitions/CreateSortExpressionFromLambdaTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/ResourceDefinitions/CreateSortExpressionFromLambdaTests.cs
@@ -37,7 +37,7 @@ public sealed class CreateSortExpressionFromLambdaTests
         string[] expected =
         {
             "-fileEntries:content",
-            "fileSystemEntries:name",
+            "fileEntries:name",
             "fileEntries:length",
             "fileSystemEntries:parent.fileSystemEntries:name",
             "fileSystemEntries:parent.fileSystemEntries:parent.fileSystemEntries:name"
@@ -103,7 +103,7 @@ public sealed class CreateSortExpressionFromLambdaTests
             "fileSystemEntries:parent.fileEntries:content",
             "count(directoryEntries:subdirectories)",
             "count(fileSystemEntries:parent.directoryEntries:files)",
-            "-fileSystemEntries:name"
+            "-directoryEntries:name"
         };
 
         expression.ToFullString().Should().Be(string.Join(',', expected));


### PR DESCRIPTION
Fixed crash when a generic resource definition references an interface field from its `OnApplySort` lambda. Where we used to special-case for `Identifiable.Id`, we now always use the expression type for resource graph lookups. This is safe because its not possible in C# to remove base members. The value of `memberExpression.Expression` is null on static member access, which is unlikely to occur in sort lambdas.

Closes #1161. See the linked issue for bug repro.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
