### PR TITLE
Add example for scopes-based authorization

### DIFF
--- a/src/JsonApiDotNetCore/Queries/Expressions/QueryExpressionRewriter.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/QueryExpressionRewriter.cs
@@ -34,7 +34,7 @@ public class QueryExpressionRewriter<TArgument> : QueryExpressionVisitor<TArgume
         return null;
     }
 
-    public override QueryExpression? VisitResourceFieldChain(ResourceFieldChainExpression expression, TArgument argument)
+    public override QueryExpression VisitResourceFieldChain(ResourceFieldChainExpression expression, TArgument argument)
     {
         return expression;
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Archiving/TelevisionBroadcastDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Archiving/TelevisionBroadcastDefinition.cs
@@ -180,7 +180,7 @@ public sealed class TelevisionBroadcastDefinition : JsonApiResourceDefinition<Te
     {
         public bool HasFilterOnArchivedAt { get; private set; }
 
-        public override QueryExpression? VisitResourceFieldChain(ResourceFieldChainExpression expression, object? argument)
+        public override QueryExpression VisitResourceFieldChain(ResourceFieldChainExpression expression, object? argument)
         {
             if (expression.Fields[0].Property.Name == nameof(TelevisionBroadcast.ArchivedAt))
             {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/Actor.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/Actor.cs
@@ -1,0 +1,19 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes")]
+public sealed class Actor : Identifiable<long>
+{
+    [Attr]
+    public string Name { get; set; } = null!;
+
+    [Attr]
+    public DateTime BornAt { get; set; }
+
+    [HasMany]
+    public ISet<Movie> ActsIn { get; set; } = new HashSet<Movie>();
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/AuthScopeSet.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/AuthScopeSet.cs
@@ -1,0 +1,127 @@
+using System.Text;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Middleware;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+internal sealed class AuthScopeSet
+{
+    private const StringSplitOptions ScopesHeaderSplitOptions = StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries;
+
+    public const string ScopesHeaderName = "X-Auth-Scopes";
+
+    private readonly Dictionary<string, Permission> _scopes = new();
+
+    public static AuthScopeSet GetRequestedScopes(IHeaderDictionary requestHeaders)
+    {
+        var requestedScopes = new AuthScopeSet();
+
+        // In a real application, the scopes would be read from the signed ticket in the Authorization HTTP header.
+        // For simplicity, this sample allows the client to send them directly, which is obviously insecure.
+
+        if (requestHeaders.TryGetValue(ScopesHeaderName, out StringValues headerValue))
+        {
+            foreach (string scopeValue in headerValue.ToString().Split(' ', ScopesHeaderSplitOptions))
+            {
+                string[] scopeParts = scopeValue.Split(':', 2, ScopesHeaderSplitOptions);
+
+                if (scopeParts.Length == 2 && Enum.TryParse(scopeParts[0], true, out Permission permission) && Enum.IsDefined(permission))
+                {
+                    requestedScopes.Include(scopeParts[1], permission);
+                }
+            }
+        }
+
+        return requestedScopes;
+    }
+
+    public void IncludeFrom(IJsonApiRequest request, ITargetedFields targetedFields)
+    {
+        Permission permission = request.IsReadOnly ? Permission.Read : Permission.Write;
+
+        if (request.PrimaryResourceType != null)
+        {
+            Include(request.PrimaryResourceType, permission);
+        }
+
+        if (request.SecondaryResourceType != null)
+        {
+            Include(request.SecondaryResourceType, permission);
+        }
+
+        if (request.Relationship != null)
+        {
+            Include(request.Relationship, permission);
+        }
+
+        foreach (RelationshipAttribute relationship in targetedFields.Relationships)
+        {
+            Include(relationship, permission);
+        }
+    }
+
+    public void Include(ResourceType resourceType, Permission permission)
+    {
+        Include(resourceType.PublicName, permission);
+    }
+
+    public void Include(RelationshipAttribute relationship, Permission permission)
+    {
+        Include(relationship.LeftType, permission);
+        Include(relationship.RightType, permission);
+    }
+
+    private void Include(string name, Permission permission)
+    {
+        // Unify with existing entries. For example, adding read:movies when write:movies already exists is a no-op.
+
+        if (_scopes.TryGetValue(name, out Permission value))
+        {
+            if (value >= permission)
+            {
+                return;
+            }
+        }
+
+        _scopes[name] = permission;
+    }
+
+    public bool ContainsAll(AuthScopeSet other)
+    {
+        foreach (string otherName in other._scopes.Keys)
+        {
+            if (!_scopes.TryGetValue(otherName, out Permission thisPermission))
+            {
+                return false;
+            }
+
+            if (thisPermission < other._scopes[otherName])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+
+        foreach ((string name, Permission permission) in _scopes.OrderBy(scope => scope.Key))
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append(' ');
+            }
+
+            builder.Append($"{permission.ToString().ToLowerInvariant()}:{name}");
+        }
+
+        return builder.ToString();
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/Genre.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/Genre.cs
@@ -1,0 +1,16 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes")]
+public sealed class Genre : Identifiable<long>
+{
+    [Attr]
+    public string Name { get; set; } = null!;
+
+    [HasMany]
+    public ISet<Movie> Movies { get; set; } = new HashSet<Movie>();
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/Movie.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/Movie.cs
@@ -1,0 +1,25 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes")]
+public sealed class Movie : Identifiable<long>
+{
+    [Attr]
+    public string Title { get; set; } = null!;
+
+    [Attr]
+    public int ReleaseYear { get; set; }
+
+    [Attr]
+    public int DurationInSeconds { get; set; }
+
+    [HasOne]
+    public Genre Genre { get; set; } = null!;
+
+    [HasMany]
+    public ISet<Actor> Cast { get; set; } = new HashSet<Actor>();
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/OperationsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/OperationsController.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using JsonApiDotNetCore.AtomicOperations;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Middleware;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Serialization.Objects;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+public sealed class OperationsController : JsonApiOperationsController
+{
+    public OperationsController(IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor,
+        IJsonApiRequest request, ITargetedFields targetedFields)
+        : base(options, resourceGraph, loggerFactory, processor, request, targetedFields)
+    {
+    }
+
+    public override async Task<IActionResult> PostOperationsAsync(IList<OperationContainer> operations, CancellationToken cancellationToken)
+    {
+        AuthScopeSet requestedScopes = AuthScopeSet.GetRequestedScopes(HttpContext.Request.Headers);
+        AuthScopeSet requiredScopes = GetRequiredScopes(operations);
+
+        if (!requestedScopes.ContainsAll(requiredScopes))
+        {
+            return Error(new ErrorObject(HttpStatusCode.Unauthorized)
+            {
+                Title = "Insufficient permissions to perform this request.",
+                Detail = $"Performing this request requires the following scopes: {requiredScopes}.",
+                Source = new ErrorSource
+                {
+                    Header = AuthScopeSet.ScopesHeaderName
+                }
+            });
+        }
+
+        return await base.PostOperationsAsync(operations, cancellationToken);
+    }
+
+    private AuthScopeSet GetRequiredScopes(IEnumerable<OperationContainer> operations)
+    {
+        var requiredScopes = new AuthScopeSet();
+
+        foreach (OperationContainer operation in operations)
+        {
+            requiredScopes.IncludeFrom(operation.Request, operation.TargetedFields);
+        }
+
+        return requiredScopes;
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/Permission.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/Permission.cs
@@ -1,0 +1,9 @@
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+internal enum Permission
+{
+    Read,
+
+    // Write access implicitly includes read access, because POST/PATCH in JSON:API may return the changed resource.
+    Write
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopeOperationsTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopeOperationsTests.cs
@@ -1,0 +1,466 @@
+using System.Net;
+using System.Net.Http.Headers;
+using FluentAssertions;
+using JsonApiDotNetCore.Serialization.Objects;
+using TestBuildingBlocks;
+using Xunit;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+public sealed class ScopeOperationsTests : IClassFixture<IntegrationTestContext<ScopesStartup<ScopesDbContext>, ScopesDbContext>>
+{
+    private const string ScopeHeaderName = "X-Auth-Scopes";
+    private readonly IntegrationTestContext<ScopesStartup<ScopesDbContext>, ScopesDbContext> _testContext;
+    private readonly ScopesFakers _fakers = new();
+
+    public ScopeOperationsTests(IntegrationTestContext<ScopesStartup<ScopesDbContext>, ScopesDbContext> testContext)
+    {
+        _testContext = testContext;
+
+        testContext.UseController<OperationsController>();
+        testContext.UseController<MoviesController>();
+        testContext.UseController<ActorsController>();
+        testContext.UseController<GenresController>();
+    }
+
+    [Fact]
+    public async Task Cannot_create_resources_without_scopes()
+    {
+        // Arrange
+        Genre newGenre = _fakers.Genre.Generate();
+        Movie newMovie = _fakers.Movie.Generate();
+
+        const string genreLocalId = "genre-1";
+
+        var requestBody = new
+        {
+            atomic__operations = new object[]
+            {
+                new
+                {
+                    op = "add",
+                    data = new
+                    {
+                        type = "genres",
+                        lid = genreLocalId,
+                        attributes = new
+                        {
+                            name = newGenre.Name
+                        }
+                    }
+                },
+                new
+                {
+                    op = "add",
+                    data = new
+                    {
+                        type = "movies",
+                        attributes = new
+                        {
+                            title = newMovie.Title,
+                            releaseYear = newMovie.ReleaseYear,
+                            durationInSeconds = newMovie.DurationInSeconds
+                        },
+                        relationships = new
+                        {
+                            genre = new
+                            {
+                                data = new
+                                {
+                                    type = "genres",
+                                    lid = genreLocalId
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        const string route = "/operations";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAtomicAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:genres write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_create_resource_with_read_scope()
+    {
+        // Arrange
+        Genre newGenre = _fakers.Genre.Generate();
+
+        var requestBody = new
+        {
+            atomic__operations = new[]
+            {
+                new
+                {
+                    op = "add",
+                    data = new
+                    {
+                        type = "genres",
+                        attributes = new
+                        {
+                            name = newGenre.Name
+                        }
+                    }
+                }
+            }
+        };
+
+        const string route = "/operations";
+
+        Action<HttpRequestHeaders> setRequestHeaders = headers => headers.Add(ScopeHeaderName, "read:genres");
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) =
+            await _testContext.ExecutePostAtomicAsync<Document>(route, requestBody, setRequestHeaders: setRequestHeaders);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:genres.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_update_resources_without_scopes()
+    {
+        // Arrange
+        string newTitle = _fakers.Movie.Generate().Title;
+        DateTime newBornAt = _fakers.Actor.Generate().BornAt;
+
+        var requestBody = new
+        {
+            atomic__operations = new object[]
+            {
+                new
+                {
+                    op = "update",
+                    data = new
+                    {
+                        type = "movies",
+                        id = "1",
+                        attributes = new
+                        {
+                            title = newTitle
+                        }
+                    }
+                },
+                new
+                {
+                    op = "update",
+                    data = new
+                    {
+                        type = "actors",
+                        id = "1",
+                        attributes = new
+                        {
+                            bornAt = newBornAt
+                        }
+                    }
+                }
+            }
+        };
+
+        const string route = "/operations";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAtomicAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:actors write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_update_resource_with_relationships_without_scopes()
+    {
+        // Arrange
+        string newTitle = _fakers.Movie.Generate().Title;
+
+        var requestBody = new
+        {
+            atomic__operations = new[]
+            {
+                new
+                {
+                    op = "update",
+                    data = new
+                    {
+                        type = "movies",
+                        id = "1",
+                        attributes = new
+                        {
+                            title = newTitle
+                        },
+                        relationships = new
+                        {
+                            cast = new
+                            {
+                                data = new[]
+                                {
+                                    new
+                                    {
+                                        type = "actors",
+                                        id = "1"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        const string route = "/operations";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAtomicAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:actors write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_delete_resources_without_scopes()
+    {
+        // Arrange
+        var requestBody = new
+        {
+            atomic__operations = new[]
+            {
+                new
+                {
+                    op = "remove",
+                    @ref = new
+                    {
+                        type = "genres",
+                        id = "1"
+                    }
+                },
+                new
+                {
+                    op = "remove",
+                    @ref = new
+                    {
+                        type = "actors",
+                        id = "1"
+                    }
+                }
+            }
+        };
+
+        const string route = "/operations";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAtomicAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:actors write:genres.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_update_ToOne_relationship_without_scopes()
+    {
+        // Arrange
+        var requestBody = new
+        {
+            atomic__operations = new[]
+            {
+                new
+                {
+                    op = "update",
+                    @ref = new
+                    {
+                        type = "movies",
+                        id = "1",
+                        relationship = "genre"
+                    },
+                    data = (object?)null
+                }
+            }
+        };
+
+        const string route = "/operations";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAtomicAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:genres write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_update_ToMany_relationship_without_scopes()
+    {
+        // Arrange
+        var requestBody = new
+        {
+            atomic__operations = new[]
+            {
+                new
+                {
+                    op = "update",
+                    @ref = new
+                    {
+                        type = "movies",
+                        id = "1",
+                        relationship = "cast"
+                    },
+                    data = Array.Empty<object>()
+                }
+            }
+        };
+
+        const string route = "/operations";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAtomicAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:actors write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_add_to_ToMany_relationship_without_scopes()
+    {
+        // Arrange
+        var requestBody = new
+        {
+            atomic__operations = new[]
+            {
+                new
+                {
+                    op = "add",
+                    @ref = new
+                    {
+                        type = "movies",
+                        id = "1",
+                        relationship = "cast"
+                    },
+                    data = Array.Empty<object>()
+                }
+            }
+        };
+
+        const string route = "/operations";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAtomicAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:actors write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_remove_from_ToMany_relationship_without_scopes()
+    {
+        // Arrange
+        var requestBody = new
+        {
+            atomic__operations = new[]
+            {
+                new
+                {
+                    op = "remove",
+                    @ref = new
+                    {
+                        type = "movies",
+                        id = "1",
+                        relationship = "cast"
+                    },
+                    data = Array.Empty<object>()
+                }
+            }
+        };
+
+        const string route = "/operations";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAtomicAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:actors write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopeReadTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopeReadTests.cs
@@ -1,0 +1,343 @@
+using System.Net;
+using System.Net.Http.Headers;
+using FluentAssertions;
+using JsonApiDotNetCore.Serialization.Objects;
+using TestBuildingBlocks;
+using Xunit;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+public sealed class ScopeReadTests : IClassFixture<IntegrationTestContext<ScopesStartup<ScopesDbContext>, ScopesDbContext>>
+{
+    private const string ScopeHeaderName = "X-Auth-Scopes";
+    private readonly IntegrationTestContext<ScopesStartup<ScopesDbContext>, ScopesDbContext> _testContext;
+    private readonly ScopesFakers _fakers = new();
+
+    public ScopeReadTests(IntegrationTestContext<ScopesStartup<ScopesDbContext>, ScopesDbContext> testContext)
+    {
+        _testContext = testContext;
+
+        testContext.UseController<MoviesController>();
+        testContext.UseController<ActorsController>();
+        testContext.UseController<GenresController>();
+    }
+
+    [Fact]
+    public async Task Cannot_get_primary_resources_without_scopes()
+    {
+        // Arrange
+        const string route = "/movies";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: read:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_get_primary_resources_with_incorrect_scopes()
+    {
+        // Arrange
+        const string route = "/movies";
+
+        Action<HttpRequestHeaders> setRequestHeaders = headers => headers.Add(ScopeHeaderName, "read:actors write:genres");
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route, setRequestHeaders);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: read:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Can_get_primary_resources_with_correct_scope()
+    {
+        // Arrange
+        Movie movie = _fakers.Movie.Generate();
+        movie.Genre = _fakers.Genre.Generate();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Movie>();
+            dbContext.Movies.Add(movie);
+            await dbContext.SaveChangesAsync();
+        });
+
+        const string route = "/movies";
+
+        Action<HttpRequestHeaders> setRequestHeaders = headers => headers.Add(ScopeHeaderName, "read:movies");
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route, setRequestHeaders);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        responseDocument.Data.ManyValue.ShouldHaveCount(1);
+        responseDocument.Data.ManyValue[0].Type.Should().Be("movies");
+        responseDocument.Data.ManyValue[0].Id.Should().Be(movie.StringId);
+        responseDocument.Data.ManyValue[0].Attributes.ShouldNotBeEmpty();
+        responseDocument.Data.ManyValue[0].Relationships.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Can_get_primary_resources_with_write_scope()
+    {
+        // Arrange
+        Genre genre = _fakers.Genre.Generate();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Genre>();
+            dbContext.Genres.Add(genre);
+            await dbContext.SaveChangesAsync();
+        });
+
+        const string route = "/genres";
+
+        Action<HttpRequestHeaders> setRequestHeaders = headers => headers.Add(ScopeHeaderName, "write:genres");
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route, setRequestHeaders);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        responseDocument.Data.ManyValue.ShouldHaveCount(1);
+        responseDocument.Data.ManyValue[0].Type.Should().Be("genres");
+        responseDocument.Data.ManyValue[0].Id.Should().Be(genre.StringId);
+        responseDocument.Data.ManyValue[0].Attributes.ShouldNotBeEmpty();
+        responseDocument.Data.ManyValue[0].Relationships.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Can_get_primary_resources_with_redundant_scopes()
+    {
+        // Arrange
+        Actor actor = _fakers.Actor.Generate();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Actor>();
+            dbContext.Actors.Add(actor);
+            await dbContext.SaveChangesAsync();
+        });
+
+        const string route = "/actors";
+
+        Action<HttpRequestHeaders> setRequestHeaders = headers => headers.Add(ScopeHeaderName, "read:genres read:actors write:movies");
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route, setRequestHeaders);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        responseDocument.Data.ManyValue.ShouldHaveCount(1);
+        responseDocument.Data.ManyValue[0].Type.Should().Be("actors");
+        responseDocument.Data.ManyValue[0].Id.Should().Be(actor.StringId);
+        responseDocument.Data.ManyValue[0].Attributes.ShouldNotBeEmpty();
+        responseDocument.Data.ManyValue[0].Relationships.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Cannot_get_primary_resource_without_scopes()
+    {
+        // Arrange
+        const string route = "/actors/1";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: read:actors.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_get_secondary_resource_without_scopes()
+    {
+        // Arrange
+        const string route = "/movies/1/genre";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: read:genres read:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_get_secondary_resources_without_scopes()
+    {
+        // Arrange
+        const string route = "/genres/1/movies";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: read:genres read:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_get_ToOne_relationship_without_scopes()
+    {
+        // Arrange
+        const string route = "/movies/1/relationships/genre";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: read:genres read:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_get_ToMany_relationship_without_scopes()
+    {
+        // Arrange
+        const string route = "/genres/1/relationships/movies";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: read:genres read:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_include_with_insufficient_scopes()
+    {
+        // Arrange
+        const string route = "/movies?include=genre,cast";
+
+        Action<HttpRequestHeaders> setRequestHeaders = headers => headers.Add(ScopeHeaderName, "read:movies");
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route, setRequestHeaders);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: read:actors read:genres read:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_filter_with_insufficient_scopes()
+    {
+        // Arrange
+        const string route = "/movies?filter=and(has(cast),equals(genre.name,'some'))";
+
+        Action<HttpRequestHeaders> setRequestHeaders = headers => headers.Add(ScopeHeaderName, "read:movies");
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route, setRequestHeaders);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: read:actors read:genres read:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_sort_with_insufficient_scopes()
+    {
+        // Arrange
+        const string route = "/movies?sort=count(cast),genre.name";
+
+        Action<HttpRequestHeaders> setRequestHeaders = headers => headers.Add(ScopeHeaderName, "read:movies");
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route, setRequestHeaders);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: read:actors read:genres read:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopeWriteTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopeWriteTests.cs
@@ -1,0 +1,434 @@
+using System.Net;
+using System.Net.Http.Headers;
+using FluentAssertions;
+using JsonApiDotNetCore.Serialization.Objects;
+using TestBuildingBlocks;
+using Xunit;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+public sealed class ScopeWriteTests : IClassFixture<IntegrationTestContext<ScopesStartup<ScopesDbContext>, ScopesDbContext>>
+{
+    private const string ScopeHeaderName = "X-Auth-Scopes";
+    private readonly IntegrationTestContext<ScopesStartup<ScopesDbContext>, ScopesDbContext> _testContext;
+    private readonly ScopesFakers _fakers = new();
+
+    public ScopeWriteTests(IntegrationTestContext<ScopesStartup<ScopesDbContext>, ScopesDbContext> testContext)
+    {
+        _testContext = testContext;
+
+        testContext.UseController<MoviesController>();
+    }
+
+    [Fact]
+    public async Task Cannot_create_resource_without_scopes()
+    {
+        // Arrange
+        Movie newMovie = _fakers.Movie.Generate();
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "movies",
+                attributes = new
+                {
+                    title = newMovie.Title,
+                    releaseYear = newMovie.ReleaseYear,
+                    durationInSeconds = newMovie.DurationInSeconds
+                }
+            }
+        };
+
+        const string route = "/movies";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_create_resource_with_relationships_without_scopes()
+    {
+        // Arrange
+        Movie newMovie = _fakers.Movie.Generate();
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "movies",
+                attributes = new
+                {
+                    title = newMovie.Title,
+                    releaseYear = newMovie.ReleaseYear,
+                    durationInSeconds = newMovie.DurationInSeconds
+                },
+                relationships = new
+                {
+                    genre = new
+                    {
+                        data = new
+                        {
+                            type = "genres",
+                            id = "1"
+                        }
+                    },
+                    cast = new
+                    {
+                        data = new[]
+                        {
+                            new
+                            {
+                                type = "actors",
+                                id = "1"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        const string route = "/movies";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:actors write:genres write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_create_resource_with_relationships_with_read_scopes()
+    {
+        // Arrange
+        Movie newMovie = _fakers.Movie.Generate();
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "movies",
+                attributes = new
+                {
+                    title = newMovie.Title,
+                    releaseYear = newMovie.ReleaseYear,
+                    durationInSeconds = newMovie.DurationInSeconds
+                },
+                relationships = new
+                {
+                    genre = new
+                    {
+                        data = new
+                        {
+                            type = "genres",
+                            id = "1"
+                        }
+                    },
+                    cast = new
+                    {
+                        data = new[]
+                        {
+                            new
+                            {
+                                type = "actors",
+                                id = "1"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        const string route = "/movies";
+
+        Action<HttpRequestHeaders> setRequestHeaders = headers => headers.Add(ScopeHeaderName, "read:movies read:genres read:actors");
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) =
+            await _testContext.ExecutePostAsync<Document>(route, requestBody, setRequestHeaders: setRequestHeaders);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:actors write:genres write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_update_resource_without_scopes()
+    {
+        // Arrange
+        string newTitle = _fakers.Movie.Generate().Title;
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "movies",
+                id = "1",
+                attributes = new
+                {
+                    title = newTitle
+                }
+            }
+        };
+
+        const string route = "/movies/1";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePatchAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_update_resource_with_relationships_without_scopes()
+    {
+        // Arrange
+        string newTitle = _fakers.Movie.Generate().Title;
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "movies",
+                id = "1",
+                attributes = new
+                {
+                    title = newTitle
+                },
+                relationships = new
+                {
+                    genre = new
+                    {
+                        data = new
+                        {
+                            type = "genres",
+                            id = "1"
+                        }
+                    },
+                    cast = new
+                    {
+                        data = new[]
+                        {
+                            new
+                            {
+                                type = "actors",
+                                id = "1"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        const string route = "/movies/1";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePatchAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:actors write:genres write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_delete_resource_without_scopes()
+    {
+        // Arrange
+        const string route = "/movies/1";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteDeleteAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_update_ToOne_relationship_without_scopes()
+    {
+        // Arrange
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "genres",
+                id = "1"
+            }
+        };
+
+        const string route = "/movies/1/relationships/genre";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePatchAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:genres write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_update_ToMany_relationship_without_scopes()
+    {
+        // Arrange
+        var requestBody = new
+        {
+            data = new[]
+            {
+                new
+                {
+                    type = "actors",
+                    id = "1"
+                }
+            }
+        };
+
+        const string route = "/movies/1/relationships/cast";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePatchAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:actors write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_add_to_ToMany_relationship_without_scopes()
+    {
+        // Arrange
+        var requestBody = new
+        {
+            data = new[]
+            {
+                new
+                {
+                    type = "actors",
+                    id = "1"
+                }
+            }
+        };
+
+        const string route = "/movies/1/relationships/cast";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:actors write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+
+    [Fact]
+    public async Task Cannot_remove_from_ToMany_relationship_without_scopes()
+    {
+        // Arrange
+        var requestBody = new
+        {
+            data = new[]
+            {
+                new
+                {
+                    type = "actors",
+                    id = "1"
+                }
+            }
+        };
+
+        const string route = "/movies/1/relationships/cast";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteDeleteAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Unauthorized);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        error.Title.Should().Be("Insufficient permissions to perform this request.");
+        error.Detail.Should().Be("Performing this request requires the following scopes: write:actors write:movies.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Header.Should().Be(ScopeHeaderName);
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopesAuthorizationFilter.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopesAuthorizationFilter.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Middleware;
+using JsonApiDotNetCore.Queries;
+using JsonApiDotNetCore.Queries.Expressions;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+using JsonApiDotNetCore.Serialization.Objects;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+// Implements IActionFilter instead of IAuthorizationFilter because it needs to execute *after* parsing query string parameters.
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+internal sealed class ScopesAuthorizationFilter : IActionFilter
+{
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+        var request = context.HttpContext.RequestServices.GetRequiredService<IJsonApiRequest>();
+        var targetedFields = context.HttpContext.RequestServices.GetRequiredService<ITargetedFields>();
+        var constraintProviders = context.HttpContext.RequestServices.GetRequiredService<IEnumerable<IQueryConstraintProvider>>();
+
+        if (request.Kind == EndpointKind.AtomicOperations)
+        {
+            // Handled in operators controller, because it requires access to the individual operations.
+            return;
+        }
+
+        AuthScopeSet requestedScopes = AuthScopeSet.GetRequestedScopes(context.HttpContext.Request.Headers);
+        AuthScopeSet requiredScopes = GetRequiredScopes(request, targetedFields, constraintProviders);
+
+        if (!requestedScopes.ContainsAll(requiredScopes))
+        {
+            context.Result = new UnauthorizedObjectResult(new ErrorObject(HttpStatusCode.Unauthorized)
+            {
+                Title = "Insufficient permissions to perform this request.",
+                Detail = $"Performing this request requires the following scopes: {requiredScopes}.",
+                Source = new ErrorSource
+                {
+                    Header = AuthScopeSet.ScopesHeaderName
+                }
+            });
+        }
+    }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+    }
+
+    private AuthScopeSet GetRequiredScopes(IJsonApiRequest request, ITargetedFields targetedFields, IEnumerable<IQueryConstraintProvider> constraintProviders)
+    {
+        var requiredScopes = new AuthScopeSet();
+        requiredScopes.IncludeFrom(request, targetedFields);
+
+        var walker = new QueryStringWalker(requiredScopes);
+        walker.IncludeScopesFrom(constraintProviders);
+
+        return requiredScopes;
+    }
+
+    private sealed class QueryStringWalker : QueryExpressionRewriter<object?>
+    {
+        private readonly AuthScopeSet _authScopeSet;
+
+        public QueryStringWalker(AuthScopeSet authScopeSet)
+        {
+            _authScopeSet = authScopeSet;
+        }
+
+        public void IncludeScopesFrom(IEnumerable<IQueryConstraintProvider> constraintProviders)
+        {
+            foreach (ExpressionInScope constraint in constraintProviders.SelectMany(provider => provider.GetConstraints()))
+            {
+                Visit(constraint.Expression, null);
+            }
+        }
+
+        public override QueryExpression VisitIncludeElement(IncludeElementExpression expression, object? argument)
+        {
+            _authScopeSet.Include(expression.Relationship, Permission.Read);
+
+            return base.VisitIncludeElement(expression, argument);
+        }
+
+        public override QueryExpression VisitResourceFieldChain(ResourceFieldChainExpression expression, object? argument)
+        {
+            foreach (ResourceFieldAttribute field in expression.Fields)
+            {
+                if (field is RelationshipAttribute relationship)
+                {
+                    _authScopeSet.Include(relationship, Permission.Read);
+                }
+                else
+                {
+                    _authScopeSet.Include(field.Type, Permission.Read);
+                }
+            }
+
+            return base.VisitResourceFieldChain(expression, argument);
+        }
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopesDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopesDbContext.cs
@@ -1,0 +1,18 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+public sealed class ScopesDbContext : TestableDbContext
+{
+    public DbSet<Movie> Movies => Set<Movie>();
+    public DbSet<Actor> Actors => Set<Actor>();
+    public DbSet<Genre> Genres => Set<Genre>();
+
+    public ScopesDbContext(DbContextOptions<ScopesDbContext> options)
+        : base(options)
+    {
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopesFakers.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopesFakers.cs
@@ -1,0 +1,29 @@
+using Bogus;
+using TestBuildingBlocks;
+
+// @formatter:wrap_chained_method_calls chop_if_long
+// @formatter:wrap_before_first_method_call true
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+internal sealed class ScopesFakers : FakerContainer
+{
+    private readonly Lazy<Faker<Movie>> _lazyMovieFaker = new(() => new Faker<Movie>()
+        .UseSeed(GetFakerSeed())
+        .RuleFor(movie => movie.Title, faker => faker.Random.Words())
+        .RuleFor(movie => movie.ReleaseYear, faker => faker.Random.Int(1900, 2050))
+        .RuleFor(movie => movie.DurationInSeconds, faker => faker.Random.Int(300, 14400)));
+
+    private readonly Lazy<Faker<Actor>> _lazyActorFaker = new(() => new Faker<Actor>()
+        .UseSeed(GetFakerSeed())
+        .RuleFor(actor => actor.Name, faker => faker.Person.FullName)
+        .RuleFor(actor => actor.BornAt, faker => faker.Date.Past()));
+
+    private readonly Lazy<Faker<Genre>> _lazyGenreFaker = new(() => new Faker<Genre>()
+        .UseSeed(GetFakerSeed())
+        .RuleFor(genre => genre.Name, faker => faker.Random.Word()));
+
+    public Faker<Movie> Movie => _lazyMovieFaker.Value;
+    public Faker<Actor> Actor => _lazyActorFaker.Value;
+    public Faker<Genre> Genre => _lazyGenreFaker.Value;
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopesStartup.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopesStartup.cs
@@ -1,0 +1,18 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TestBuildingBlocks;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
+
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+public sealed class ScopesStartup<TDbContext> : TestableStartup<TDbContext>
+    where TDbContext : TestableDbContext
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        IMvcCoreBuilder mvcBuilder = services.AddMvcCore(options => options.Filters.Add<ScopesAuthorizationFilter>(int.MaxValue));
+
+        services.AddJsonApi<TDbContext>(SetJsonApiOptions, mvcBuilder: mvcBuilder);
+    }
+}

--- a/test/JsonApiDotNetCoreTests/UnitTests/Queries/TestableQueryExpressionRewriter.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Queries/TestableQueryExpressionRewriter.cs
@@ -18,7 +18,7 @@ internal sealed class TestableQueryExpressionRewriter : QueryExpressionRewriter<
         return base.VisitComparison(expression, argument);
     }
 
-    public override QueryExpression? VisitResourceFieldChain(ResourceFieldChainExpression expression, object? argument)
+    public override QueryExpression VisitResourceFieldChain(ResourceFieldChainExpression expression, object? argument)
     {
         Capture(expression);
         return base.VisitResourceFieldChain(expression, argument);


### PR DESCRIPTION
This PR adds an example for using scopes-based authorization in a generic way.

For simplicity in this sample, accessing relationships requires access to both the left and right sides of the relationship. An alternative approach could be to define relationship-specific scopes, such as `read:relationship:movies-genre`. Another limitation of this sample is that it only supports access checks on resource _types_. For example, consider a resource type TodoItem that contains an owner (type Person) and an assignee (type Person). Now it's not possible to allow fetching/updating the assignee while preventing to fetch/update the owner.

Just so you know, this is only a sample. Personally, I'd never use such fine-grained scopes because it quickly becomes an administrative nightmare. What I would do is define scopes around functional areas (like the [GitHub API](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes) does), and then directly annotate controller action methods with them.

Closes #1300.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
