### PR TITLE
Fixed: ModelState validation failed when [Range] does not include property default value

### DIFF
--- a/src/JsonApiDotNetCore/Configuration/JsonApiModelMetadataProvider.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiModelMetadataProvider.cs
@@ -32,11 +32,7 @@ internal sealed class JsonApiModelMetadataProvider : DefaultModelMetadataProvide
     protected override ModelMetadata CreateModelMetadata(DefaultMetadataDetails entry)
     {
         var metadata = (DefaultModelMetadata)base.CreateModelMetadata(entry);
-
-        if (metadata.ValidationMetadata.IsRequired == true)
-        {
-            metadata.ValidationMetadata.PropertyValidationFilter = _jsonApiValidationFilter;
-        }
+        metadata.ValidationMetadata.PropertyValidationFilter = _jsonApiValidationFilter;
 
         return metadata;
     }

--- a/src/JsonApiDotNetCore/Configuration/JsonApiValidationFilter.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiValidationFilter.cs
@@ -1,6 +1,7 @@
 using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.Resources;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -23,15 +24,13 @@ internal sealed class JsonApiValidationFilter : IPropertyValidationFilter
     /// <inheritdoc />
     public bool ShouldValidateEntry(ValidationEntry entry, ValidationEntry parentEntry)
     {
-        IServiceProvider serviceProvider = GetScopedServiceProvider();
-
-        var request = serviceProvider.GetRequiredService<IJsonApiRequest>();
-
-        if (IsId(entry.Key))
+        if (entry.Metadata.MetadataKind == ModelMetadataKind.Type || IsId(entry.Key))
         {
             return true;
         }
 
+        IServiceProvider serviceProvider = GetScopedServiceProvider();
+        var request = serviceProvider.GetRequiredService<IJsonApiRequest>();
         bool isTopResourceInPrimaryRequest = string.IsNullOrEmpty(parentEntry.Key) && IsAtPrimaryEndpoint(request);
 
         if (!isTopResourceInPrimaryRequest)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/ModelStateFakers.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/ModelStateFakers.cs
@@ -17,14 +17,14 @@ internal sealed class ModelStateFakers : FakerContainer
         new Faker<SystemFile>()
             .UseSeed(GetFakerSeed())
             .RuleFor(systemFile => systemFile.FileName, faker => faker.System.FileName())
+            .RuleFor(systemFile => systemFile.Attributes, faker => faker.Random.Enum(FileAttributes.Normal, FileAttributes.Hidden, FileAttributes.ReadOnly))
             .RuleFor(systemFile => systemFile.SizeInBytes, faker => faker.Random.Long(0, 1_000_000)));
 
     private readonly Lazy<Faker<SystemDirectory>> _lazySystemDirectoryFaker = new(() =>
         new Faker<SystemDirectory>()
             .UseSeed(GetFakerSeed())
-            .RuleFor(systemDirectory => systemDirectory.Name, faker => faker.Address.City())
-            .RuleFor(systemDirectory => systemDirectory.IsCaseSensitive, faker => faker.Random.Bool())
-            .RuleFor(systemDirectory => systemDirectory.SizeInBytes, faker => faker.Random.Long(0, 1_000_000)));
+            .RuleFor(systemDirectory => systemDirectory.Name, faker => Path.GetFileNameWithoutExtension(faker.System.FileName()))
+            .RuleFor(systemDirectory => systemDirectory.IsCaseSensitive, faker => faker.Random.Bool()));
 
     public Faker<SystemVolume> SystemVolume => _lazySystemVolumeFaker.Value;
     public Faker<SystemFile> SystemFile => _lazySystemFileFaker.Value;

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/ModelStateValidationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/ModelStateValidationTests.cs
@@ -166,8 +166,6 @@ public sealed class ModelStateValidationTests : IClassFixture<IntegrationTestCon
                 type = "systemDirectories",
                 attributes = new
                 {
-                    isCaseSensitive = false,
-                    sizeInBytes = -1
                 }
             }
         };
@@ -192,9 +190,9 @@ public sealed class ModelStateValidationTests : IClassFixture<IntegrationTestCon
         ErrorObject error2 = responseDocument.Errors[1];
         error2.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
         error2.Title.Should().Be("Input validation failed.");
-        error2.Detail.Should().Be("The field SizeInBytes must be between 0 and 9223372036854775807.");
+        error2.Detail.Should().Be("The IsCaseSensitive field is required.");
         error2.Source.ShouldNotBeNull();
-        error2.Source.Pointer.Should().Be("/data/attributes/sizeInBytes");
+        error2.Source.Pointer.Should().Be("/data/attributes/isCaseSensitive");
     }
 
     [Fact]
@@ -205,15 +203,14 @@ public sealed class ModelStateValidationTests : IClassFixture<IntegrationTestCon
         {
             data = new
             {
-                type = "systemDirectories",
+                type = "systemFiles",
                 attributes = new
                 {
-                    sizeInBytes = -1
                 }
             }
         };
 
-        const string route = "/systemDirectories";
+        const string route = "/systemFiles";
 
         // Act
         (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
@@ -232,16 +229,16 @@ public sealed class ModelStateValidationTests : IClassFixture<IntegrationTestCon
         ErrorObject error2 = responseDocument.Errors[1];
         error2.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
         error2.Title.Should().Be("Input validation failed.");
-        error2.Detail.Should().Be("The Name field is required.");
+        error2.Detail.Should().Be("The FileName field is required.");
         error2.Source.ShouldNotBeNull();
-        error2.Source.Pointer.Should().Be("/data/attributes/directoryName");
+        error2.Source.Pointer.Should().Be("/data/attributes/fileName");
 
         ErrorObject error3 = responseDocument.Errors[2];
         error3.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
         error3.Title.Should().Be("Input validation failed.");
-        error3.Detail.Should().Be("The IsCaseSensitive field is required.");
+        error3.Detail.Should().Be("The Attributes field is required.");
         error3.Source.ShouldNotBeNull();
-        error3.Source.Pointer.Should().Be("/data/attributes/isCaseSensitive");
+        error3.Source.Pointer.Should().Be("/data/attributes/attributes");
     }
 
     [Fact]
@@ -360,13 +357,13 @@ public sealed class ModelStateValidationTests : IClassFixture<IntegrationTestCon
     public async Task Can_update_resource_with_omitted_required_attribute_value()
     {
         // Arrange
-        SystemDirectory existingDirectory = _fakers.SystemDirectory.Generate();
+        SystemFile existingFile = _fakers.SystemFile.Generate();
 
-        long newSizeInBytes = _fakers.SystemDirectory.Generate().SizeInBytes;
+        long? newSizeInBytes = _fakers.SystemFile.Generate().SizeInBytes;
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            dbContext.Directories.Add(existingDirectory);
+            dbContext.Files.Add(existingFile);
             await dbContext.SaveChangesAsync();
         });
 
@@ -374,8 +371,8 @@ public sealed class ModelStateValidationTests : IClassFixture<IntegrationTestCon
         {
             data = new
             {
-                type = "systemDirectories",
-                id = existingDirectory.StringId,
+                type = "systemFiles",
+                id = existingFile.StringId,
                 attributes = new
                 {
                     sizeInBytes = newSizeInBytes
@@ -383,7 +380,7 @@ public sealed class ModelStateValidationTests : IClassFixture<IntegrationTestCon
             }
         };
 
-        string route = $"/systemDirectories/{existingDirectory.StringId}";
+        string route = $"/systemFiles/{existingFile.StringId}";
 
         // Act
         (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePatchAsync<string>(route, requestBody);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/SystemDirectory.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/SystemDirectory.cs
@@ -20,10 +20,6 @@ public sealed class SystemDirectory : Identifiable<int>
     [Required]
     public bool? IsCaseSensitive { get; set; }
 
-    [Attr]
-    [Range(typeof(long), "0", "9223372036854775807")]
-    public long SizeInBytes { get; set; }
-
     [HasMany]
     public ICollection<SystemDirectory> Subdirectories { get; set; } = new List<SystemDirectory>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/SystemFile.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/SystemFile.cs
@@ -15,6 +15,9 @@ public sealed class SystemFile : Identifiable<int>
 
     [Attr]
     [Required]
-    [Range(typeof(long), "0", "9223372036854775807")]
-    public long? SizeInBytes { get; set; }
+    public FileAttributes? Attributes { get; set; }
+
+    [Attr]
+    [Range(typeof(long), "1", "9223372036854775807")]
+    public long SizeInBytes { get; set; }
 }


### PR DESCRIPTION
Before this change, the JADNC ModelState validation filter would only kick in for required properties, which is incorrect. We didn't have a test for an optional property containing a range validation, where the property default value is not in the required range. In that case, using such a resource as non-toplevel (for example: update relationship) would incorrectly produce a validation error.

For example:
```c#
[Attr]
[Range(10, 100)]
public int Value { get; set; }
```

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
