### PR TITLE
Enable running code cleanup locally only on files changed since the specified branch

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "regitlint": {
-      "version": "6.0.8",
+      "version": "6.1.1",
       "commands": [
         "regitlint"
       ]

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,8 +58,8 @@ Please follow these steps to have your contribution considered by the maintainer
 
 We use [CSharpGuidelines](https://csharpcodingguidelines.com/) as our coding standard (with a few minor exceptions). Coding style is validated during PR build, where we inject an extra settings layer that promotes various suggestions to warning level. This ensures a high-quality codebase without interfering too much when editing code.
 You can run the following [PowerShell scripts](https://github.com/PowerShell/PowerShell/releases) locally:
-- `pwsh inspectcode.ps1`: Scans the code for style violations and opens the result in your web browser.
-- `pwsh cleanupcode.ps1`: Reformats the entire codebase to match with our configured style.
+- `pwsh ./inspectcode.ps1`: Scans the code for style violations and opens the result in your web browser.
+- `pwsh ./cleanupcode.ps1 [branch-name-or-commit-hash]`: Reformats the codebase to match with our configured style, optionally only changed files since the specified branch (usually master).
 
 Code inspection violations can be addressed in several ways, depending on the situation:
 - Types that are reported to be never instantiated (because the IoC container creates them dynamically) should be decorated with `[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]`.

--- a/Build.ps1
+++ b/Build.ps1
@@ -40,16 +40,21 @@ function RunCleanupCode {
     # When running in cibuild for a pull request, this reformats only the files changed in the PR and fails if the reformat produces changes.
 
     if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT) {
-        Write-Output "Running code cleanup on changed files in pull request"
-
         # In the past, we used $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT for the merge commit hash. That is the pinned hash at the time the build is enqueued.
         # When a force-push happens after that, while the build hasn't yet started, this hash becomes invalid during the build, resulting in a lookup error.
-        # To prevent failing the build for unobvious reasons we use HEAD, which is always the latest version.
-        $mergeCommitHash = git rev-parse "HEAD"
-        $targetCommitHash = git rev-parse "$env:APPVEYOR_REPO_BRANCH"
+        # To prevent failing the build for unobvious reasons we use HEAD, which is always a detached head (the PR merge result).
 
-        dotnet regitlint -s JsonApiDotNetCore.sln --print-command --disable-jb-path-hack --jb --profile='\"JADNC Full Cleanup\"' --jb --properties:Configuration=Release --jb --verbosity=WARN -f commits -a $mergeCommitHash -b $targetCommitHash --fail-on-diff --print-diff
+        $headCommitHash = git rev-parse HEAD
         CheckLastExitCode
+
+        $baseCommitHash = git rev-parse "$env:APPVEYOR_REPO_BRANCH"
+        CheckLastExitCode
+
+        if ($baseCommitHash -ne $headCommitHash) {
+            Write-Output "Running code cleanup on commit range $baseCommitHash..$headCommitHash in pull request."
+            dotnet regitlint -s JsonApiDotNetCore.sln --print-command --skip-tool-check --jb-profile="JADNC Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=WARN -f commits -a $headCommitHash -b $baseCommitHash --fail-on-diff --print-diff
+            CheckLastExitCode
+        }
     }
 }
 

--- a/cleanupcode.ps1
+++ b/cleanupcode.ps1
@@ -1,17 +1,44 @@
 #Requires -Version 7.0
 
-# This script reformats the entire codebase to make it compliant with our coding guidelines.
+# This script reformats (part of) the codebase to make it compliant with our coding guidelines.
+
+param(
+    # Git branch name or base commit hash to reformat only the subset of changed files. Omit for all files.
+    [string] $revision
+)
+
+function VerifySuccessExitCode {
+    if ($LastExitCode -ne 0) {
+        throw "Command failed with exit code $LastExitCode."
+    }
+}
 
 dotnet tool restore
-
-if ($LASTEXITCODE -ne 0) {
-    throw "Tool restore failed with exit code $LASTEXITCODE"
-}
+VerifySuccessExitCode
 
 dotnet restore
+VerifySuccessExitCode
 
-if ($LASTEXITCODE -ne 0) {
-    throw "Package restore failed with exit code $LASTEXITCODE"
+if ($revision) {
+    $headCommitHash = git rev-parse HEAD
+    VerifySuccessExitCode
+
+    $baseCommitHash = git rev-parse $revision
+    VerifySuccessExitCode
+
+    if ($baseCommitHash -eq $headCommitHash) {
+        Write-Output "Running code cleanup on staged/unstaged files."
+        dotnet regitlint -s JsonApiDotNetCore.sln --print-command --skip-tool-check --jb-profile="JADNC Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=WARN -f staged,modified
+        VerifySuccessExitCode
+    }
+    else {
+        Write-Output "Running code cleanup on commit range $baseCommitHash..$headCommitHash, including staged/unstaged files."
+        dotnet regitlint -s JsonApiDotNetCore.sln --print-command --skip-tool-check --jb-profile="JADNC Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=WARN -f staged,modified,commits -a $headCommitHash -b $baseCommitHash
+        VerifySuccessExitCode
+    }
 }
-
-dotnet regitlint -s JsonApiDotNetCore.sln --print-command --disable-jb-path-hack --jb --profile='\"JADNC Full Cleanup\"' --jb --properties:Configuration=Release --jb --verbosity=WARN
+else {
+    Write-Output "Running code cleanup on all files."
+    dotnet regitlint -s JsonApiDotNetCore.sln --print-command --skip-tool-check --jb-profile="JADNC Full Cleanup" --jb --properties:Configuration=Release --jb --verbosity=WARN
+    VerifySuccessExitCode
+}


### PR DESCRIPTION
This PR adds an optional parameter to `cleanupcode.ps1`, which allows formatting only changed files since a git branch or commit hash. And it now includes staged and unstaged files.

Example usage:

```
C:\Source\Repos\JsonApiDotNetCore [cleanupcode-diff ≡]> ./cleanupcode.ps1 master
```

Fixes #1112 (well, the first bullet of https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1112#issuecomment-975354625; the second one can be addressed by importing the severities layer locally).

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [x] Documentation updated
