### PR TITLE
QA: Demonstrates how to run the JADNC pipeline outside of ASP.NET without a database

### DIFF
--- a/JsonApiDotNetCore.sln
+++ b/JsonApiDotNetCore.sln
@@ -52,6 +52,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JsonApiDotNetCore.Annotatio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DatabasePerTenantExample", "src\Examples\DatabasePerTenantExample\DatabasePerTenantExample.csproj", "{60334658-BE51-43B3-9C4D-F2BBF56C89CE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NoDbConsoleQueryExample", "src\Examples\NoDbConsoleQueryExample\NoDbConsoleQueryExample.csproj", "{3C2149D9-D888-49B2-BDCC-3767A26972FE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -266,6 +268,18 @@ Global
 		{60334658-BE51-43B3-9C4D-F2BBF56C89CE}.Release|x64.Build.0 = Release|Any CPU
 		{60334658-BE51-43B3-9C4D-F2BBF56C89CE}.Release|x86.ActiveCfg = Release|Any CPU
 		{60334658-BE51-43B3-9C4D-F2BBF56C89CE}.Release|x86.Build.0 = Release|Any CPU
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE}.Debug|x64.Build.0 = Debug|Any CPU
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE}.Debug|x86.Build.0 = Debug|Any CPU
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE}.Release|x64.ActiveCfg = Release|Any CPU
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE}.Release|x64.Build.0 = Release|Any CPU
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE}.Release|x86.ActiveCfg = Release|Any CPU
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -288,6 +302,7 @@ Global
 		{0E0B5C51-F7E2-4F40-A4E4-DED0E9731DC9} = {24B15015-62E5-42E1-9BA0-ECE6BE7AA15F}
 		{83FF097C-C8C6-477B-9FAB-DF99B84978B5} = {7A2B7ADD-ECB5-4D00-AA6A-D45BD11C97CF}
 		{60334658-BE51-43B3-9C4D-F2BBF56C89CE} = {026FBC6C-AF76-4568-9B87-EC73457899FD}
+		{3C2149D9-D888-49B2-BDCC-3767A26972FE} = {026FBC6C-AF76-4568-9B87-EC73457899FD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A2421882-8F0A-4905-928F-B550B192F9A4}

--- a/src/Examples/NoDbConsoleQueryExample/Interop/FakeMvcBuilder.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Interop/FakeMvcBuilder.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+
+namespace NoDbConsoleQueryExample.Interop;
+
+/// <summary>
+/// Discards any MVC-specific service registrations.
+/// </summary>
+internal sealed class FakeMvcBuilder : IMvcCoreBuilder
+{
+    public IServiceCollection Services { get; } = new ServiceCollection();
+    public ApplicationPartManager PartManager { get; } = new();
+}

--- a/src/Examples/NoDbConsoleQueryExample/Interop/HiddenLinkGenerator.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Interop/HiddenLinkGenerator.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+#pragma warning disable AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
+
+namespace NoDbConsoleQueryExample.Interop;
+
+/// <summary>
+/// Never emits links, overcoming the limitation that the base type depends on ASP.NET.
+/// </summary>
+internal sealed class HiddenLinkGenerator : LinkGenerator
+{
+    public override string? GetPathByAddress<TAddress>(HttpContext httpContext, TAddress address, RouteValueDictionary values,
+        RouteValueDictionary? ambientValues = null, PathString? pathBase = null, FragmentString fragment = new(), LinkOptions? options = null)
+    {
+        return null;
+    }
+
+    public override string? GetPathByAddress<TAddress>(TAddress address, RouteValueDictionary values, PathString pathBase = new(),
+        FragmentString fragment = new(), LinkOptions? options = null)
+    {
+        return null;
+    }
+
+    public override string? GetUriByAddress<TAddress>(HttpContext httpContext, TAddress address, RouteValueDictionary values,
+        RouteValueDictionary? ambientValues = null, string? scheme = null, HostString? host = null, PathString? pathBase = null,
+        FragmentString fragment = new(), LinkOptions? options = null)
+    {
+        return null;
+    }
+
+    public override string? GetUriByAddress<TAddress>(TAddress address, RouteValueDictionary values, string? scheme, HostString host,
+        PathString pathBase = new(), FragmentString fragment = new(), LinkOptions? options = null)
+    {
+        return null;
+    }
+}

--- a/src/Examples/NoDbConsoleQueryExample/Interop/InjectableRequestQueryStringAccessor.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Interop/InjectableRequestQueryStringAccessor.cs
@@ -1,0 +1,18 @@
+using JsonApiDotNetCore.QueryStrings;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace NoDbConsoleQueryExample.Interop;
+
+/// <summary>
+/// Enables to directly inject a query string, when not running inside an ASP.NET context.
+/// </summary>
+internal sealed class InjectableRequestQueryStringAccessor : IRequestQueryStringAccessor
+{
+    public IQueryCollection Query { get; private set; } = new QueryCollection();
+
+    public void SetFromText(string queryString)
+    {
+        Query = new QueryCollection(QueryHelpers.ParseQuery(queryString));
+    }
+}

--- a/src/Examples/NoDbConsoleQueryExample/Models/Artist.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Models/Artist.cs
@@ -1,0 +1,15 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace NoDbConsoleQueryExample.Models;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+public sealed class Artist : Identifiable<long>
+{
+    [Attr]
+    public string Name { get; set; } = null!;
+
+    [HasMany]
+    public ISet<Track> Tracks { get; set; } = new HashSet<Track>();
+}

--- a/src/Examples/NoDbConsoleQueryExample/Models/Genre.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Models/Genre.cs
@@ -1,0 +1,15 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace NoDbConsoleQueryExample.Models;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+public sealed class Genre : Identifiable<long>
+{
+    [Attr]
+    public string Name { get; set; } = null!;
+
+    [HasMany]
+    public ISet<Track> Tracks { get; set; } = new HashSet<Track>();
+}

--- a/src/Examples/NoDbConsoleQueryExample/Models/Track.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Models/Track.cs
@@ -1,0 +1,24 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace NoDbConsoleQueryExample.Models;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+public sealed class Track : Identifiable<long>
+{
+    [Attr]
+    public string FileName { get; set; } = null!;
+
+    [Attr]
+    public string? DisplayName { get; set; }
+
+    [Attr]
+    public int LengthInSeconds { get; set; }
+
+    [HasOne]
+    public Genre Genre { get; set; } = null!;
+
+    [HasOne]
+    public Artist Artist { get; set; } = null!;
+}

--- a/src/Examples/NoDbConsoleQueryExample/NoDbConsoleQueryExample.csproj
+++ b/src/Examples/NoDbConsoleQueryExample/NoDbConsoleQueryExample.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>$(TargetFrameworkName)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(AspNetVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\JsonApiDotNetCore\JsonApiDotNetCore.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Examples/NoDbConsoleQueryExample/Program.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Program.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Diagnostics;
+using JsonApiDotNetCore.QueryStrings;
+using JsonApiDotNetCore.Repositories;
+using Microsoft.AspNetCore.Routing;
+using NoDbConsoleQueryExample;
+using NoDbConsoleQueryExample.Interop;
+using NoDbConsoleQueryExample.Models;
+using NoDbConsoleQueryExample.Repositories;
+
+IHost host = Host.CreateDefaultBuilder(args).ConfigureServices(services =>
+{
+    services.AddHostedService<Worker>();
+    services.Configure<HostOptions>(options => options.ShutdownTimeout = Timeout.InfiniteTimeSpan);
+    AddHostedJsonApi(services);
+}).Build();
+
+await host.StartAsync();
+await host.StopAsync();
+await host.WaitForShutdownAsync();
+
+static void AddHostedJsonApi(IServiceCollection serviceCollection)
+{
+    ReplaceCodeTimer();
+
+    // Discard any MVC-specific service registrations, we won't need them.
+    var fakeMvcBuilder = new FakeMvcBuilder();
+
+    serviceCollection.AddJsonApi(options =>
+    {
+        // Avoid service registration for ModelState validation, which requires ASP.NET.
+        options.ValidateModelState = false;
+    }, null, builder =>
+    {
+        builder.Add<Track, long>();
+        builder.Add<Artist, long>();
+        builder.Add<Genre, long>();
+    }, fakeMvcBuilder);
+
+    // Override service registration that depends on ASP.NET routing.
+    serviceCollection.AddSingleton<LinkGenerator>(_ => new HiddenLinkGenerator());
+
+    // This allows us to inject a query string, since ASP.NET is unavailable.
+    serviceCollection.AddScoped<IRequestQueryStringAccessor, InjectableRequestQueryStringAccessor>();
+
+    // Use generic ObjectRepository for in-memory data, instead of default EntityFrameworkCoreRepository.
+    serviceCollection.AddScoped(typeof(IResourceReadRepository<,>), typeof(ObjectRepository<,>));
+    serviceCollection.AddScoped(typeof(IResourceRepository<,>), typeof(ObjectRepository<,>));
+
+    serviceCollection.AddScoped(typeof(IDataSourceProvider<,>), typeof(ObjectDataSourceProvider<,>));
+}
+
+[Conditional("DEBUG")]
+static void ReplaceCodeTimer()
+{
+    // This is only needed when building against JADNC debug sources directly, instead of the NuGet package.
+    ICodeTimerSession codeTimerSession = new DefaultCodeTimerSession();
+    CodeTimingSessionManager.Capture(codeTimerSession);
+}

--- a/src/Examples/NoDbConsoleQueryExample/Properties/launchSettings.json
+++ b/src/Examples/NoDbConsoleQueryExample/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+﻿{
+  "profiles": {
+    "QueryWorkerService": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Examples/NoDbConsoleQueryExample/Repositories/IDataSourceProvider.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Repositories/IDataSourceProvider.cs
@@ -1,0 +1,14 @@
+using JsonApiDotNetCore.Resources;
+
+namespace NoDbConsoleQueryExample.Repositories;
+
+/// <summary>
+/// Provides access to in-memory data (when not using a database).
+/// </summary>
+public interface IDataSourceProvider<TResource, TId>
+    where TResource : class, IIdentifiable<TId>
+{
+    void Set(IEnumerable<TResource> resources);
+
+    IEnumerable<TResource> Get();
+}

--- a/src/Examples/NoDbConsoleQueryExample/Repositories/ObjectDataSourceProvider.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Repositories/ObjectDataSourceProvider.cs
@@ -1,0 +1,20 @@
+using JsonApiDotNetCore.Resources;
+
+namespace NoDbConsoleQueryExample.Repositories;
+
+/// <inheritdoc />
+internal sealed class ObjectDataSourceProvider<TResource, TId> : IDataSourceProvider<TResource, TId>
+    where TResource : class, IIdentifiable<TId>
+{
+    private IEnumerable<TResource> _resources = Enumerable.Empty<TResource>();
+
+    public void Set(IEnumerable<TResource> resources)
+    {
+        _resources = resources;
+    }
+
+    public IEnumerable<TResource> Get()
+    {
+        return _resources;
+    }
+}

--- a/src/Examples/NoDbConsoleQueryExample/Repositories/ObjectQueryableBuilder.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Repositories/ObjectQueryableBuilder.cs
@@ -1,0 +1,27 @@
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Queries.Expressions;
+using JsonApiDotNetCore.Queries.Internal.QueryableBuilding;
+using JsonApiDotNetCore.Resources;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace NoDbConsoleQueryExample.Repositories;
+
+[PublicAPI]
+public class ObjectQueryableBuilder : QueryableBuilder
+{
+    public ObjectQueryableBuilder(Expression source, Type elementType, Type extensionType, LambdaParameterNameFactory nameFactory,
+        IResourceFactory resourceFactory, IModel entityModel, LambdaScopeFactory? lambdaScopeFactory = null)
+        : base(source, elementType, extensionType, nameFactory, resourceFactory, entityModel, lambdaScopeFactory)
+    {
+    }
+
+    protected override Expression ApplyInclude(Expression source, IncludeExpression include, ResourceType resourceType)
+    {
+        // This prevents emitting a call to 'Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.Include()',
+        // which is unavailable when not using Entity Framework Core.
+        // But since we have all data in memory, there's no need for it anyway.
+        return source;
+    }
+}

--- a/src/Examples/NoDbConsoleQueryExample/Repositories/ObjectRepository.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Repositories/ObjectRepository.cs
@@ -1,0 +1,68 @@
+using System.Linq.Expressions;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Queries;
+using JsonApiDotNetCore.Queries.Expressions;
+using JsonApiDotNetCore.Queries.Internal.QueryableBuilding;
+using JsonApiDotNetCore.Repositories;
+using JsonApiDotNetCore.Resources;
+
+namespace NoDbConsoleQueryExample.Repositories;
+
+/// <summary>
+/// A read-only repository that acts on in-memory resources, instead of a database.
+/// </summary>
+public sealed class ObjectRepository<TResource, TId> : IResourceReadRepository<TResource, TId>
+    where TResource : class, IIdentifiable<TId>
+{
+    private readonly IResourceGraph _resourceGraph;
+    private readonly IResourceFactory _resourceFactory;
+    private readonly IDataSourceProvider<TResource, TId> _dataSourceProvider;
+
+    public ObjectRepository(IResourceGraph resourceGraph, IResourceFactory resourceFactory, IDataSourceProvider<TResource, TId> dataSourceProvider)
+    {
+        _resourceGraph = resourceGraph;
+        _resourceFactory = resourceFactory;
+        _dataSourceProvider = dataSourceProvider;
+    }
+
+    public Task<IReadOnlyCollection<TResource>> GetAsync(QueryLayer queryLayer, CancellationToken cancellationToken)
+    {
+        IEnumerable<TResource> query = ApplyQueryLayer(queryLayer);
+
+        IReadOnlyCollection<TResource> resources = query.ToList();
+        return Task.FromResult(resources);
+    }
+
+    public Task<int> CountAsync(FilterExpression? filter, CancellationToken cancellationToken)
+    {
+        ResourceType resourceType = _resourceGraph.GetResourceType<TResource>();
+
+        var layer = new QueryLayer(resourceType)
+        {
+            Filter = filter
+        };
+
+        IEnumerable<TResource> resources = ApplyQueryLayer(layer);
+
+        int count = resources.Count();
+        return Task.FromResult(count);
+    }
+
+    private IEnumerable<TResource> ApplyQueryLayer(QueryLayer queryLayer)
+    {
+        IQueryable<TResource> source = _dataSourceProvider.Get().AsQueryable();
+        Expression expression = GetExpression(source, queryLayer);
+
+        return source.Provider.CreateQuery<TResource>(expression);
+    }
+
+    private Expression GetExpression(IQueryable<TResource> source, QueryLayer queryLayer)
+    {
+        var nameFactory = new LambdaParameterNameFactory();
+
+        var builder = new ObjectQueryableBuilder(source.Expression, source.ElementType, typeof(Queryable), nameFactory, _resourceFactory,
+            new ResourceModel(_resourceGraph));
+
+        return builder.ApplyQuery(queryLayer);
+    }
+}

--- a/src/Examples/NoDbConsoleQueryExample/Repositories/ResourceModel.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Repositories/ResourceModel.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using JsonApiDotNetCore.Configuration;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace NoDbConsoleQueryExample.Repositories;
+
+/// <summary>
+/// Provides access to resource types and their fields, when not using Entity Framework Core.
+/// </summary>
+internal sealed class ResourceModel : RuntimeModel
+{
+    public ResourceModel(IResourceGraph resourceGraph)
+    {
+        foreach (ResourceType resourceType in resourceGraph.GetResourceTypes())
+        {
+            RuntimeEntityType entityType = AddEntityType(resourceType.ClrType.FullName!, resourceType.ClrType);
+            SetEntityProperties(entityType, resourceType);
+        }
+    }
+
+    private static void SetEntityProperties(RuntimeEntityType entityType, ResourceType resourceType)
+    {
+        foreach (PropertyInfo property in resourceType.ClrType.GetProperties())
+        {
+            entityType.AddProperty(property.Name, property.PropertyType, property);
+        }
+    }
+}

--- a/src/Examples/NoDbConsoleQueryExample/Worker.cs
+++ b/src/Examples/NoDbConsoleQueryExample/Worker.cs
@@ -1,0 +1,128 @@
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Middleware;
+using JsonApiDotNetCore.QueryStrings;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Services;
+using NoDbConsoleQueryExample.Interop;
+using NoDbConsoleQueryExample.Models;
+using NoDbConsoleQueryExample.Repositories;
+
+namespace NoDbConsoleQueryExample;
+
+public sealed class Worker : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public Worker(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await using AsyncServiceScope scope = _serviceProvider.CreateAsyncScope();
+        await ExecuteInScopeAsync(scope.ServiceProvider, stoppingToken);
+    }
+
+    private async Task ExecuteInScopeAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        // JsonApiMiddleware depends on ASP.NET, so we must setup IJsonApiRequest ourselves.
+        SetupJsonApiRequest<Track>(serviceProvider);
+
+        // ASP.NET action filters do not execute, so we must invoke the query string reader ourselves.
+        const string queryString = "?filter=greaterThan(lengthInSeconds,'225')&include=artist,genre";
+        ParseQueryString(serviceProvider, queryString);
+
+        // Gather data and make it accessible to repository.
+        var dataSourceProvider = serviceProvider.GetRequiredService<IDataSourceProvider<Track, long>>();
+        IEnumerable<Track> allTracks = CreateSampleData();
+        dataSourceProvider.Set(allTracks);
+
+        // Controllers depend on ASP.NET, so instead we invoke from the resource service layer.
+        var trackService = serviceProvider.GetRequiredService<IResourceService<Track, long>>();
+        IReadOnlyCollection<Track> tracks = await trackService.GetAsync(cancellationToken);
+
+        PrintTracks(tracks);
+    }
+
+    private static void SetupJsonApiRequest<TResource>(IServiceProvider serviceProvider)
+        where TResource : class, IIdentifiable
+    {
+        var resourceGraph = serviceProvider.GetRequiredService<IResourceGraph>();
+
+        var request = (JsonApiRequest)serviceProvider.GetRequiredService<IJsonApiRequest>();
+        request.Kind = EndpointKind.Primary;
+        request.PrimaryResourceType = resourceGraph.GetResourceType<TResource>();
+        request.IsCollection = true;
+        request.IsReadOnly = true;
+    }
+
+    private static void ParseQueryString(IServiceProvider serviceProvider, string queryString)
+    {
+        var queryStringAccessor = (InjectableRequestQueryStringAccessor)serviceProvider.GetRequiredService<IRequestQueryStringAccessor>();
+        queryStringAccessor.SetFromText(queryString);
+
+        var queryStringReader = serviceProvider.GetRequiredService<IQueryStringReader>();
+        queryStringReader.ReadAll(null);
+    }
+
+    private static IEnumerable<Track> CreateSampleData()
+    {
+        var artist = new Artist
+        {
+            Name = "AC/DC"
+        };
+
+        var genre = new Genre
+        {
+            Name = "Hard rock"
+        };
+
+        var tracks = new List<Track>
+        {
+            new()
+            {
+                FileName = "01-fly-on-the-wall.mp3",
+                DisplayName = "Fly On The Wall",
+                LengthInSeconds = 224,
+                Genre = genre,
+                Artist = artist
+            },
+            new()
+            {
+                FileName = "02-first-blood.mp3",
+                DisplayName = "First Blood",
+                LengthInSeconds = 226,
+                Genre = genre,
+                Artist = artist
+            },
+            new()
+            {
+                FileName = "03-sink-the-pink.mp3",
+                DisplayName = "Sink The Pink",
+                LengthInSeconds = 255,
+                Genre = genre,
+                Artist = artist
+            }
+        };
+
+        // Set bi-directional object references manually (normally EF Core handles this)
+        foreach (Track track in tracks)
+        {
+            track.Artist.Tracks.Add(track);
+            track.Genre.Tracks.Add(track);
+        }
+
+        return tracks;
+    }
+
+    private void PrintTracks(IReadOnlyCollection<Track> tracks)
+    {
+        Console.WriteLine($"Found {tracks.Count} matching track(s)");
+
+        foreach (Track track in tracks)
+        {
+            Console.WriteLine($"  {track.DisplayName} ({TimeSpan.FromSeconds(track.LengthInSeconds)}) - {track.Artist.Name} ({track.Genre.Name})");
+        }
+    }
+}

--- a/src/Examples/NoDbConsoleQueryExample/appsettings.json
+++ b/src/Examples/NoDbConsoleQueryExample/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
Example of a console app that runs outside of ASP.NET and enables the use of JADNC query syntax without an underlying database.

Basically a variation of #1144, but using an in-memory object model instead of a database. Answer to the question at #1164.

This PR is not intended to be merged.