### PR TITLE
task: bump to net7, EFCore6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <NetCoreAppVersion>netcoreapp3.1</NetCoreAppVersion>
-    <AspNetCoreVersion>3.1.*</AspNetCoreVersion>
-    <EFCoreVersion>3.1.*</EFCoreVersion>
-    <NpgsqlPostgreSQLVersion>3.1.*</NpgsqlPostgreSQLVersion>
+    <NetCoreAppVersion>net7.0</NetCoreAppVersion>
+    <AspNetCoreVersion>7.0.0</AspNetCoreVersion>
+    <EFCoreVersion>6.0.0</EFCoreVersion>
+    <NpgsqlPostgreSQLVersion>6.0.0</NpgsqlPostgreSQLVersion>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodingGuidelines.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
@@ -15,7 +15,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <NoWarn>$(NoWarn);1591</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Since JADNC 4.2.0 works fine under NET7 and EFCore 6 i am proposing we create a Nuget release/4.2.1 

The reason this is valuable is because it allows developers to more easily migrate to JADNC 5.2.0 by adding a step for them to more safely upgrade itteratively and test their code on NET7 / EFCore 6 before taking the leap to 5.2.0



Closes #{ISSUE_NUMBER}

#### QUALITY CHECKLIST
- [ ] Changes implemented in code
- [ ] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] Adapted tests
- [ ] Documentation updated
