### PR TITLE
Answer for question at #1238

### DIFF
--- a/src/Examples/NoEntityFrameworkExample/Models/Booking.cs
+++ b/src/Examples/NoEntityFrameworkExample/Models/Booking.cs
@@ -1,0 +1,15 @@
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace NoEntityFrameworkExample.Models;
+
+// This is the main resource for which I'm creating the API:
+[Resource]
+public class Booking : Identifiable<string>
+{
+    [Attr(PublicName = "title")]
+    public required string Title { get; set; }
+
+    [HasMany(PublicName = "spaces")]
+    public required List<Space> Spaces { get; set; } // space ids
+}

--- a/src/Examples/NoEntityFrameworkExample/Models/Space.cs
+++ b/src/Examples/NoEntityFrameworkExample/Models/Space.cs
@@ -1,0 +1,12 @@
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace NoEntityFrameworkExample.Models;
+
+// This is another resource which should be connected to Bookings.
+[Resource]
+public class Space : Identifiable<string>
+{
+    [Attr(PublicName = "title")]
+    public required string Title { get; set; }
+}

--- a/src/Examples/NoEntityFrameworkExample/NoEntityFrameworkExample.csproj
+++ b/src/Examples/NoEntityFrameworkExample/NoEntityFrameworkExample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkName)</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Examples/NoEntityFrameworkExample/Program.cs
+++ b/src/Examples/NoEntityFrameworkExample/Program.cs
@@ -10,9 +10,19 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 string connectionString = GetConnectionString(builder.Configuration);
 builder.Services.AddNpgsql<AppDbContext>(connectionString);
 
-builder.Services.AddJsonApi(options => options.Namespace = "api/v1", resources: resourceGraphBuilder => resourceGraphBuilder.Add<WorkItem, int>());
+builder.Services.AddJsonApi(options =>
+{
+    options.Namespace = "api/v1";
+    options.SerializerOptions.WriteIndented = true;
+}, resources: resourceGraphBuilder =>
+{
+    resourceGraphBuilder.Add<WorkItem, int>();
+    resourceGraphBuilder.Add<Booking, string>();
+    resourceGraphBuilder.Add<Space, string>();
+});
 
 builder.Services.AddResourceService<WorkItemService>();
+builder.Services.AddResourceService<BookingsService>();
 
 WebApplication app = builder.Build();
 

--- a/src/Examples/NoEntityFrameworkExample/Properties/launchSettings.json
+++ b/src/Examples/NoEntityFrameworkExample/Properties/launchSettings.json
@@ -12,7 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "api/v1/workItems",
+      "launchUrl": "api/v1/bookings?include=spaces",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -20,7 +20,7 @@
     "Kestrel": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/v1/workItems",
+      "launchUrl": "api/v1/bookings?include=spaces",
       "applicationUrl": "https://localhost:44349;http://localhost:14149",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/Examples/NoEntityFrameworkExample/Services/BookingsService.cs
+++ b/src/Examples/NoEntityFrameworkExample/Services/BookingsService.cs
@@ -11,15 +11,22 @@ namespace NoEntityFrameworkExample.Services;
 // This is the implementation of BookingService.
 public class BookingsService : JsonApiResourceService<Booking, string>
 {
+    private readonly IQueryLayerComposer _queryLayerComposer;
+    private readonly IJsonApiRequest _request;
+
     public BookingsService(IResourceRepositoryAccessor repositoryAccessor, IQueryLayerComposer queryLayerComposer, IPaginationContext paginationContext,
         IJsonApiOptions options, ILoggerFactory loggerFactory, IJsonApiRequest request, IResourceChangeTracker<Booking> resourceChangeTracker,
         IResourceDefinitionAccessor resourceDefinitionAccessor)
         : base(repositoryAccessor, queryLayerComposer, paginationContext, options, loggerFactory, request, resourceChangeTracker, resourceDefinitionAccessor)
     {
+        _queryLayerComposer = queryLayerComposer;
+        _request = request;
     }
 
     public override async Task<IReadOnlyCollection<Booking>> GetAsync(CancellationToken cancellationToken)
     {
+        _queryLayerComposer.ComposeFromConstraints(_request.PrimaryResourceType!);
+
         return new List<Booking>
         {
             new()

--- a/src/Examples/NoEntityFrameworkExample/Services/BookingsService.cs
+++ b/src/Examples/NoEntityFrameworkExample/Services/BookingsService.cs
@@ -1,0 +1,53 @@
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Middleware;
+using JsonApiDotNetCore.Queries;
+using JsonApiDotNetCore.Repositories;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Services;
+using NoEntityFrameworkExample.Models;
+
+namespace NoEntityFrameworkExample.Services;
+
+// This is the implementation of BookingService.
+public class BookingsService : JsonApiResourceService<Booking, string>
+{
+    public BookingsService(IResourceRepositoryAccessor repositoryAccessor, IQueryLayerComposer queryLayerComposer, IPaginationContext paginationContext,
+        IJsonApiOptions options, ILoggerFactory loggerFactory, IJsonApiRequest request, IResourceChangeTracker<Booking> resourceChangeTracker,
+        IResourceDefinitionAccessor resourceDefinitionAccessor)
+        : base(repositoryAccessor, queryLayerComposer, paginationContext, options, loggerFactory, request, resourceChangeTracker, resourceDefinitionAccessor)
+    {
+    }
+
+    public override async Task<IReadOnlyCollection<Booking>> GetAsync(CancellationToken cancellationToken)
+    {
+        return new List<Booking>
+        {
+            new()
+            {
+                Id = "1",
+                Title = "booking 1",
+                Spaces = new List<Space>
+                {
+                    new()
+                    {
+                        Id = "1",
+                        Title = "test space"
+                    }
+                }
+            },
+            new()
+            {
+                Id = "2",
+                Title = "booking 2",
+                Spaces = new List<Space>
+                {
+                    new()
+                    {
+                        Id = "1",
+                        Title = "test space"
+                    }
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
The first commit in this PR adds the repro scenario from #1238 to the NoEntityFrameworkExample project. The second commit fixes the problem. Set that project as the startup project and press F5 to run.

Without the fix, adding a breakpoint at:

https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/be992341d236094e0abbf9d0a8e9bafb788356c8/src/JsonApiDotNetCore/Serialization/Response/ResponseModelAdapter.cs#L67

shows that `_evaluatedIncludeCache` is empty. It does not contain the requested include from query string. Searching for usages of its `Set` method, we can see it is called by `QueryLayerComposer.ComposeFromConstraints`:

https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/be992341d236094e0abbf9d0a8e9bafb788356c8/src/JsonApiDotNetCore/Queries/Internal/QueryLayerComposer.cs#L141

which in turn is called by the built-in resource service `GetAsync` method at:

https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/be992341d236094e0abbf9d0a8e9bafb788356c8/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs#L76

So the fix is to call this method before returning the data.

Now, why is this needed? When using the built-in resource service and repository, callbacks are made into `IResourceDefinition<,>` methods, which is our extensibility point for API developers to write custom business logic. In this case, `OnApplyIncludes` is called, which enables developers to add/remove includes from the request. The evaluated set of includes is then stored in `IEvaluatedIncludeCache`. Likewise, there's an `ISparseFieldSetCache` that behaves similarly.

`QueryLayerComposer.ComposeFromConstraints` gathers all the parsed query string parameters, combines that with configured options (such as default page size), and turns that into a `QueryLayer` object, which is the internal representation of the current request. While building that, it visits the `IResourceDefinition<,>` methods. Call `QueryLayer.ToString()` in the debugger to see what it contains. It may be of use in your further custom resource service implementation. `QueryLayer` is passed to `IResourceRepository<>`, which is database-agnostic. Instead of creating a custom resource service, it may be easier to create a custom repository instead. That way, you're reusing a lot of the built-in features at the resource service level.

Closes #1238.
