### PR TITLE
Access query string parameters from resource service

### DIFF
--- a/test/NoEntityFrameworkTests/WorkItemTests.cs
+++ b/test/NoEntityFrameworkTests/WorkItemTests.cs
@@ -45,7 +45,7 @@ public sealed class WorkItemTests : IntegrationTest, IClassFixture<WebApplicatio
             await dbContext.SaveChangesAsync();
         });
 
-        const string route = "/api/v1/workItems";
+        const string route = "/api/v1/workItems?filter=not(equals(title,'skipMe'))";
 
         // Act
         (HttpResponseMessage httpResponse, Document responseDocument) = await ExecuteGetAsync<Document>(route);


### PR DESCRIPTION
Answer to question at https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1180. This PR shows how to access query string parameters.

Runing the test `Can_get_WorkItems` in the debugger, the Output window shows:
```
Incoming filter: not(equals(title,'skipMe'))
```

Putting a breakpoint in the `foreach` loop and inspecting the `filter` loop variable:

![image](https://user-images.githubusercontent.com/10324372/185254683-9fe41748-b12f-425f-9c0c-667f79e866c9.png)
