### PR TITLE
Package updates; run tests against EF Core 7

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "regitlint": {
-      "version": "6.2.1",
+      "version": "6.3.10",
       "commands": [
         "regitlint"
       ]
@@ -21,7 +21,7 @@
       ]
     },
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.1.11",
+      "version": "5.1.15",
       "commands": [
         "reportgenerator"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <TargetFrameworkName>net6.0</TargetFrameworkName>
     <AspNetVersion>6.0.*</AspNetVersion>
-    <EFCoreVersion>6.0.*</EFCoreVersion>
-    <EFCorePostgresVersion>6.0.*</EFCorePostgresVersion>
-    <MicrosoftCodeAnalysisVersion>4.3.*</MicrosoftCodeAnalysisVersion>
+    <EFCoreVersion>7.0.*</EFCoreVersion>
+    <EFCorePostgresVersion>7.0.*</EFCorePostgresVersion>
+    <MicrosoftCodeAnalysisVersion>4.4.*</MicrosoftCodeAnalysisVersion>
     <HumanizerVersion>2.14.1</HumanizerVersion>
     <JsonApiDotNetCoreVersionPrefix>5.1.2</JsonApiDotNetCoreVersionPrefix>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodingGuidelines.ruleset</CodeAnalysisRuleSet>
@@ -33,8 +33,8 @@
 
   <!-- Test Project Dependencies -->
   <PropertyGroup>
-    <CoverletVersion>3.2.0</CoverletVersion>
-    <MoqVersion>4.18.2</MoqVersion>
-    <TestSdkVersion>17.4.0</TestSdkVersion>
+    <CoverletVersion>3.2.*</CoverletVersion>
+    <MoqVersion>4.18.*</MoqVersion>
+    <TestSdkVersion>17.4.*</TestSdkVersion>
   </PropertyGroup>
 </Project>

--- a/benchmarks/Benchmarks.csproj
+++ b/benchmarks/Benchmarks.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" PrivateAssets="all">
       <!-- This reference solely exists to prevent build warnings for conflicting versions of Microsoft.CodeAnalysis. -->
     </PackageReference>

--- a/src/Examples/JsonApiDotNetCoreExample/Program.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Program.cs
@@ -47,7 +47,7 @@ static void ConfigureServices(WebApplicationBuilder builder)
 
     builder.Services.AddDbContext<AppDbContext>(options =>
     {
-        string connectionString = GetConnectionString(builder.Configuration);
+        string? connectionString = GetConnectionString(builder.Configuration);
 
         options.UseNpgsql(connectionString);
 #if DEBUG
@@ -73,10 +73,10 @@ static void ConfigureServices(WebApplicationBuilder builder)
     }
 }
 
-static string GetConnectionString(IConfiguration configuration)
+static string? GetConnectionString(IConfiguration configuration)
 {
     string postgresPassword = Environment.GetEnvironmentVariable("PGPASSWORD") ?? "postgres";
-    return configuration["Data:DefaultConnection"].Replace("###", postgresPassword);
+    return configuration["Data:DefaultConnection"]?.Replace("###", postgresPassword);
 }
 
 static void ConfigurePipeline(WebApplication webApplication)

--- a/src/Examples/NoEntityFrameworkExample/Program.cs
+++ b/src/Examples/NoEntityFrameworkExample/Program.cs
@@ -7,7 +7,7 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
-string connectionString = GetConnectionString(builder.Configuration);
+string? connectionString = GetConnectionString(builder.Configuration);
 builder.Services.AddNpgsql<AppDbContext>(connectionString);
 
 builder.Services.AddJsonApi(options => options.Namespace = "api/v1", resources: resourceGraphBuilder => resourceGraphBuilder.Add<WorkItem, int>());
@@ -26,10 +26,10 @@ await CreateDatabaseAsync(app.Services);
 
 app.Run();
 
-static string GetConnectionString(IConfiguration configuration)
+static string? GetConnectionString(IConfiguration configuration)
 {
     string postgresPassword = Environment.GetEnvironmentVariable("PGPASSWORD") ?? "postgres";
-    return configuration["Data:DefaultConnection"].Replace("###", postgresPassword);
+    return configuration["Data:DefaultConnection"]?.Replace("###", postgresPassword);
 }
 
 static async Task CreateDatabaseAsync(IServiceProvider serviceProvider)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceWriteTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceWriteTests.cs
@@ -2298,7 +2298,7 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            dbContext.Set<VehicleManufacturer>().Add(existingManufacturer);
+            dbContext.VehicleManufacturers.Add(existingManufacturer);
             dbContext.Vehicles.Add(existingTandem);
             await dbContext.SaveChangesAsync();
         });
@@ -2327,8 +2327,16 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            VehicleManufacturer manufacturerInDatabase = await dbContext.Set<VehicleManufacturer>().Include(manufacturer => manufacturer.Vehicles)
+            // @formatter:wrap_chained_method_calls chop_always
+            // @formatter:keep_existing_linebreaks true
+
+            VehicleManufacturer manufacturerInDatabase = await dbContext.VehicleManufacturers
+                .Include(manufacturer => manufacturer.Vehicles
+                    .OrderByDescending(vehicle => vehicle.Id))
                 .FirstWithIdAsync(existingManufacturer.Id);
+
+            // @formatter:keep_existing_linebreaks restore
+            // @formatter:wrap_chained_method_calls restore
 
             manufacturerInDatabase.Vehicles.ShouldHaveCount(2);
             manufacturerInDatabase.Vehicles.ElementAt(0).Should().BeOfType<Car>();
@@ -2578,7 +2586,7 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            dbContext.Set<VehicleManufacturer>().Add(existingManufacturer);
+            dbContext.VehicleManufacturers.Add(existingManufacturer);
             await dbContext.SaveChangesAsync();
         });
 
@@ -2606,7 +2614,7 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            VehicleManufacturer manufacturerInDatabase = await dbContext.Set<VehicleManufacturer>().Include(manufacturer => manufacturer.Vehicles)
+            VehicleManufacturer manufacturerInDatabase = await dbContext.VehicleManufacturers.Include(manufacturer => manufacturer.Vehicles)
                 .FirstWithIdAsync(existingManufacturer.Id);
 
             manufacturerInDatabase.Vehicles.ShouldHaveCount(1);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerConcreteType/TablePerConcreteTypeDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerConcreteType/TablePerConcreteTypeDbContext.cs
@@ -4,12 +4,12 @@ using Microsoft.EntityFrameworkCore;
 
 // @formatter:wrap_chained_method_calls chop_always
 
-namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceInheritance.TablePerType;
+namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceInheritance.TablePerConcreteType;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class TablePerTypeDbContext : ResourceInheritanceDbContext
+public sealed class TablePerConcreteTypeDbContext : ResourceInheritanceDbContext
 {
-    public TablePerTypeDbContext(DbContextOptions<TablePerTypeDbContext> options)
+    public TablePerConcreteTypeDbContext(DbContextOptions<TablePerConcreteTypeDbContext> options)
         : base(options)
     {
     }
@@ -17,16 +17,16 @@ public sealed class TablePerTypeDbContext : ResourceInheritanceDbContext
     protected override void OnModelCreating(ModelBuilder builder)
     {
         builder.Entity<Vehicle>()
-            .UseTptMappingStrategy();
+            .UseTpcMappingStrategy();
 
         builder.Entity<Wheel>()
-            .UseTptMappingStrategy();
+            .UseTpcMappingStrategy();
 
         builder.Entity<Engine>()
-            .UseTptMappingStrategy();
+            .UseTpcMappingStrategy();
 
         builder.Entity<GenericProperty>()
-            .UseTptMappingStrategy();
+            .UseTpcMappingStrategy();
 
         base.OnModelCreating(builder);
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerConcreteType/TablePerConcreteTypeReadTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerConcreteType/TablePerConcreteTypeReadTests.cs
@@ -1,0 +1,13 @@
+using JetBrains.Annotations;
+using TestBuildingBlocks;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceInheritance.TablePerConcreteType;
+
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+public sealed class TablePerConcreteTypeReadTests : ResourceInheritanceReadTests<TablePerConcreteTypeDbContext>
+{
+    public TablePerConcreteTypeReadTests(IntegrationTestContext<TestableStartup<TablePerConcreteTypeDbContext>, TablePerConcreteTypeDbContext> testContext)
+        : base(testContext)
+    {
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerConcreteType/TablePerConcreteTypeWriteTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerConcreteType/TablePerConcreteTypeWriteTests.cs
@@ -1,0 +1,13 @@
+using JetBrains.Annotations;
+using TestBuildingBlocks;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceInheritance.TablePerConcreteType;
+
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+public sealed class TablePerConcreteTypeWriteTests : ResourceInheritanceWriteTests<TablePerConcreteTypeDbContext>
+{
+    public TablePerConcreteTypeWriteTests(IntegrationTestContext<TestableStartup<TablePerConcreteTypeDbContext>, TablePerConcreteTypeDbContext> testContext)
+        : base(testContext)
+    {
+    }
+}

--- a/test/SourceGeneratorTests/CompilationBuilder.cs
+++ b/test/SourceGeneratorTests/CompilationBuilder.cs
@@ -9,7 +9,13 @@ namespace SourceGeneratorTests;
 
 internal sealed class CompilationBuilder
 {
-    private static readonly CSharpCompilationOptions DefaultOptions = new(OutputKind.DynamicallyLinkedLibrary);
+    private static readonly CSharpCompilationOptions DefaultOptions =
+        new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary).WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic>
+        {
+            // Suppress warning for version conflict on Microsoft.Extensions.Logging.Abstractions:
+            // JsonApiDotNetCore indirectly depends on v6 (via Entity Framework Core 6), whereas Entity Framework Core 7 depends on v7.
+            ["CS1701"] = ReportDiagnostic.Suppress
+        });
 
     private readonly HashSet<SyntaxTree> _syntaxTrees = new();
     private readonly HashSet<MetadataReference> _references = new();

--- a/test/TestBuildingBlocks/FakeLoggerFactory.cs
+++ b/test/TestBuildingBlocks/FakeLoggerFactory.cs
@@ -59,6 +59,7 @@ public sealed class FakeLoggerFactory : ILoggerFactory, ILoggerProvider
         }
 
         public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
         {
             return NullScope.Instance;
         }

--- a/test/TestBuildingBlocks/TestBuildingBlocks.csproj
+++ b/test/TestBuildingBlocks/TestBuildingBlocks.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)" PrivateAssets="All" />
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="FluentAssertions" Version="6.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EFCoreVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />


### PR DESCRIPTION
In addition to minor package updates, this PR makes tests run against EF Core 7.
All code still targets .NET 6, and JsonApiDotNetCore itself still references EF Core 6, so this is a non-breaking change.

Closes #1212.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
