### PR TITLE
Use deterministic culture when converting to string

### DIFF
--- a/src/JsonApiDotNetCore.Annotations/Resources/Internal/RuntimeTypeConverter.cs
+++ b/src/JsonApiDotNetCore.Annotations/Resources/Internal/RuntimeTypeConverter.cs
@@ -46,7 +46,7 @@ public static class RuntimeTypeConverter
             return value;
         }
 
-        string? stringValue = value.ToString();
+        string? stringValue = value is IFormattable cultureAwareValue ? cultureAwareValue.ToString(null, cultureInfo) : value.ToString();
 
         if (string.IsNullOrEmpty(stringValue))
         {


### PR DESCRIPTION
Although there's currently no code in JsonApiDotNetCore that uses `RuntimeTypeConverter` for converting _to_ string, it's a public type. So its behavior should be deterministic and not depend on the OS-level culture settings.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
