### PR TITLE
Improve speed of running tests

### DIFF
--- a/test/AnnotationTests/AnnotationTests.csproj
+++ b/test/AnnotationTests/AnnotationTests.csproj
@@ -4,12 +4,6 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
     <Using Remove="System.Net.Http" />
   </ItemGroup>

--- a/test/DiscoveryTests/DiscoveryTests.csproj
+++ b/test/DiscoveryTests/DiscoveryTests.csproj
@@ -4,12 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Examples\JsonApiDotNetCoreExample\JsonApiDotNetCoreExample.csproj" />
     <ProjectReference Include="..\TestBuildingBlocks\TestBuildingBlocks.csproj" />
   </ItemGroup>

--- a/test/DiscoveryTests/xunit.runner.json
+++ b/test/DiscoveryTests/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-  "parallelizeAssembly": false,
-  "parallelizeTestCollections": false
-}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/OperationsDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/OperationsDbContext.cs
@@ -31,5 +31,7 @@ public sealed class OperationsDbContext : TestableDbContext
         builder.Entity<MusicTrack>()
             .HasMany(musicTrack => musicTrack.OccursIn)
             .WithMany(playlist => playlist.Tracks);
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/CompositeDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/CompositeDbContext.cs
@@ -39,5 +39,7 @@ public sealed class CompositeDbContext : TestableDbContext
         builder.Entity<Car>()
             .HasMany(car => car.PreviousDealerships)
             .WithMany(dealership => dealership.SoldCars);
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/EagerLoading/EagerLoadingDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/EagerLoading/EagerLoadingDbContext.cs
@@ -34,5 +34,7 @@ public sealed class EagerLoadingDbContext : TestableDbContext
             .HasOne(building => building.SecondaryDoor)
             .WithOne()
             .HasForeignKey<Building>("SecondaryDoorId");
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/ModelStateDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/ModelStateDbContext.cs
@@ -37,5 +37,7 @@ public sealed class ModelStateDbContext : TestableDbContext
         builder.Entity<SystemDirectory>()
             .HasOne(systemDirectory => systemDirectory.AlsoSelf)
             .WithOne();
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/LinksDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/LinksDbContext.cs
@@ -24,5 +24,7 @@ public sealed class LinksDbContext : TestableDbContext
             .HasOne(photo => photo.Location)
             .WithOne(location => location.Photo)
             .HasForeignKey<Photo>("LocationId");
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/MultiTenancyDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/MultiTenancyDbContext.cs
@@ -31,5 +31,7 @@ public sealed class MultiTenancyDbContext : TestableDbContext
 
         builder.Entity<WebProduct>()
             .HasQueryFilter(webProduct => webProduct.Shop.TenantId == _tenantProvider.TenantId);
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Filtering/FilterDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Filtering/FilterDbContext.cs
@@ -21,5 +21,7 @@ public sealed class FilterDbContext : TestableDbContext
         builder.Entity<FilterableResource>()
             .Property(resource => resource.SomeDateTimeInLocalZone)
             .HasColumnType("timestamp without time zone");
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/QueryStringDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/QueryStringDbContext.cs
@@ -37,5 +37,7 @@ public sealed class QueryStringDbContext : TestableDbContext
             .HasOne(man => man.Wife)
             .WithOne(woman => woman.Husband)
             .HasForeignKey<Man>();
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/ReadWriteDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/ReadWriteDbContext.cs
@@ -49,5 +49,7 @@ public sealed class ReadWriteDbContext : TestableDbContext
                 left => left
                     .HasOne(joinEntity => joinEntity.ToItem)
                     .WithMany());
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/RequiredRelationships/DefaultBehaviorDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/RequiredRelationships/DefaultBehaviorDbContext.cs
@@ -33,5 +33,7 @@ public sealed class DefaultBehaviorDbContext : TestableDbContext
             .HasOne(order => order.Shipment)
             .WithOne(shipment => shipment.Order)
             .HasForeignKey<Shipment>("OrderId");
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/SerializationDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/SerializationDbContext.cs
@@ -22,5 +22,7 @@ public sealed class SerializationDbContext : TestableDbContext
         builder.Entity<Scholarship>()
             .HasMany(scholarship => scholarship.Participants)
             .WithOne(student => student.Scholarship!);
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceReadTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceReadTests.cs
@@ -2429,7 +2429,7 @@ public abstract class ResourceInheritanceReadTests<TDbContext> : IClassFixture<I
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            await dbContext.ClearTableAsync<Vehicle>();
+            await dbContext.ClearTableAsync<Wheel>();
             dbContext.Wheels.AddRange(chromeWheel1, chromeWheel2, chromeWheel3, carbonWheel1, carbonWheel2);
             await dbContext.SaveChangesAsync();
         });
@@ -2487,7 +2487,7 @@ public abstract class ResourceInheritanceReadTests<TDbContext> : IClassFixture<I
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            await dbContext.ClearTableAsync<Vehicle>();
+            await dbContext.ClearTableAsync<Wheel>();
             dbContext.Wheels.AddRange(chromeWheel1, chromeWheel2, chromeWheel3, carbonWheel1, carbonWheel2);
             await dbContext.SaveChangesAsync();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerType/TablePerTypeDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerType/TablePerTypeDbContext.cs
@@ -32,5 +32,7 @@ public sealed class TablePerTypeDbContext : ResourceInheritanceDbContext
         builder.Entity<GenericProperty>().ToTable("GenericProperties");
         builder.Entity<StringProperty>().ToTable("StringProperties");
         builder.Entity<NumberProperty>().ToTable("NumberProperties");
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/SoftDeletion/SoftDeletionDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/SoftDeletion/SoftDeletionDbContext.cs
@@ -24,5 +24,7 @@ public sealed class SoftDeletionDbContext : TestableDbContext
 
         builder.Entity<Department>()
             .HasQueryFilter(department => department.SoftDeletedAt == null);
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/ZeroKeyDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/ZeroKeyDbContext.cs
@@ -27,5 +27,7 @@ public sealed class ZeroKeyDbContext : TestableDbContext
         builder.Entity<Player>()
             .HasOne(player => player.ActiveGame)
             .WithMany(game => game.ActivePlayers);
+
+        base.OnModelCreating(builder);
     }
 }

--- a/test/JsonApiDotNetCoreTests/JsonApiDotNetCoreTests.csproj
+++ b/test/JsonApiDotNetCoreTests/JsonApiDotNetCoreTests.csproj
@@ -4,12 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\TestBuildingBlocks\TestBuildingBlocks.csproj" />
     <ProjectReference Include="..\..\src\JsonApiDotNetCore.SourceGenerators\JsonApiDotNetCore.SourceGenerators.csproj" OutputItemType="Analyzer"
       ReferenceOutputAssembly="false" />

--- a/test/JsonApiDotNetCoreTests/UnitTests/Configuration/DependencyContainerRegistrationTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Configuration/DependencyContainerRegistrationTests.cs
@@ -74,7 +74,7 @@ public sealed class DependencyContainerRegistrationTests
         IHostBuilder hostBuilder = Host.CreateDefaultBuilder().ConfigureWebHostDefaults(webBuilder =>
         {
             webBuilder.ConfigureServices(services =>
-                services.AddDbContext<DependencyContainerRegistrationDbContext>(options => options.UseInMemoryDatabase("db")));
+                services.AddDbContext<DependencyContainerRegistrationDbContext>(options => options.UseInMemoryDatabase(Guid.NewGuid().ToString())));
 
             webBuilder.UseStartup<TestableStartup<DependencyContainerRegistrationDbContext>>();
 

--- a/test/JsonApiDotNetCoreTests/xunit.runner.json
+++ b/test/JsonApiDotNetCoreTests/xunit.runner.json
@@ -1,5 +1,0 @@
-{
-  "parallelizeAssembly": false,
-  "parallelizeTestCollections": false,
-  "maxParallelThreads": 1
-}

--- a/test/MultiDbContextTests/MultiDbContextTests.csproj
+++ b/test/MultiDbContextTests/MultiDbContextTests.csproj
@@ -4,12 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Examples\MultiDbContextExample\MultiDbContextExample.csproj" />
     <ProjectReference Include="..\TestBuildingBlocks\TestBuildingBlocks.csproj" />
   </ItemGroup>

--- a/test/MultiDbContextTests/xunit.runner.json
+++ b/test/MultiDbContextTests/xunit.runner.json
@@ -1,5 +1,0 @@
-{
-  "parallelizeAssembly": false,
-  "parallelizeTestCollections": false,
-  "maxParallelThreads": 1
-}

--- a/test/TestBuildingBlocks/DbContextExtensions.cs
+++ b/test/TestBuildingBlocks/DbContextExtensions.cs
@@ -1,6 +1,5 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Npgsql;
 
 namespace TestBuildingBlocks;
 
@@ -36,17 +35,7 @@ public static class DbContextExtensions
             }
 
             string tableName = entityType.GetTableName()!;
-
-            // PERF: We first try to clear the table, which is fast and usually succeeds, unless foreign key constraints are violated.
-            // In that case, we recursively delete all related data, which is slow.
-            try
-            {
-                await dbContext.Database.ExecuteSqlRawAsync($"delete from \"{tableName}\"");
-            }
-            catch (PostgresException)
-            {
-                await dbContext.Database.ExecuteSqlRawAsync($"truncate table \"{tableName}\" cascade");
-            }
+            await dbContext.Database.ExecuteSqlRawAsync($"delete from \"{tableName}\"");
         }
     }
 }

--- a/test/TestBuildingBlocks/IntegrationTest.cs
+++ b/test/TestBuildingBlocks/IntegrationTest.cs
@@ -2,14 +2,18 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using JsonApiDotNetCore.Middleware;
+using Xunit;
 
 namespace TestBuildingBlocks;
 
 /// <summary>
-/// A base class for tests that conveniently enables to execute HTTP requests against JSON:API endpoints.
+/// A base class for tests that conveniently enables to execute HTTP requests against JSON:API endpoints. It throttles tests that are running in parallel
+/// to avoid exceeding the maximum active database connections.
 /// </summary>
-public abstract class IntegrationTest
+public abstract class IntegrationTest : IAsyncLifetime
 {
+    private static readonly SemaphoreSlim ThrottleSemaphore = new(64);
+
     protected abstract JsonSerializerOptions SerializerOptions { get; }
 
     public async Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecuteHeadAsync<TResponseDocument>(string requestUrl,
@@ -104,5 +108,16 @@ public abstract class IntegrationTest
         {
             throw new FormatException($"Failed to deserialize response body to JSON:\n{responseText}", exception);
         }
+    }
+
+    public async Task InitializeAsync()
+    {
+        await ThrottleSemaphore.WaitAsync();
+    }
+
+    public virtual Task DisposeAsync()
+    {
+        _ = ThrottleSemaphore.Release();
+        return Task.CompletedTask;
     }
 }

--- a/test/TestBuildingBlocks/TestableDbContext.cs
+++ b/test/TestBuildingBlocks/TestableDbContext.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using JsonApiDotNetCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
 
 namespace TestBuildingBlocks;
@@ -16,5 +17,16 @@ public abstract class TestableDbContext : DbContext
     {
         // Writes SQL statements to the Output Window when debugging.
         builder.LogTo(message => Debug.WriteLine(message), DbLoggerCategory.Database.Name.AsArray(), LogLevel.Information);
+    }
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        foreach (IMutableForeignKey foreignKey in builder.Model.GetEntityTypes().SelectMany(entityType => entityType.GetForeignKeys()))
+        {
+            if (foreignKey.DeleteBehavior == DeleteBehavior.ClientSetNull)
+            {
+                foreignKey.DeleteBehavior = DeleteBehavior.SetNull;
+            }
+        }
     }
 }

--- a/test/UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/test/UnitTests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -25,7 +25,7 @@ public sealed class ServiceCollectionExtensionsTests
         // Arrange
         var services = new ServiceCollection();
         services.AddLogging();
-        services.AddDbContext<TestDbContext>(options => options.UseInMemoryDatabase("UnitTestDb"));
+        services.AddDbContext<TestDbContext>(options => options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
 
         // Act
         services.AddJsonApi<TestDbContext>();

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -4,12 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\TestBuildingBlocks\TestBuildingBlocks.csproj" />
   </ItemGroup>
 

--- a/test/UnitTests/xunit.runner.json
+++ b/test/UnitTests/xunit.runner.json
@@ -1,4 +1,0 @@
-{
-  "parallelizeAssembly": false,
-  "parallelizeTestCollections": false
-}


### PR DESCRIPTION
This PR activates async throttling of integration tests (instead of reducing parallelism in xUnit, which is what we had before). It uses the approach described at https://github.com/xunit/xunit/issues/2003#issuecomment-943123699.

Throttling is needed to avoid PostgreSQL failing because the maximum number of open connections has been reached (100 by default). As an alternative for throttling, I've tried increasing the max connections limit to 1000 and 500, but without much success.

I've experimented with various throttling thresholds and found a good balance at 64, which leaves some room for abandoned connections (when hard-killing tests during development and debugging). Watching the database server with pgAdmin while running tests, I didn't see more than ~50 temporary databases simultaneously. Measurements confirm that setting the threshold higher doesn't provide measurable gain.

In addition, all models in integration tests now use `DeleteBehavior.SetNull` instead of `DeleteBehavior.ClientSetNull`, so that PostgreSQL performs the related deletes on the database server. That's not only more reliable but also more efficient; it shaves off another ~5 seconds.

Running all tests on my computer with:

```bash
git clean -xdf ; dotnet build
Measure-Command { dotnet test --no-build | Out-Default }
```

This yields the following results:
| system | master (sec) | PR (sec) | % |
|---|---|---|---|
| local | 96 | 45 | 46% |
| AppVeyor Windows | 209 | 221 | 106% |
| AppVeyor Linux | 239 | 195 | 82% |

Conclusion: this makes running our tests twice as fast locally! The duration of cibuilds varies wildly, so measurements are not very reliable to compare. Also, their VMs have fewer cores, possibly resulting in more context switches. 

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
