### PR TITLE
Allow at least one constant instead of two in any() filter function

### DIFF
--- a/docs/usage/reading/filtering.md
+++ b/docs/usage/reading/filtering.md
@@ -196,7 +196,7 @@ matchTextExpression:
     ( 'contains' | 'startsWith' | 'endsWith' ) LPAREN fieldChain COMMA literalConstant RPAREN;
 
 anyExpression:
-    'any' LPAREN fieldChain COMMA literalConstant ( COMMA literalConstant )+ RPAREN;
+    'any' LPAREN fieldChain ( COMMA literalConstant )+ RPAREN;
 
 hasExpression:
     'has' LPAREN fieldChain ( COMMA filterExpression )? RPAREN;

--- a/src/JsonApiDotNetCore/Queries/Expressions/AnyExpression.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/AnyExpression.cs
@@ -17,12 +17,7 @@ public class AnyExpression : FilterExpression
     public AnyExpression(ResourceFieldChainExpression targetAttribute, IImmutableSet<LiteralConstantExpression> constants)
     {
         ArgumentGuard.NotNull(targetAttribute);
-        ArgumentGuard.NotNull(constants);
-
-        if (constants.Count < 2)
-        {
-            throw new ArgumentException("At least two constants are required.", nameof(constants));
-        }
+        ArgumentGuard.NotNullNorEmpty(constants);
 
         TargetAttribute = targetAttribute;
         Constants = constants;

--- a/src/JsonApiDotNetCore/Queries/Internal/Parsing/FilterParser.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/Parsing/FilterParser.cs
@@ -199,11 +199,6 @@ public class FilterParser : QueryExpressionParser
         LiteralConstantExpression constant = ParseConstant();
         constantsBuilder.Add(constant);
 
-        EatSingleCharacterToken(TokenKind.Comma);
-
-        constant = ParseConstant();
-        constantsBuilder.Add(constant);
-
         while (TokenStack.TryPeek(out Token? nextToken) && nextToken.Kind == TokenKind.Comma)
         {
             EatSingleCharacterToken(TokenKind.Comma);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Filtering/FilterOperatorTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Filtering/FilterOperatorTests.cs
@@ -466,6 +466,7 @@ public sealed class FilterOperatorTests : IClassFixture<IntegrationTestContext<T
     }
 
     [Theory]
+    [InlineData("yes", "no", "'yes'")]
     [InlineData("two", "one two", "'one','two','three'")]
     [InlineData("two", "nine", "'one','two','three','four','five'")]
     public async Task Can_filter_in_set(string matchingText, string nonMatchingText, string filterText)

--- a/test/JsonApiDotNetCoreTests/UnitTests/QueryStringParameters/FilterParseTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/QueryStringParameters/FilterParseTests.cs
@@ -86,7 +86,7 @@ public sealed class FilterParseTests : BaseParseTests
     [InlineData("filter", "any(null,'a','b')", "Attribute 'null' does not exist on resource type 'blogs'.")]
     [InlineData("filter", "any('a','b','c')", "Field name expected.")]
     [InlineData("filter", "any(title,'b','c',)", "Value between quotes expected.")]
-    [InlineData("filter", "any(title,'b')", ", expected.")]
+    [InlineData("filter", "any(title)", ", expected.")]
     [InlineData("filter[posts]", "any(author,'a','b')", "Attribute 'author' does not exist on resource type 'blogPosts'.")]
     [InlineData("filter", "and(", "Filter function expected.")]
     [InlineData("filter", "or(equals(title,'some'),equals(title,'other')", ") expected.")]
@@ -146,6 +146,7 @@ public sealed class FilterParseTests : BaseParseTests
     [InlineData("filter", "contains(title,'this')", null, "contains(title,'this')")]
     [InlineData("filter", "startsWith(title,'this')", null, "startsWith(title,'this')")]
     [InlineData("filter", "endsWith(title,'this')", null, "endsWith(title,'this')")]
+    [InlineData("filter", "any(title,'this')", null, "any(title,'this')")]
     [InlineData("filter", "any(title,'this','that','there')", null, "any(title,'that','there','this')")]
     [InlineData("filter", "and(contains(title,'sales'),contains(title,'marketing'),contains(title,'advertising'))", null,
         "and(contains(title,'sales'),contains(title,'marketing'),contains(title,'advertising'))")]


### PR DESCRIPTION
It turns out that EF Core 6 (tested with PostgreSQL and Sqlite) is smart enough to translate a single-element collection to a SQL `=` expression, instead of `IN (...)`:

```c#
.Where((FilterableResource filterableResource) => #List<string>.Contains(filterableResource.SomeString))
.OrderBy((FilterableResource filterableResource) => filterableResource.Id)
.Take(Tuple.Create(10).Item1)
```

Multiple elements for `#List<string>` reference:
```sql
-- Executed DbCommand (2ms) [Parameters=[@__Create_Item1_0='10'], CommandType='Text', CommandTimeout='30']
SELECT f.*
FROM "FilterableResources" AS f
WHERE f."SomeString" IN ('four', 'three', 'one', 'two', 'five')
ORDER BY f."Id"
LIMIT @__Create_Item1_0
```

Single element:
```sql
-- Executed DbCommand (1ms) [Parameters=[@__Create_Item1_0='10'], CommandType='Text', CommandTimeout='30']
SELECT f.*
FROM "FilterableResources" AS f
WHERE f."SomeString" = 'yes'
ORDER BY f."Id"
LIMIT @__Create_Item1_0
```

Closes #1152.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [x] Documentation updated
