### PR TITLE
Remove dependency on EF Core "Issue26779" AppContext switch

### DIFF
--- a/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
@@ -102,12 +102,6 @@ public sealed class JsonApiOptions : IJsonApiOptions
         }
     };
 
-    static JsonApiOptions()
-    {
-        // Bug workaround for https://github.com/dotnet/efcore/issues/27436
-        AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue26779", true);
-    }
-
     public JsonApiOptions()
     {
         _lazySerializerReadOptions = new Lazy<JsonSerializerOptions>(() => new JsonSerializerOptions(SerializerOptions), LazyThreadSafetyMode.PublicationOnly);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/Car.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/Car.cs
@@ -47,4 +47,7 @@ public sealed class Car : Identifiable<string?>
 
     [HasOne]
     public Dealership? Dealership { get; set; }
+
+    [HasMany]
+    public ISet<Dealership> PreviousDealerships { get; set; } = new HashSet<Dealership>();
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/CompositeDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/CompositeDbContext.cs
@@ -34,5 +34,9 @@ public sealed class CompositeDbContext : DbContext
         builder.Entity<Dealership>()
             .HasMany(dealership => dealership.Inventory)
             .WithOne(car => car.Dealership!);
+
+        builder.Entity<Car>()
+            .HasMany(car => car.PreviousDealerships)
+            .WithMany(dealership => dealership.SoldCars);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/Dealership.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/Dealership.cs
@@ -13,4 +13,7 @@ public sealed class Dealership : Identifiable<int>
 
     [HasMany]
     public ISet<Car> Inventory { get; set; } = new HashSet<Car>();
+
+    [HasMany]
+    public ISet<Car> SoldCars { get; set; } = new HashSet<Car>();
 }


### PR DESCRIPTION
EF Core v6.0.2 introduced a breaking change regarding change tracking of many-to-many relationships, which broke removing from many-to-many relationships in JsonApiDotNetCore in some cases. Fortunately, an AppContext switch to revert to the old behavior was added, which we've used since JsonApiDotNetCore v5.0.0.

The switch has been removed in EF (Core) 7. This PR fixes our code to no longer require the "Microsoft.EntityFrameworkCore.Issue26779" backward-compatibility switch. This unblocks us from upgrading to the latest preview version.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
