### PR TITLE
Fixed: incorrect meta:total on secondary endpoint with filter

### DIFF
--- a/src/JsonApiDotNetCore/Queries/Internal/QueryLayerComposer.cs
+++ b/src/JsonApiDotNetCore/Queries/Internal/QueryLayerComposer.cs
@@ -82,13 +82,11 @@ public class QueryLayerComposer : IQueryLayerComposer
 
         ExpressionInScope[] constraints = _constraintProviders.SelectMany(provider => provider.GetConstraints()).ToArray();
 
-        var secondaryScope = new ResourceFieldChainExpression(hasManyRelationship);
-
         // @formatter:wrap_chained_method_calls chop_always
         // @formatter:keep_existing_linebreaks true
 
         FilterExpression[] filtersInSecondaryScope = constraints
-            .Where(constraint => secondaryScope.Equals(constraint.Scope))
+            .Where(constraint => constraint.Scope == null)
             .Select(constraint => constraint.Expression)
             .OfType<FilterExpression>()
             .ToArray();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/SupportTicket.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/SupportTicket.cs
@@ -10,4 +10,7 @@ public sealed class SupportTicket : Identifiable<int>
 {
     [Attr]
     public string Description { get; set; } = null!;
+
+    [HasOne]
+    public ProductFamily? ProductFamily { get; set; }
 }


### PR DESCRIPTION
Fixed: on secondary endpoint, the incoming filter from query string was not applied when determining total resource count via inverse relationship.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
