### PR TITLE
Fail on missing required non-nullable value type in request body

### DIFF
--- a/src/JsonApiDotNetCore/Serialization/Request/JsonMissingRequiredAttributeInfo.cs
+++ b/src/JsonApiDotNetCore/Serialization/Request/JsonMissingRequiredAttributeInfo.cs
@@ -1,0 +1,19 @@
+namespace JsonApiDotNetCore.Serialization.Request;
+
+/// <summary>
+/// A sentinel value that is temporarily stored in the attributes dictionary to postpone producing an error.
+/// </summary>
+internal sealed class JsonMissingRequiredAttributeInfo
+{
+    public string AttributeName { get; }
+    public string ResourceName { get; }
+
+    public JsonMissingRequiredAttributeInfo(string attributeName, string resourceName)
+    {
+        ArgumentGuard.NotNull(attributeName);
+        ArgumentGuard.NotNull(resourceName);
+
+        AttributeName = attributeName;
+        ResourceName = resourceName;
+    }
+}


### PR DESCRIPTION
This proof-of-concept PR fails deserialization of an incoming request body at a POST resource endpoint when the value is omitted for a non-nullable value type property decorated with `[Attr] [Required]`.

This works around the limitation in ASP.NET ModelState validation described at https://www.jsonapi.net/usage/resources/nullability.html#value-types.

However, I wonder if we should actually take this approach. It feels like a dirty hack that mixes model binding with validation, which are distinct steps in ASP.NET. Also, it prevents any other ModelState violations from being returned in the response. A better approach would be to still detect it during deserialization, but instead of producing an error, somehow make it result in a ModelState validation error via request-scoped shared state. This would only work properly when ModelState validation is turned on. That approach would potentially apply to various other errors that currently cause a deserialization failure, such as "missing ID", "property is read-only" etc.

And this is just one approach to dealing with the situation. Alternatives:
- Document the behavior and advise users not to do this. This is a fundamental limitation in ASP.NET, not our concern.
- Scan for this situation when building the resource graph and produce a hard error that prevents application startup, or log a warning. The former is a breaking change, the latter means it'll still occur and we may want to handle it.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] TODO: Adapted tests
- [ ] Documentation updated
