### PR TITLE
Updates tests to write SQL statements to the Output Window

### DIFF
--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Archiving/TelevisionDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Archiving/TelevisionDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.Archiving;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class TelevisionDbContext : DbContext
+public sealed class TelevisionDbContext : TestableDbContext
 {
     public DbSet<TelevisionNetwork> Networks => Set<TelevisionNetwork>();
     public DbSet<TelevisionStation> Stations => Set<TelevisionStation>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/OperationsDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/OperationsDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class OperationsDbContext : DbContext
+public sealed class OperationsDbContext : TestableDbContext
 {
     public DbSet<Playlist> Playlists => Set<Playlist>();
     public DbSet<MusicTrack> MusicTracks => Set<MusicTrack>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Transactions/ExtraDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Transactions/ExtraDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Transactions;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ExtraDbContext : DbContext
+public sealed class ExtraDbContext : TestableDbContext
 {
     public ExtraDbContext(DbContextOptions<ExtraDbContext> options)
         : base(options)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Blobs/BlobDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Blobs/BlobDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.Blobs;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class BlobDbContext : DbContext
+public sealed class BlobDbContext : TestableDbContext
 {
     public DbSet<ImageContainer> ImageContainers => Set<ImageContainer>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/CompositeDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/CompositeDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.CompositeKeys;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class CompositeDbContext : DbContext
+public sealed class CompositeDbContext : TestableDbContext
 {
     public DbSet<Car> Cars => Set<Car>();
     public DbSet<Engine> Engines => Set<Engine>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/PolicyDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/PolicyDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ContentNegotiation;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class PolicyDbContext : DbContext
+public sealed class PolicyDbContext : TestableDbContext
 {
     public DbSet<Policy> Policies => Set<Policy>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ControllerActionResults/ActionResultDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ControllerActionResults/ActionResultDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ControllerActionResults;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ActionResultDbContext : DbContext
+public sealed class ActionResultDbContext : TestableDbContext
 {
     public DbSet<Toothbrush> Toothbrushes => Set<Toothbrush>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CustomRoutes/CustomRouteDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CustomRoutes/CustomRouteDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.CustomRoutes;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class CustomRouteDbContext : DbContext
+public sealed class CustomRouteDbContext : TestableDbContext
 {
     public DbSet<Town> Towns => Set<Town>();
     public DbSet<Civilian> Civilians => Set<Civilian>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/EagerLoading/EagerLoadingDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/EagerLoading/EagerLoadingDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.EagerLoading;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class EagerLoadingDbContext : DbContext
+public sealed class EagerLoadingDbContext : TestableDbContext
 {
     public DbSet<State> States => Set<State>();
     public DbSet<Street> Streets => Set<Street>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ExceptionHandling/ErrorDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ExceptionHandling/ErrorDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ExceptionHandling;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ErrorDbContext : DbContext
+public sealed class ErrorDbContext : TestableDbContext
 {
     public DbSet<ConsumerArticle> ConsumerArticles => Set<ConsumerArticle>();
     public DbSet<ThrowingArticle> ThrowingArticles => Set<ThrowingArticle>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/HostingInIIS/HostingDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/HostingInIIS/HostingDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.HostingInIIS;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class HostingDbContext : DbContext
+public sealed class HostingDbContext : TestableDbContext
 {
     public DbSet<ArtGallery> ArtGalleries => Set<ArtGallery>();
     public DbSet<Painting> Paintings => Set<Painting>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/HostingInIIS/HostingStartup.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/HostingInIIS/HostingStartup.cs
@@ -1,14 +1,13 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.EntityFrameworkCore;
 using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.HostingInIIS;
 
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
 public sealed class HostingStartup<TDbContext> : TestableStartup<TDbContext>
-    where TDbContext : DbContext
+    where TDbContext : TestableDbContext
 {
     protected override void SetJsonApiOptions(JsonApiOptions options)
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/IdObfuscation/ObfuscationDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/IdObfuscation/ObfuscationDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.IdObfuscation;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ObfuscationDbContext : DbContext
+public sealed class ObfuscationDbContext : TestableDbContext
 {
     public DbSet<BankAccount> BankAccounts => Set<BankAccount>();
     public DbSet<DebitCard> DebitCards => Set<DebitCard>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/ModelStateDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/ModelStateDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.InputValidation.ModelState;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ModelStateDbContext : DbContext
+public sealed class ModelStateDbContext : TestableDbContext
 {
     public DbSet<SystemVolume> Volumes => Set<SystemVolume>();
     public DbSet<SystemDirectory> Directories => Set<SystemDirectory>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/RequestBody/WorkflowDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/RequestBody/WorkflowDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.InputValidation.RequestBody;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class WorkflowDbContext : DbContext
+public sealed class WorkflowDbContext : TestableDbContext
 {
     public DbSet<Workflow> Workflows => Set<Workflow>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/LinksDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/LinksDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.Links;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class LinksDbContext : DbContext
+public sealed class LinksDbContext : TestableDbContext
 {
     public DbSet<PhotoAlbum> PhotoAlbums => Set<PhotoAlbum>();
     public DbSet<Photo> Photos => Set<Photo>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Logging/LoggingDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Logging/LoggingDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.Logging;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class LoggingDbContext : DbContext
+public sealed class LoggingDbContext : TestableDbContext
 {
     public DbSet<AuditEntry> AuditEntries => Set<AuditEntry>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/MetaDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/MetaDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.Meta;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class MetaDbContext : DbContext
+public sealed class MetaDbContext : TestableDbContext
 {
     public DbSet<ProductFamily> ProductFamilies => Set<ProductFamily>();
     public DbSet<SupportTicket> SupportTickets => Set<SupportTicket>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDelivery;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class FireForgetDbContext : DbContext
+public sealed class FireForgetDbContext : TestableDbContext
 {
     public DbSet<DomainUser> Users => Set<DomainUser>();
     public DbSet<DomainGroup> Groups => Set<DomainGroup>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxDbContext.cs
@@ -1,11 +1,12 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCoreTests.IntegrationTests.Microservices.Messages;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOutboxPattern;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class OutboxDbContext : DbContext
+public sealed class OutboxDbContext : TestableDbContext
 {
     public DbSet<DomainUser> Users => Set<DomainUser>();
     public DbSet<DomainGroup> Groups => Set<DomainGroup>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/MultiTenancyDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/MultiTenancyDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.MultiTenancy;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class MultiTenancyDbContext : DbContext
+public sealed class MultiTenancyDbContext : TestableDbContext
 {
     private readonly ITenantProvider _tenantProvider;
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/KebabCasingConventionStartup.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/KebabCasingConventionStartup.cs
@@ -1,13 +1,12 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
-using Microsoft.EntityFrameworkCore;
 using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.NamingConventions;
 
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
 public sealed class KebabCasingConventionStartup<TDbContext> : TestableStartup<TDbContext>
-    where TDbContext : DbContext
+    where TDbContext : TestableDbContext
 {
     protected override void SetJsonApiOptions(JsonApiOptions options)
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/NamingDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/NamingDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.NamingConventions;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class NamingDbContext : DbContext
+public sealed class NamingDbContext : TestableDbContext
 {
     public DbSet<SwimmingPool> SwimmingPools => Set<SwimmingPool>();
     public DbSet<WaterSlide> WaterSlides => Set<WaterSlide>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/PascalCasingConventionStartup.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/PascalCasingConventionStartup.cs
@@ -1,13 +1,12 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
-using Microsoft.EntityFrameworkCore;
 using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.NamingConventions;
 
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
 public sealed class PascalCasingConventionStartup<TDbContext> : TestableStartup<TDbContext>
-    where TDbContext : DbContext
+    where TDbContext : TestableDbContext
 {
     protected override void SetJsonApiOptions(JsonApiOptions options)
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NonJsonApiControllers/EmptyDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NonJsonApiControllers/EmptyDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.NonJsonApiControllers;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class EmptyDbContext : DbContext
+public sealed class EmptyDbContext : TestableDbContext
 {
     public EmptyDbContext(DbContextOptions<EmptyDbContext> options)
         : base(options)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NonJsonApiControllers/KnownDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NonJsonApiControllers/KnownDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.NonJsonApiControllers;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class KnownDbContext : DbContext
+public sealed class KnownDbContext : TestableDbContext
 {
     public DbSet<KnownResource> KnownResources => Set<KnownResource>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Filtering/FilterDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Filtering/FilterDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Filtering;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class FilterDbContext : DbContext
+public sealed class FilterDbContext : TestableDbContext
 {
     public DbSet<FilterableResource> FilterableResources => Set<FilterableResource>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/QueryStringDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/QueryStringDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class QueryStringDbContext : DbContext
+public sealed class QueryStringDbContext : TestableDbContext
 {
     public DbSet<Blog> Blogs => Set<Blog>();
     public DbSet<BlogPost> Posts => Set<BlogPost>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/ReadWriteDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/ReadWriteDbContext.cs
@@ -1,5 +1,6 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 // @formatter:keep_existing_linebreaks true
@@ -7,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ReadWrite;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ReadWriteDbContext : DbContext
+public sealed class ReadWriteDbContext : TestableDbContext
 {
     public DbSet<WorkItem> WorkItems => Set<WorkItem>();
     public DbSet<WorkTag> WorkTags => Set<WorkTag>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/RequiredRelationships/DefaultBehaviorDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/RequiredRelationships/DefaultBehaviorDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.RequiredRelationships;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class DefaultBehaviorDbContext : DbContext
+public sealed class DefaultBehaviorDbContext : TestableDbContext
 {
     public DbSet<Customer> Customers => Set<Customer>();
     public DbSet<Order> Orders => Set<Order>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceConstructorInjection/InjectionDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceConstructorInjection/InjectionDbContext.cs
@@ -2,11 +2,12 @@ using JetBrains.Annotations;
 using JsonApiDotNetCore;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceConstructorInjection;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class InjectionDbContext : DbContext
+public sealed class InjectionDbContext : TestableDbContext
 {
     public ISystemClock SystemClock { get; }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/UniverseDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/UniverseDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class UniverseDbContext : DbContext
+public sealed class UniverseDbContext : TestableDbContext
 {
     public DbSet<Star> Stars => Set<Star>();
     public DbSet<Planet> Planets => Set<Planet>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/SerializationDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/SerializationDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serialization;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class SerializationDbContext : DbContext
+public sealed class SerializationDbContext : TestableDbContext
 {
     public DbSet<Student> Students => Set<Student>();
     public DbSet<Scholarship> Scholarships => Set<Scholarship>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceDbContext.cs
@@ -1,11 +1,12 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCoreTests.IntegrationTests.ResourceInheritance.Models;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceInheritance;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public abstract class ResourceInheritanceDbContext : DbContext
+public abstract class ResourceInheritanceDbContext : TestableDbContext
 {
     public DbSet<Vehicle> Vehicles => Set<Vehicle>();
     public DbSet<Bike> Bikes => Set<Bike>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/RestrictionDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/RestrictionDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.RestrictedControllers;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class RestrictionDbContext : DbContext
+public sealed class RestrictionDbContext : TestableDbContext
 {
     public DbSet<Table> Tables => Set<Table>();
     public DbSet<Chair> Chairs => Set<Chair>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/SerializationDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/SerializationDbContext.cs
@@ -1,10 +1,11 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class SerializationDbContext : DbContext
+public sealed class SerializationDbContext : TestableDbContext
 {
     public DbSet<Meeting> Meetings => Set<Meeting>();
     public DbSet<MeetingAttendee> Attendees => Set<MeetingAttendee>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/SoftDeletion/SoftDeletionDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/SoftDeletion/SoftDeletionDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.SoftDeletion;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class SoftDeletionDbContext : DbContext
+public sealed class SoftDeletionDbContext : TestableDbContext
 {
     public DbSet<Company> Companies => Set<Company>();
     public DbSet<Department> Departments => Set<Department>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/ZeroKeyDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/ZeroKeyDbContext.cs
@@ -1,12 +1,13 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
 
 // @formatter:wrap_chained_method_calls chop_always
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ZeroKeyDbContext : DbContext
+public sealed class ZeroKeyDbContext : TestableDbContext
 {
     public DbSet<Game> Games => Set<Game>();
     public DbSet<Player> Players => Set<Player>();

--- a/test/JsonApiDotNetCoreTests/Startups/AbsoluteLinksInApiNamespaceStartup.cs
+++ b/test/JsonApiDotNetCoreTests/Startups/AbsoluteLinksInApiNamespaceStartup.cs
@@ -1,13 +1,12 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
-using Microsoft.EntityFrameworkCore;
 using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.Startups;
 
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
 public sealed class AbsoluteLinksInApiNamespaceStartup<TDbContext> : TestableStartup<TDbContext>
-    where TDbContext : DbContext
+    where TDbContext : TestableDbContext
 {
     protected override void SetJsonApiOptions(JsonApiOptions options)
     {

--- a/test/JsonApiDotNetCoreTests/Startups/AbsoluteLinksNoNamespaceStartup.cs
+++ b/test/JsonApiDotNetCoreTests/Startups/AbsoluteLinksNoNamespaceStartup.cs
@@ -1,13 +1,12 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
-using Microsoft.EntityFrameworkCore;
 using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.Startups;
 
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
 public sealed class AbsoluteLinksNoNamespaceStartup<TDbContext> : TestableStartup<TDbContext>
-    where TDbContext : DbContext
+    where TDbContext : TestableDbContext
 {
     protected override void SetJsonApiOptions(JsonApiOptions options)
     {

--- a/test/JsonApiDotNetCoreTests/Startups/NoModelStateValidationStartup.cs
+++ b/test/JsonApiDotNetCoreTests/Startups/NoModelStateValidationStartup.cs
@@ -1,13 +1,12 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
-using Microsoft.EntityFrameworkCore;
 using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.Startups;
 
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
 public sealed class NoModelStateValidationStartup<TDbContext> : TestableStartup<TDbContext>
-    where TDbContext : DbContext
+    where TDbContext : TestableDbContext
 {
     protected override void SetJsonApiOptions(JsonApiOptions options)
     {

--- a/test/JsonApiDotNetCoreTests/Startups/RelativeLinksInApiNamespaceStartup.cs
+++ b/test/JsonApiDotNetCoreTests/Startups/RelativeLinksInApiNamespaceStartup.cs
@@ -1,13 +1,12 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
-using Microsoft.EntityFrameworkCore;
 using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.Startups;
 
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
 public sealed class RelativeLinksInApiNamespaceStartup<TDbContext> : TestableStartup<TDbContext>
-    where TDbContext : DbContext
+    where TDbContext : TestableDbContext
 {
     protected override void SetJsonApiOptions(JsonApiOptions options)
     {

--- a/test/JsonApiDotNetCoreTests/Startups/RelativeLinksNoNamespaceStartup.cs
+++ b/test/JsonApiDotNetCoreTests/Startups/RelativeLinksNoNamespaceStartup.cs
@@ -1,13 +1,12 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
-using Microsoft.EntityFrameworkCore;
 using TestBuildingBlocks;
 
 namespace JsonApiDotNetCoreTests.Startups;
 
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
 public sealed class RelativeLinksNoNamespaceStartup<TDbContext> : TestableStartup<TDbContext>
-    where TDbContext : DbContext
+    where TDbContext : TestableDbContext
 {
     protected override void SetJsonApiOptions(JsonApiOptions options)
     {

--- a/test/JsonApiDotNetCoreTests/UnitTests/Configuration/DependencyContainerRegistrationTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Configuration/DependencyContainerRegistrationTests.cs
@@ -124,7 +124,7 @@ public sealed class DependencyContainerRegistrationTests
     }
 
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    private sealed class DependencyContainerRegistrationDbContext : DbContext
+    private sealed class DependencyContainerRegistrationDbContext : TestableDbContext
     {
         public DbSet<Resource> Resources => Set<Resource>();
 

--- a/test/TestBuildingBlocks/IntegrationTestContext.cs
+++ b/test/TestBuildingBlocks/IntegrationTestContext.cs
@@ -26,7 +26,7 @@ namespace TestBuildingBlocks;
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
 public class IntegrationTestContext<TStartup, TDbContext> : IntegrationTest, IDisposable
     where TStartup : class
-    where TDbContext : DbContext
+    where TDbContext : TestableDbContext
 {
     private readonly Lazy<WebApplicationFactory<TStartup>> _lazyFactory;
     private readonly TestControllerProvider _testControllerProvider = new();

--- a/test/TestBuildingBlocks/TestableDbContext.cs
+++ b/test/TestBuildingBlocks/TestableDbContext.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics;
+using JsonApiDotNetCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace TestBuildingBlocks;
+
+public abstract class TestableDbContext : DbContext
+{
+    protected TestableDbContext(DbContextOptions options)
+        : base(options)
+    {
+    }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder builder)
+    {
+        // Writes SQL statements to the Output Window when debugging.
+        builder.LogTo(message => Debug.WriteLine(message), DbLoggerCategory.Database.Name.AsArray(), LogLevel.Information);
+    }
+}

--- a/test/TestBuildingBlocks/TestableStartup.cs
+++ b/test/TestBuildingBlocks/TestableStartup.cs
@@ -1,12 +1,11 @@
 using JsonApiDotNetCore.Configuration;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace TestBuildingBlocks;
 
 public class TestableStartup<TDbContext>
-    where TDbContext : DbContext
+    where TDbContext : TestableDbContext
 {
     public virtual void ConfigureServices(IServiceCollection services)
     {

--- a/test/UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/test/UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -12,6 +12,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 using JsonApiDotNetCore.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using TestBuildingBlocks;
 using Xunit;
 
 namespace UnitTests.Extensions;
@@ -589,7 +590,7 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    private sealed class TestDbContext : DbContext
+    private sealed class TestDbContext : TestableDbContext
     {
         public DbSet<ResourceOfInt32> ResourcesOfInt32 => Set<ResourceOfInt32>();
         public DbSet<ResourceOfGuid> ResourcesOfGuid => Set<ResourceOfGuid>();


### PR DESCRIPTION
Updates tests to write SQL statements to the Output Window, so we don't need to edit `appsettings.json` when debugging.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
