### PR TITLE
Remove workaround for RSRP-491451

### DIFF
--- a/src/Examples/DatabasePerTenantExample/Controllers/EmployeesController.cs
+++ b/src/Examples/DatabasePerTenantExample/Controllers/EmployeesController.cs
@@ -3,11 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace DatabasePerTenantExample.Controllers;
 
-// Workaround for https://youtrack.jetbrains.com/issue/RSRP-487028
-public partial class EmployeesController
-{
-}
-
 [DisableRoutingConvention]
 [Route("api/{tenantName}/employees")]
 partial class EmployeesController

--- a/test/DiscoveryTests/PrivateResource.cs
+++ b/test/DiscoveryTests/PrivateResource.cs
@@ -1,9 +1,11 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
 
 namespace DiscoveryTests;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource]
 public sealed class PrivateResource : Identifiable<int>
 {
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ControllerActionResults/ToothbrushesController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ControllerActionResults/ToothbrushesController.cs
@@ -4,11 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ControllerActionResults;
 
-// Workaround for https://youtrack.jetbrains.com/issue/RSRP-487028
-public partial class ToothbrushesController
-{
-}
-
 partial class ToothbrushesController
 {
     internal const int EmptyActionResultId = 11111111;

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CustomRoutes/CiviliansController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CustomRoutes/CiviliansController.cs
@@ -3,11 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.CustomRoutes;
 
-// Workaround for https://youtrack.jetbrains.com/issue/RSRP-487028
-public partial class CiviliansController
-{
-}
-
 [ApiController]
 [DisableRoutingConvention]
 [Route("world-civilians")]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CustomRoutes/TownsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CustomRoutes/TownsController.cs
@@ -8,11 +8,6 @@ using Microsoft.Extensions.Logging;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.CustomRoutes;
 
-// Workaround for https://youtrack.jetbrains.com/issue/RSRP-487028
-public partial class TownsController
-{
-}
-
 [DisableRoutingConvention]
 [Route("world-api/civilization/popular/towns")]
 partial class TownsController

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/EagerLoading/City.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/EagerLoading/City.cs
@@ -5,6 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreTests.IntegrationTests.EagerLoading;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.EagerLoading")]
 public sealed class City : Identifiable<int>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/HostingInIIS/PaintingsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/HostingInIIS/PaintingsController.cs
@@ -3,11 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.HostingInIIS;
 
-// Workaround for https://youtrack.jetbrains.com/issue/RSRP-487028
-public partial class PaintingsController
-{
-}
-
 [DisableRoutingConvention]
 [Route("custom/path/to/paintings-of-the-world")]
 partial class PaintingsController

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/IdObfuscation/BankAccount.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/IdObfuscation/BankAccount.cs
@@ -1,9 +1,11 @@
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Controllers;
 using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.IdObfuscation;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(GenerateControllerEndpoints = JsonApiEndpoints.None)]
 public sealed class BankAccount : ObfuscatedIdentifiable
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/IdObfuscation/DebitCard.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/IdObfuscation/DebitCard.cs
@@ -1,9 +1,11 @@
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Controllers;
 using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.IdObfuscation;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(GenerateControllerEndpoints = JsonApiEndpoints.None)]
 public sealed class DebitCard : ObfuscatedIdentifiable
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/WebProductsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/WebProductsController.cs
@@ -3,11 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.MultiTenancy;
 
-// Workaround for https://youtrack.jetbrains.com/issue/RSRP-487028
-public partial class WebProductsController
-{
-}
-
 [DisableRoutingConvention]
 [Route("{countryCode}/products")]
 partial class WebProductsController

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/WebShopsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/WebShopsController.cs
@@ -3,11 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.MultiTenancy;
 
-// Workaround for https://youtrack.jetbrains.com/issue/RSRP-487028
-public partial class WebShopsController
-{
-}
-
 [DisableRoutingConvention]
 [Route("{countryCode}/shops")]
 partial class WebShopsController

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/DivingBoard.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/DivingBoard.cs
@@ -1,11 +1,13 @@
 using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Controllers;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.NamingConventions;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(GenerateControllerEndpoints = JsonApiEndpoints.None)]
 public sealed class DivingBoard : Identifiable<int>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/SwimmingPool.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/SwimmingPool.cs
@@ -1,10 +1,12 @@
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Controllers;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.NamingConventions;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(GenerateControllerEndpoints = JsonApiEndpoints.None)]
 public sealed class SwimmingPool : Identifiable<int>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/WaterSlide.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/WaterSlide.cs
@@ -1,10 +1,12 @@
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Controllers;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.NamingConventions;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(GenerateControllerEndpoints = JsonApiEndpoints.None)]
 public sealed class WaterSlide : Identifiable<int>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/AccountPreferences.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/AccountPreferences.cs
@@ -5,6 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.QueryStrings")]
 public sealed class AccountPreferences : Identifiable<int>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Appointment.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Appointment.cs
@@ -5,6 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.QueryStrings")]
 public sealed class Appointment : Identifiable<int>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Label.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Label.cs
@@ -5,6 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.QueryStrings")]
 public sealed class Label : Identifiable<int>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/LoginAttempt.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/LoginAttempt.cs
@@ -5,6 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.QueryStrings")]
 public sealed class LoginAttempt : Identifiable<int>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/PillowsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/PillowsController.cs
@@ -2,11 +2,6 @@ using JsonApiDotNetCore.Controllers.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.RestrictedControllers;
 
-// Workaround for https://youtrack.jetbrains.com/issue/RSRP-487028
-public partial class PillowsController
-{
-}
-
 [DisableQueryString("skipCache")]
 partial class PillowsController
 {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/Room.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/Room.cs
@@ -5,6 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCoreTests.IntegrationTests.RestrictedControllers;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.RestrictedControllers")]
 public sealed class Room : Identifiable<int>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/SofasController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/SofasController.cs
@@ -3,11 +3,6 @@ using JsonApiDotNetCore.QueryStrings;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.RestrictedControllers;
 
-// Workaround for https://youtrack.jetbrains.com/issue/RSRP-487028
-public partial class SofasController
-{
-}
-
 [DisableQueryString(JsonApiQueryStringParameters.Sort | JsonApiQueryStringParameters.Page)]
 partial class SofasController
 {


### PR DESCRIPTION
This PR was originally created to repro https://youtrack.jetbrains.com/issue/RSRP-491451. It removes existing workarounds.

But after running the cibuild 20x, the problem no longer occurs. So this can be merged now.
