### PR TITLE
Answer for issue 1226: Handle int (in DTO) as string in JSON for attribute properties

### DIFF
--- a/src/Examples/JsonApiDotNetCoreExample/Data/AppDbContext.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Data/AppDbContext.cs
@@ -28,13 +28,5 @@ public sealed class AppDbContext : DbContext
         builder.Entity<TodoItem>()
             .HasOne(todoItem => todoItem.Owner)
             .WithMany();
-
-        builder.Entity<MyDto>()
-            .Property(myDto => myDto.EmployeeId)
-            .HasConversion<int?>(
-                // Convert to DB type
-                value => value == null ? null : int.Parse(value),
-                // Convert to model type
-                value => value.ToString());
     }
 }

--- a/src/Examples/JsonApiDotNetCoreExample/Data/AppDbContext.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Data/AppDbContext.cs
@@ -10,6 +10,7 @@ namespace JsonApiDotNetCoreExample.Data;
 public sealed class AppDbContext : DbContext
 {
     public DbSet<TodoItem> TodoItems => Set<TodoItem>();
+    public DbSet<MyDto> MyDtos => Set<MyDto>();
 
     public AppDbContext(DbContextOptions<AppDbContext> options)
         : base(options)
@@ -27,5 +28,13 @@ public sealed class AppDbContext : DbContext
         builder.Entity<TodoItem>()
             .HasOne(todoItem => todoItem.Owner)
             .WithMany();
+
+        builder.Entity<MyDto>()
+            .Property(myDto => myDto.EmployeeId)
+            .HasConversion<int?>(
+                // Convert to DB type
+                value => value == null ? null : int.Parse(value),
+                // Convert to model type
+                value => value.ToString());
     }
 }

--- a/src/Examples/JsonApiDotNetCoreExample/Models/MyDto.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Models/MyDto.cs
@@ -7,5 +7,11 @@ namespace JsonApiDotNetCoreExample.Models;
 public sealed class MyDto : Identifiable<int>
 {
     [Attr]
-    public string? EmployeeId { get; set; }
+    public int? EmployeeId { get; set; }
+
+    [Attr]
+    public int SomeInt { get; set; }
+
+    [Attr]
+    public string? SomeString { get; set; }
 }

--- a/src/Examples/JsonApiDotNetCoreExample/Models/MyDto.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Models/MyDto.cs
@@ -1,0 +1,11 @@
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace JsonApiDotNetCoreExample.Models;
+
+[Resource]
+public sealed class MyDto : Identifiable<int>
+{
+    [Attr]
+    public string? EmployeeId { get; set; }
+}

--- a/src/Examples/JsonApiDotNetCoreExample/Program.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Program.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Diagnostics;
 using JsonApiDotNetCoreExample.Data;
+using JsonApiDotNetCoreExample.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -98,5 +99,17 @@ static async Task CreateDatabaseAsync(IServiceProvider serviceProvider)
     await using AsyncServiceScope scope = serviceProvider.CreateAsyncScope();
 
     var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+    await dbContext.Database.EnsureDeletedAsync();
     await dbContext.Database.EnsureCreatedAsync();
+
+    dbContext.MyDtos.AddRange(new MyDto
+    {
+        EmployeeId = "123"
+    }, new MyDto
+    {
+        EmployeeId = null
+    });
+
+    await dbContext.SaveChangesAsync();
 }

--- a/src/Examples/JsonApiDotNetCoreExample/Serialization/WritePropertyNamesEndingInIdAsStringConverter.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Serialization/WritePropertyNamesEndingInIdAsStringConverter.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JsonApiDotNetCore.Serialization.JsonConverters;
+using JsonApiDotNetCore.Serialization.Objects;
+
+namespace JsonApiDotNetCoreExample.Serialization;
+
+public sealed class WritePropertyNamesEndingInIdAsStringConverter : JsonConverter<ResourceObject>
+{
+    private static readonly JsonEncodedText TypeText = JsonEncodedText.Encode("type");
+    private static readonly JsonEncodedText IdText = JsonEncodedText.Encode("id");
+    private static readonly JsonEncodedText LidText = JsonEncodedText.Encode("lid");
+    private static readonly JsonEncodedText MetaText = JsonEncodedText.Encode("meta");
+    private static readonly JsonEncodedText AttributesText = JsonEncodedText.Encode("attributes");
+    private static readonly JsonEncodedText RelationshipsText = JsonEncodedText.Encode("relationships");
+    private static readonly JsonEncodedText LinksText = JsonEncodedText.Encode("links");
+
+    private readonly ResourceObjectConverter _innerConverter;
+
+    public WritePropertyNamesEndingInIdAsStringConverter(ResourceObjectConverter innerConverter)
+    {
+        ArgumentNullException.ThrowIfNull(innerConverter);
+
+        _innerConverter = innerConverter;
+    }
+
+    public override ResourceObject Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return _innerConverter.Read(ref reader, typeToConvert, options);
+    }
+
+    public override void Write(Utf8JsonWriter writer, ResourceObject value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        writer.WriteString(TypeText, value.Type);
+
+        if (value.Id != null)
+        {
+            writer.WriteString(IdText, value.Id);
+        }
+
+        if (value.Lid != null)
+        {
+            writer.WriteString(LidText, value.Lid);
+        }
+
+        if (value.Attributes != null && value.Attributes.Any())
+        {
+            WriteAttributes(writer, value.Attributes, options);
+        }
+
+        if (value.Relationships != null && value.Relationships.Any())
+        {
+            writer.WritePropertyName(RelationshipsText);
+            WriteSubTree(writer, value.Relationships, options);
+        }
+
+        if (value.Links != null && !string.IsNullOrEmpty(value.Links.Self))
+        {
+            writer.WritePropertyName(LinksText);
+            WriteSubTree(writer, value.Links, options);
+        }
+
+        if (value.Meta != null && value.Meta.Any())
+        {
+            writer.WritePropertyName(MetaText);
+            WriteSubTree(writer, value.Meta, options);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteAttributes(Utf8JsonWriter writer, IDictionary<string, object?> attributes, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject(AttributesText);
+
+        foreach ((string attributeName, object? attributeValue) in attributes)
+        {
+            if (attributeValue == null)
+            {
+                writer.WriteNull(attributeName);
+            }
+            else
+            {
+                writer.WritePropertyName(attributeName);
+
+                object? outputAttributeValue = ShouldWriteAttributeValueAsString(attributeName) ? attributeValue.ToString() : attributeValue;
+                WriteSubTree(writer, outputAttributeValue, options);
+            }
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static bool ShouldWriteAttributeValueAsString(string attributeName)
+    {
+        return attributeName.Length > 2 && attributeName.EndsWith("Id", StringComparison.Ordinal);
+    }
+
+    private static void WriteSubTree<TValue>(Utf8JsonWriter writer, TValue value, JsonSerializerOptions options)
+    {
+        if (typeof(TValue) != typeof(object) && options.GetConverter(typeof(TValue)) is JsonConverter<TValue> converter)
+        {
+            converter.Write(writer, value, options);
+        }
+        else
+        {
+            JsonSerializer.Serialize(writer, value, options);
+        }
+    }
+}

--- a/src/Examples/JsonApiDotNetCoreExample/appsettings.json
+++ b/src/Examples/JsonApiDotNetCoreExample/appsettings.json
@@ -7,7 +7,7 @@
       "Default": "Warning",
       "Microsoft.Hosting.Lifetime": "Warning",
       "Microsoft.EntityFrameworkCore.Update": "Critical",
-      "Microsoft.EntityFrameworkCore.Database.Command": "Critical",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Information",
       "JsonApiDotNetCore.Middleware.JsonApiMiddleware": "Information",
       "Program": "Information"
     }


### PR DESCRIPTION
Answer to the question at https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1226.

This produces the following SQL CREATE statement (see logs):

```sql
CREATE TABLE "MyDtos" (
    "Id" integer GENERATED BY DEFAULT AS IDENTITY,
    "EmployeeId" integer NULL,
    CONSTRAINT "PK_MyDtos" PRIMARY KEY ("Id")
);
```

When sending GET request to http://localhost:14140/api/v1/myDtos:

```json
{
  "links": {
    "self": "/api/v1/myDtos",
    "first": "/api/v1/myDtos",
    "last": "/api/v1/myDtos"
  },
  "data": [
    {
      "type": "myDtos",
      "id": "1",
      "attributes": {
        "employeeId": "123"
      },
      "links": {
        "self": "/api/v1/myDtos/1"
      }
    },
    {
      "type": "myDtos",
      "id": "2",
      "attributes": {
        "employeeId": null
      },
      "links": {
        "self": "/api/v1/myDtos/2"
      }
    }
  ],
  "meta": {
    "total": 2
  }
}
```