### PR TITLE
Fix missing HttpContext on ValidationContext during atomic operations

### DIFF
--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiOperationsController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiOperationsController.cs
@@ -166,7 +166,8 @@ public abstract class BaseJsonApiOperationsController : CoreJsonApiController
                 ModelState =
                 {
                     MaxAllowedErrors = maxErrorsRemaining
-                }
+                },
+                HttpContext = HttpContext
             };
 
             ObjectValidator.Validate(validationContext, null, string.Empty, operation.Resource);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using FluentAssertions.Extensions;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Serialization.Objects;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using TestBuildingBlocks;
@@ -25,6 +26,11 @@ public sealed class AtomicCreateResourceTests : IClassFixture<IntegrationTestCon
         testContext.UseController<LyricsController>();
         testContext.UseController<MusicTracksController>();
         testContext.UseController<PlaylistsController>();
+
+        testContext.ConfigureServicesBeforeStartup(services =>
+        {
+            services.AddSingleton<ISystemClock, FrozenSystemClock>();
+        });
 
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
         options.AllowUnknownFieldsInRequestBody = false;

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithClientGeneratedIdTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithClientGeneratedIdTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using FluentAssertions;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Serialization.Objects;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using TestBuildingBlocks;
 using Xunit;
@@ -28,6 +29,7 @@ public sealed class AtomicCreateResourceWithClientGeneratedIdTests
             services.AddResourceDefinition<ImplicitlyChangingTextLanguageDefinition>();
 
             services.AddSingleton<ResourceDefinitionHitCounter>();
+            services.AddSingleton<ISystemClock, FrozenSystemClock>();
         });
 
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/DateMustBeInThePastAttribute.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/DateMustBeInThePastAttribute.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+using JsonApiDotNetCore.Resources;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations;
+
+[AttributeUsage(AttributeTargets.Property)]
+internal sealed class DateMustBeInThePastAttribute : ValidationAttribute
+{
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        var targetedFields = validationContext.GetRequiredService<ITargetedFields>();
+
+        if (targetedFields.Attributes.Any(attribute => attribute.Property.Name == validationContext.MemberName))
+        {
+            PropertyInfo propertyInfo = validationContext.ObjectType.GetProperty(validationContext.MemberName!)!;
+
+            if (propertyInfo.PropertyType == typeof(DateTimeOffset) || propertyInfo.PropertyType == typeof(DateTimeOffset?))
+            {
+                var typedValue = (DateTimeOffset?)propertyInfo.GetValue(validationContext.ObjectInstance);
+                var systemClock = validationContext.GetRequiredService<ISystemClock>();
+
+                if (typedValue >= systemClock.UtcNow)
+                {
+                    return new ValidationResult($"{validationContext.MemberName} must be in the past.");
+                }
+            }
+        }
+
+        return ValidationResult.Success;
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/AtomicResourceMetaTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/AtomicResourceMetaTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using FluentAssertions.Extensions;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Serialization.Objects;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using TestBuildingBlocks;
 using Xunit;
@@ -27,6 +28,7 @@ public sealed class AtomicResourceMetaTests : IClassFixture<IntegrationTestConte
             services.AddResourceDefinition<TextLanguageMetaDefinition>();
 
             services.AddSingleton<ResourceDefinitionHitCounter>();
+            services.AddSingleton<ISystemClock, FrozenSystemClock>();
         });
 
         var hitCounter = _testContext.Factory.Services.GetRequiredService<ResourceDefinitionHitCounter>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/MusicTrack.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/MusicTrack.cs
@@ -23,6 +23,7 @@ public sealed class MusicTrack : Identifiable<Guid>
     public string? Genre { get; set; }
 
     [Attr]
+    [DateMustBeInThePast]
     public DateTimeOffset ReleasedAt { get; set; }
 
     [HasOne]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Updating/Resources/AtomicUpdateResourceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Updating/Resources/AtomicUpdateResourceTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using FluentAssertions.Extensions;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Serialization.Objects;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using TestBuildingBlocks;
@@ -29,6 +30,7 @@ public sealed class AtomicUpdateResourceTests : IClassFixture<IntegrationTestCon
             services.AddResourceDefinition<ImplicitlyChangingTextLanguageDefinition>();
 
             services.AddSingleton<ResourceDefinitionHitCounter>();
+            services.AddSingleton<ISystemClock, FrozenSystemClock>();
         });
 
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();

--- a/test/TestBuildingBlocks/FakerContainer.cs
+++ b/test/TestBuildingBlocks/FakerContainer.cs
@@ -12,7 +12,7 @@ public abstract class FakerContainer
     {
         // Setting the system DateTime to kind Utc, so that faker calls like PastOffset() don't depend on the system time zone.
         // See https://docs.microsoft.com/en-us/dotnet/api/system.datetimeoffset.op_implicit?view=net-6.0#remarks
-        Date.SystemClock = () => 1.January(2020).AsUtc();
+        Date.SystemClock = () => 1.January(2020).At(1, 1, 1).AsUtc();
     }
 
     protected static int GetFakerSeed()

--- a/test/TestBuildingBlocks/FrozenSystemClock.cs
+++ b/test/TestBuildingBlocks/FrozenSystemClock.cs
@@ -5,7 +5,7 @@ namespace TestBuildingBlocks;
 
 public sealed class FrozenSystemClock : ISystemClock
 {
-    private static readonly DateTimeOffset DefaultTime = 1.January(2000).At(1, 1, 1).AsUtc();
+    private static readonly DateTimeOffset DefaultTime = 1.January(2020).At(1, 1, 1).AsUtc();
 
     public DateTimeOffset UtcNow { get; set; } = DefaultTime;
 }


### PR DESCRIPTION
Closes #1250

This PR
* Adds `HttpContext` to the `ValidationContext` when validating objects during atomic operations, allowing dependency injection
* Adds a test case to the integration tests to validate this

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A Documentation updated
