### PR TITLE
Fix exception thrown by EF Core 8 preview

### DIFF
--- a/src/JsonApiDotNetCore.SourceGenerators/SourceCodeWriter.cs
+++ b/src/JsonApiDotNetCore.SourceGenerators/SourceCodeWriter.cs
@@ -98,7 +98,7 @@ internal sealed class SourceCodeWriter
 
     private void WriteNamespaceImports(INamedTypeSymbol loggerFactoryInterface, INamedTypeSymbol resourceType, string? controllerNamespace)
     {
-        _sourceBuilder.AppendLine($@"using {loggerFactoryInterface.ContainingNamespace};");
+        _sourceBuilder.AppendLine($"using {loggerFactoryInterface.ContainingNamespace};");
 
         _sourceBuilder.AppendLine("using JsonApiDotNetCore.Configuration;");
         _sourceBuilder.AppendLine("using JsonApiDotNetCore.Controllers;");
@@ -123,7 +123,7 @@ internal sealed class SourceCodeWriter
         string baseClassName = GetControllerBaseClassName(endpointsToGenerate);
 
         WriteIndent();
-        _sourceBuilder.AppendLine($@"public sealed partial class {controllerName} : {baseClassName}<{resourceType.Name}, {idType}>");
+        _sourceBuilder.AppendLine($"public sealed partial class {controllerName} : {baseClassName}<{resourceType.Name}, {idType}>");
 
         WriteOpenCurly();
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/MusicTrack.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/MusicTrack.cs
@@ -9,7 +9,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations;
 [Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations")]
 public sealed class MusicTrack : Identifiable<Guid>
 {
-    [RegularExpression(@"(?im)^[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?$")]
+    [RegularExpression("(?im)^[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?$")]
     public override Guid Id { get; set; }
 
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NonJsonApiControllers/NonJsonApiControllerTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NonJsonApiControllers/NonJsonApiControllerTests.cs
@@ -41,14 +41,13 @@ public sealed class NonJsonApiControllerTests : IClassFixture<IntegrationTestCon
     public async Task Post_skips_middleware_and_formatters()
     {
         // Arrange
-        using var request = new HttpRequestMessage(HttpMethod.Post, "/NonJsonApi")
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/NonJsonApi");
+
+        request.Content = new StringContent("Jack")
         {
-            Content = new StringContent("Jack")
+            Headers =
             {
-                Headers =
-                {
-                    ContentType = new MediaTypeHeaderValue("text/plain")
-                }
+                ContentType = new MediaTypeHeaderValue("text/plain")
             }
         };
 
@@ -90,14 +89,13 @@ public sealed class NonJsonApiControllerTests : IClassFixture<IntegrationTestCon
     public async Task Put_skips_middleware_and_formatters()
     {
         // Arrange
-        using var request = new HttpRequestMessage(HttpMethod.Put, "/NonJsonApi")
+        using var request = new HttpRequestMessage(HttpMethod.Put, "/NonJsonApi");
+
+        request.Content = new StringContent("\"Jane\"")
         {
-            Content = new StringContent("\"Jane\"")
+            Headers =
             {
-                Headers =
-                {
-                    ContentType = new MediaTypeHeaderValue("application/json")
-                }
+                ContentType = new MediaTypeHeaderValue("application/json")
             }
         };
 

--- a/test/SourceGeneratorTests/ControllerGenerationTests.cs
+++ b/test/SourceGeneratorTests/ControllerGenerationTests.cs
@@ -538,7 +538,7 @@ public sealed partial class ItemsController : JsonApiController<Item, long>
         GeneratorDriverRunResult runResult = driver.GetRunResult();
         runResult.Should().NotHaveDiagnostics();
 
-        runResult.Should().HaveProducedSourceCodeContaining(@"#nullable enable");
+        runResult.Should().HaveProducedSourceCodeContaining("#nullable enable");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes a bug where an unneeded SQL query was executed when updating a one-to-one relationship. This was silently ignored on earlier versions of Entity Framework Core, but fails in the preview version of v8. The fix is to only execute the query when needed.

Details at: https://github.com/dotnet/efcore/issues/31271.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
