### PR TITLE
Client-generated IDs per resource type

### DIFF
--- a/JsonApiDotNetCore.sln.DotSettings
+++ b/JsonApiDotNetCore.sln.DotSettings
@@ -665,6 +665,7 @@ $left$ = $right$;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Startups/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subdirectory/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unarchive/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unprocessable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Workflows/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=xunit/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -10,15 +10,34 @@ builder.Services.AddJsonApi<AppDbContext>(options =>
 });
 ```
 
-## Client Generated IDs
+## Client-generated IDs
 
 By default, the server will respond with a 403 Forbidden HTTP Status Code if a POST request is received with a client-generated ID.
 
-However, this can be allowed by setting the AllowClientGeneratedIds flag in the options:
+However, this can be allowed or required globally (for all resource types) by setting `ClientIdGeneration` in options:
 
 ```c#
-options.AllowClientGeneratedIds = true;
+options.ClientIdGeneration = ClientIdGenerationMode.Allowed;
 ```
+
+or:
+
+```c#
+options.ClientIdGeneration = ClientIdGenerationMode.Required;
+```
+
+It is possible to overrule this setting per resource type:
+
+```c#
+[Resource(ClientIdGeneration = ClientIdGenerationMode.Required)]
+public class Article : Identifiable<Guid>
+{
+    // ...
+}
+```
+
+> [!NOTE]
+> JsonApiDotNetCore versions before v5.4.0 only provided the global `AllowClientGeneratedIds` boolean property.
 
 ## Pagination
 

--- a/src/JsonApiDotNetCore.Annotations/Configuration/ClientIdGenerationMode.shared.cs
+++ b/src/JsonApiDotNetCore.Annotations/Configuration/ClientIdGenerationMode.shared.cs
@@ -1,0 +1,25 @@
+using JetBrains.Annotations;
+
+namespace JsonApiDotNetCore.Configuration;
+
+/// <summary>
+/// Indicates how to handle IDs sent by JSON:API clients when creating resources.
+/// </summary>
+[PublicAPI]
+public enum ClientIdGenerationMode
+{
+    /// <summary>
+    /// Returns an HTTP 403 (Forbidden) response if a client attempts to create a resource with a client-supplied ID.
+    /// </summary>
+    Forbidden,
+
+    /// <summary>
+    /// Allows a client to create a resource with a client-supplied ID, but does not require it.
+    /// </summary>
+    Allowed,
+
+    /// <summary>
+    /// Returns an HTTP 422 (Unprocessable Content) response if a client attempts to create a resource without a client-supplied ID.
+    /// </summary>
+    Required
+}

--- a/src/JsonApiDotNetCore.Annotations/Configuration/ResourceType.cs
+++ b/src/JsonApiDotNetCore.Annotations/Configuration/ResourceType.cs
@@ -19,6 +19,12 @@ public sealed class ResourceType
     public string PublicName { get; }
 
     /// <summary>
+    /// Whether API clients are allowed or required to provide IDs when creating resources of this type. When <c>null</c>, the value from global options
+    /// applies.
+    /// </summary>
+    public ClientIdGenerationMode? ClientIdGeneration { get; }
+
+    /// <summary>
     /// The CLR type of the resource.
     /// </summary>
     public Type ClrType { get; }
@@ -89,22 +95,24 @@ public sealed class ResourceType
     /// </remarks>
     public LinkTypes RelationshipLinks { get; }
 
-    public ResourceType(string publicName, Type clrType, Type identityClrType, LinkTypes topLevelLinks = LinkTypes.NotConfigured,
-        LinkTypes resourceLinks = LinkTypes.NotConfigured, LinkTypes relationshipLinks = LinkTypes.NotConfigured)
-        : this(publicName, clrType, identityClrType, null, null, null, topLevelLinks, resourceLinks, relationshipLinks)
+    public ResourceType(string publicName, ClientIdGenerationMode? clientIdGeneration, Type clrType, Type identityClrType,
+        LinkTypes topLevelLinks = LinkTypes.NotConfigured, LinkTypes resourceLinks = LinkTypes.NotConfigured,
+        LinkTypes relationshipLinks = LinkTypes.NotConfigured)
+        : this(publicName, clientIdGeneration, clrType, identityClrType, null, null, null, topLevelLinks, resourceLinks, relationshipLinks)
     {
     }
 
-    public ResourceType(string publicName, Type clrType, Type identityClrType, IReadOnlyCollection<AttrAttribute>? attributes,
-        IReadOnlyCollection<RelationshipAttribute>? relationships, IReadOnlyCollection<EagerLoadAttribute>? eagerLoads,
-        LinkTypes topLevelLinks = LinkTypes.NotConfigured, LinkTypes resourceLinks = LinkTypes.NotConfigured,
-        LinkTypes relationshipLinks = LinkTypes.NotConfigured)
+    public ResourceType(string publicName, ClientIdGenerationMode? clientIdGeneration, Type clrType, Type identityClrType,
+        IReadOnlyCollection<AttrAttribute>? attributes, IReadOnlyCollection<RelationshipAttribute>? relationships,
+        IReadOnlyCollection<EagerLoadAttribute>? eagerLoads, LinkTypes topLevelLinks = LinkTypes.NotConfigured,
+        LinkTypes resourceLinks = LinkTypes.NotConfigured, LinkTypes relationshipLinks = LinkTypes.NotConfigured)
     {
         ArgumentGuard.NotNullNorEmpty(publicName);
         ArgumentGuard.NotNull(clrType);
         ArgumentGuard.NotNull(identityClrType);
 
         PublicName = publicName;
+        ClientIdGeneration = clientIdGeneration;
         ClrType = clrType;
         IdentityClrType = identityClrType;
         Attributes = attributes ?? Array.Empty<AttrAttribute>();

--- a/src/JsonApiDotNetCore.Annotations/Resources/Annotations/ResourceAttribute.shared.cs
+++ b/src/JsonApiDotNetCore.Annotations/Resources/Annotations/ResourceAttribute.shared.cs
@@ -1,4 +1,5 @@
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Controllers;
 
 namespace JsonApiDotNetCore.Resources.Annotations;
@@ -10,10 +11,22 @@ namespace JsonApiDotNetCore.Resources.Annotations;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
 public sealed class ResourceAttribute : Attribute
 {
+    internal ClientIdGenerationMode? NullableClientIdGeneration { get; set; }
+
     /// <summary>
     /// Optional. The publicly exposed name of this resource type.
     /// </summary>
     public string? PublicName { get; set; }
+
+    /// <summary>
+    /// Optional. Whether API clients are allowed or required to provide IDs when creating resources of this type. When not set, the value from global
+    /// options applies.
+    /// </summary>
+    public ClientIdGenerationMode ClientIdGeneration
+    {
+        get => NullableClientIdGeneration.GetValueOrDefault();
+        set => NullableClientIdGeneration = value;
+    }
 
     /// <summary>
     /// The set of endpoints to auto-generate an ASP.NET controller for. Defaults to <see cref="JsonApiEndpoints.All" />. Set to

--- a/src/JsonApiDotNetCore/Configuration/IJsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/IJsonApiOptions.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Text.Json;
+using JetBrains.Annotations;
 using JsonApiDotNetCore.Resources.Annotations;
 using JsonApiDotNetCore.Serialization.Objects;
 
@@ -21,37 +22,40 @@ public interface IJsonApiOptions
     string? Namespace { get; }
 
     /// <summary>
-    /// Specifies the default set of allowed capabilities on JSON:API attributes. Defaults to <see cref="AttrCapabilities.All" />.
+    /// Specifies the default set of allowed capabilities on JSON:API attributes. Defaults to <see cref="AttrCapabilities.All" />. This setting can be
+    /// overruled per attribute using <see cref="AttrAttribute.Capabilities" />.
     /// </summary>
     AttrCapabilities DefaultAttrCapabilities { get; }
 
     /// <summary>
-    /// Specifies the default set of allowed capabilities on JSON:API to-one relationships. Defaults to <see cref="HasOneCapabilities.All" />.
+    /// Specifies the default set of allowed capabilities on JSON:API to-one relationships. Defaults to <see cref="HasOneCapabilities.All" />. This setting
+    /// can be overruled per relationship using <see cref="HasOneAttribute.Capabilities" />.
     /// </summary>
     HasOneCapabilities DefaultHasOneCapabilities { get; }
 
     /// <summary>
-    /// Specifies the default set of allowed capabilities on JSON:API to-many relationships. Defaults to <see cref="HasManyCapabilities.All" />.
+    /// Specifies the default set of allowed capabilities on JSON:API to-many relationships. Defaults to <see cref="HasManyCapabilities.All" />. This setting
+    /// can be overruled per relationship using <see cref="HasManyAttribute.Capabilities" />.
     /// </summary>
     HasManyCapabilities DefaultHasManyCapabilities { get; }
 
     /// <summary>
-    /// Indicates whether responses should contain a jsonapi object that contains the highest JSON:API version supported. False by default.
+    /// Whether to include a 'jsonapi' object in responses, which contains the highest JSON:API version supported. <c>false</c> by default.
     /// </summary>
     bool IncludeJsonApiVersion { get; }
 
     /// <summary>
-    /// Whether or not <see cref="Exception" /> stack traces should be included in <see cref="ErrorObject.Meta" />. False by default.
+    /// Whether to include <see cref="Exception" /> stack traces in <see cref="ErrorObject.Meta" /> responses. <c>false</c> by default.
     /// </summary>
     bool IncludeExceptionStackTraceInErrors { get; }
 
     /// <summary>
-    /// Whether or not the request body should be included in <see cref="Document.Meta" /> when it is invalid. False by default.
+    /// Whether to include the request body in <see cref="Document.Meta" /> responses when it is invalid. <c>false</c> by default.
     /// </summary>
     bool IncludeRequestBodyInErrors { get; }
 
     /// <summary>
-    /// Use relative links for all resources. False by default.
+    /// Whether to use relative links for all resources. <c>false</c> by default.
     /// </summary>
     /// <example>
     /// <code><![CDATA[
@@ -94,7 +98,7 @@ public interface IJsonApiOptions
     LinkTypes RelationshipLinks { get; }
 
     /// <summary>
-    /// Whether or not the total resource count should be included in top-level meta objects. This requires an additional database query. False by default.
+    /// Whether to include the total resource count in top-level meta objects. This requires an additional database query. <c>false</c> by default.
     /// </summary>
     bool IncludeTotalResourceCount { get; }
 
@@ -114,28 +118,40 @@ public interface IJsonApiOptions
     PageNumber? MaximumPageNumber { get; }
 
     /// <summary>
-    /// Whether or not to enable ASP.NET ModelState validation. True by default.
+    /// Whether ASP.NET ModelState validation is enabled. <c>true</c> by default.
     /// </summary>
     bool ValidateModelState { get; }
 
     /// <summary>
-    /// Whether or not clients can provide IDs when creating resources. When not allowed, a 403 Forbidden response is returned if a client attempts to create
-    /// a resource with a defined ID. False by default.
+    /// Whether clients are allowed or required to provide IDs when creating resources. <see cref="ClientIdGenerationMode.Forbidden" /> by default. This
+    /// setting can be overruled per resource type using <see cref="ResourceAttribute.ClientIdGeneration" />.
     /// </summary>
+    ClientIdGenerationMode ClientIdGeneration { get; }
+
+    /// <summary>
+    /// Whether clients can provide IDs when creating resources. When not allowed, a 403 Forbidden response is returned if a client attempts to create a
+    /// resource with a defined ID. <c>false</c> by default.
+    /// </summary>
+    /// <remarks>
+    /// Setting this to <c>true</c> corresponds to <see cref="ClientIdGenerationMode.Allowed" />, while <c>false</c> corresponds to
+    /// <see cref="ClientIdGenerationMode.Forbidden" />.
+    /// </remarks>
+    [PublicAPI]
+    [Obsolete("Use ClientIdGeneration instead.")]
     bool AllowClientGeneratedIds { get; }
 
     /// <summary>
-    /// Whether or not to produce an error on unknown query string parameters. False by default.
+    /// Whether to produce an error on unknown query string parameters. <c>false</c> by default.
     /// </summary>
     bool AllowUnknownQueryStringParameters { get; }
 
     /// <summary>
-    /// Whether or not to produce an error on unknown attribute and relationship keys in request bodies. False by default.
+    /// Whether to produce an error on unknown attribute and relationship keys in request bodies. <c>false</c> by default.
     /// </summary>
     bool AllowUnknownFieldsInRequestBody { get; }
 
     /// <summary>
-    /// Determines whether legacy filter notation in query strings, such as =eq:, =like:, and =in: is enabled. False by default.
+    /// Determines whether legacy filter notation in query strings (such as =eq:, =like:, and =in:) is enabled. <c>false</c> by default.
     /// </summary>
     bool EnableLegacyFilterNotation { get; }
 

--- a/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiOptions.cs
@@ -69,7 +69,15 @@ public sealed class JsonApiOptions : IJsonApiOptions
     public bool ValidateModelState { get; set; } = true;
 
     /// <inheritdoc />
-    public bool AllowClientGeneratedIds { get; set; }
+    public ClientIdGenerationMode ClientIdGeneration { get; set; }
+
+    /// <inheritdoc />
+    [Obsolete("Use ClientIdGeneration instead.")]
+    public bool AllowClientGeneratedIds
+    {
+        get => ClientIdGeneration is ClientIdGenerationMode.Allowed or ClientIdGenerationMode.Required;
+        set => ClientIdGeneration = value ? ClientIdGenerationMode.Allowed : ClientIdGenerationMode.Forbidden;
+    }
 
     /// <inheritdoc />
     public bool AllowUnknownQueryStringParameters { get; set; }

--- a/src/JsonApiDotNetCore/Configuration/ResourceGraphBuilder.cs
+++ b/src/JsonApiDotNetCore/Configuration/ResourceGraphBuilder.cs
@@ -237,6 +237,8 @@ public class ResourceGraphBuilder
 
     private ResourceType CreateResourceType(string publicName, Type resourceClrType, Type idClrType)
     {
+        ClientIdGenerationMode? clientIdGeneration = GetClientIdGeneration(resourceClrType);
+
         IReadOnlyCollection<AttrAttribute> attributes = GetAttributes(resourceClrType);
         IReadOnlyCollection<RelationshipAttribute> relationships = GetRelationships(resourceClrType);
         IReadOnlyCollection<EagerLoadAttribute> eagerLoads = GetEagerLoads(resourceClrType);
@@ -246,9 +248,15 @@ public class ResourceGraphBuilder
         var linksAttribute = resourceClrType.GetCustomAttribute<ResourceLinksAttribute>(true);
 
         return linksAttribute == null
-            ? new ResourceType(publicName, resourceClrType, idClrType, attributes, relationships, eagerLoads)
-            : new ResourceType(publicName, resourceClrType, idClrType, attributes, relationships, eagerLoads, linksAttribute.TopLevelLinks,
+            ? new ResourceType(publicName, clientIdGeneration, resourceClrType, idClrType, attributes, relationships, eagerLoads)
+            : new ResourceType(publicName, clientIdGeneration, resourceClrType, idClrType, attributes, relationships, eagerLoads, linksAttribute.TopLevelLinks,
                 linksAttribute.ResourceLinks, linksAttribute.RelationshipLinks);
+    }
+
+    private ClientIdGenerationMode? GetClientIdGeneration(Type resourceClrType)
+    {
+        var resourceAttribute = resourceClrType.GetCustomAttribute<ResourceAttribute>(true);
+        return resourceAttribute?.NullableClientIdGeneration;
     }
 
     private IReadOnlyCollection<AttrAttribute> GetAttributes(Type resourceClrType)

--- a/src/JsonApiDotNetCore/Resources/ResourceDefinitionAccessor.cs
+++ b/src/JsonApiDotNetCore/Resources/ResourceDefinitionAccessor.cs
@@ -17,6 +17,7 @@ public class ResourceDefinitionAccessor : IResourceDefinitionAccessor
     private readonly IServiceProvider _serviceProvider;
 
     /// <inheritdoc />
+    [Obsolete("Use IJsonApiRequest.IsReadOnly.")]
     public bool IsReadOnlyRequest
     {
         get
@@ -27,6 +28,7 @@ public class ResourceDefinitionAccessor : IResourceDefinitionAccessor
     }
 
     /// <inheritdoc />
+    [Obsolete("Use injected IQueryableBuilder instead.")]
     public IQueryableBuilder QueryableBuilder => _serviceProvider.GetRequiredService<IQueryableBuilder>();
 
     public ResourceDefinitionAccessor(IResourceGraph resourceGraph, IServiceProvider serviceProvider)

--- a/src/JsonApiDotNetCore/Serialization/Request/Adapters/AtomicOperationObjectAdapter.cs
+++ b/src/JsonApiDotNetCore/Serialization/Request/Adapters/AtomicOperationObjectAdapter.cs
@@ -122,13 +122,10 @@ public sealed class AtomicOperationObjectAdapter : IAtomicOperationObjectAdapter
 
     private ResourceIdentityRequirements CreateRefRequirements(RequestAdapterState state)
     {
-        JsonElementConstraint? idConstraint = state.Request.WriteOperation == WriteOperationKind.CreateResource
-            ? _options.AllowClientGeneratedIds ? null : JsonElementConstraint.Forbidden
-            : JsonElementConstraint.Required;
-
         return new ResourceIdentityRequirements
         {
-            IdConstraint = idConstraint
+            EvaluateIdConstraint = resourceType =>
+                ResourceIdentityRequirements.DoEvaluateIdConstraint(resourceType, state.Request.WriteOperation, _options.ClientIdGeneration)
         };
     }
 
@@ -137,7 +134,7 @@ public sealed class AtomicOperationObjectAdapter : IAtomicOperationObjectAdapter
         return new ResourceIdentityRequirements
         {
             ResourceType = refResult.ResourceType,
-            IdConstraint = refRequirements.IdConstraint,
+            EvaluateIdConstraint = refRequirements.EvaluateIdConstraint,
             IdValue = refResult.Resource.StringId,
             LidValue = refResult.Resource.LocalId,
             RelationshipName = refResult.Relationship?.PublicName

--- a/src/JsonApiDotNetCore/Serialization/Request/Adapters/DocumentInResourceOrRelationshipRequestAdapter.cs
+++ b/src/JsonApiDotNetCore/Serialization/Request/Adapters/DocumentInResourceOrRelationshipRequestAdapter.cs
@@ -60,14 +60,11 @@ public sealed class DocumentInResourceOrRelationshipRequestAdapter : IDocumentIn
 
     private ResourceIdentityRequirements CreateIdentityRequirements(RequestAdapterState state)
     {
-        JsonElementConstraint? idConstraint = state.Request.WriteOperation == WriteOperationKind.CreateResource
-            ? _options.AllowClientGeneratedIds ? null : JsonElementConstraint.Forbidden
-            : JsonElementConstraint.Required;
-
         var requirements = new ResourceIdentityRequirements
         {
             ResourceType = state.Request.PrimaryResourceType,
-            IdConstraint = idConstraint,
+            EvaluateIdConstraint = resourceType =>
+                ResourceIdentityRequirements.DoEvaluateIdConstraint(resourceType, state.Request.WriteOperation, _options.ClientIdGeneration),
             IdValue = state.Request.PrimaryId
         };
 

--- a/src/JsonApiDotNetCore/Serialization/Request/Adapters/RelationshipDataAdapter.cs
+++ b/src/JsonApiDotNetCore/Serialization/Request/Adapters/RelationshipDataAdapter.cs
@@ -70,7 +70,7 @@ public sealed class RelationshipDataAdapter : BaseAdapter, IRelationshipDataAdap
         var requirements = new ResourceIdentityRequirements
         {
             ResourceType = relationship.RightType,
-            IdConstraint = JsonElementConstraint.Required,
+            EvaluateIdConstraint = _ => JsonElementConstraint.Required,
             RelationshipName = relationship.PublicName
         };
 

--- a/src/JsonApiDotNetCore/Serialization/Response/ResourceObjectTreeNode.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/ResourceObjectTreeNode.cs
@@ -15,7 +15,7 @@ namespace JsonApiDotNetCore.Serialization.Response;
 internal sealed class ResourceObjectTreeNode : IEquatable<ResourceObjectTreeNode>
 {
     // Placeholder root node for the tree, which is never emitted itself.
-    private static readonly ResourceType RootType = new("(root)", typeof(object), typeof(object));
+    private static readonly ResourceType RootType = new("(root)", ClientIdGenerationMode.Forbidden, typeof(object), typeof(object));
     private static readonly IIdentifiable RootResource = new EmptyResource();
 
     // Direct children from root. These are emitted in 'data'.

--- a/test/AnnotationTests/Models/TreeNode.cs
+++ b/test/AnnotationTests/Models/TreeNode.cs
@@ -1,4 +1,5 @@
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Controllers;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
@@ -6,7 +7,8 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace AnnotationTests.Models;
 
 [PublicAPI]
-[Resource(PublicName = "tree-node", ControllerNamespace = "Models", GenerateControllerEndpoints = JsonApiEndpoints.Query)]
+[Resource(PublicName = "tree-node", ClientIdGeneration = ClientIdGenerationMode.Required, ControllerNamespace = "Models",
+    GenerateControllerEndpoints = JsonApiEndpoints.Query)]
 public sealed class TreeNode : Identifiable<long>
 {
     [Attr(PublicName = "name", Capabilities = AttrCapabilities.AllowSort)]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicSerializationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicSerializationTests.cs
@@ -31,7 +31,7 @@ public sealed class AtomicSerializationTests : IClassFixture<IntegrationTestCont
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
         options.IncludeExceptionStackTraceInErrors = false;
         options.IncludeJsonApiVersion = true;
-        options.AllowClientGeneratedIds = true;
+        options.ClientIdGeneration = ClientIdGenerationMode.Allowed;
     }
 
     [Fact]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/CompositeKeyTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/CompositeKeyTests.cs
@@ -3,7 +3,6 @@ using FluentAssertions;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Serialization.Objects;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using TestBuildingBlocks;
 using Xunit;
 
@@ -27,9 +26,6 @@ public sealed class CompositeKeyTests : IClassFixture<IntegrationTestContext<Tes
             services.AddResourceRepository<CarCompositeKeyAwareRepository<Car, string?>>();
             services.AddResourceRepository<CarCompositeKeyAwareRepository<Dealership, int>>();
         });
-
-        var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
-        options.AllowClientGeneratedIds = true;
     }
 
     [Fact]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceTests.cs
@@ -27,7 +27,6 @@ public sealed class CreateResourceTests : IClassFixture<IntegrationTestContext<T
 
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
         options.UseRelativeLinks = false;
-        options.AllowClientGeneratedIds = false;
         options.AllowUnknownFieldsInRequestBody = false;
     }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToOneRelationshipTests.cs
@@ -25,7 +25,7 @@ public sealed class CreateResourceWithToOneRelationshipTests : IClassFixture<Int
         testContext.UseController<UserAccountsController>();
 
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
-        options.AllowClientGeneratedIds = true;
+        options.ClientIdGeneration = ClientIdGenerationMode.Allowed;
     }
 
     [Fact]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/ETagTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/ETagTests.cs
@@ -97,6 +97,7 @@ public sealed class ETagTests : IClassFixture<IntegrationTestContext<TestableSta
     public async Task Returns_no_ETag_for_POST_request()
     {
         // Arrange
+        var newId = Guid.NewGuid();
         string newTitle = _fakers.Meeting.Generate().Title;
 
         var requestBody = new
@@ -104,6 +105,7 @@ public sealed class ETagTests : IClassFixture<IntegrationTestContext<TestableSta
             data = new
             {
                 type = "meetings",
+                id = newId,
                 attributes = new
                 {
                     title = newTitle

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/Meeting.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/Meeting.cs
@@ -1,13 +1,14 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.Serialization")]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.Serialization", ClientIdGeneration = ClientIdGenerationMode.Required)]
 public sealed class Meeting : Identifiable<Guid>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/SerializationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/SerializationTests.cs
@@ -30,7 +30,6 @@ public sealed class SerializationTests : IClassFixture<IntegrationTestContext<Te
 
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
         options.IncludeExceptionStackTraceInErrors = false;
-        options.AllowClientGeneratedIds = true;
         options.IncludeJsonApiVersion = false;
         options.IncludeTotalResourceCount = true;
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/EmptyGuidAsKeyTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/EmptyGuidAsKeyTests.cs
@@ -24,7 +24,6 @@ public sealed class EmptyGuidAsKeyTests : IClassFixture<IntegrationTestContext<T
 
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
         options.UseRelativeLinks = true;
-        options.AllowClientGeneratedIds = true;
     }
 
     [Fact]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/Game.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/Game.cs
@@ -1,12 +1,13 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys")]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys", ClientIdGeneration = ClientIdGenerationMode.Allowed)]
 public sealed class Game : Identifiable<int?>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/Map.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/Map.cs
@@ -1,11 +1,12 @@
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys")]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys", ClientIdGeneration = ClientIdGenerationMode.Allowed)]
 public sealed class Map : Identifiable<Guid?>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/ZeroAsKeyTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/ZeroAsKeyTests.cs
@@ -24,7 +24,6 @@ public sealed class ZeroAsKeyTests : IClassFixture<IntegrationTestContext<Testab
 
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
         options.UseRelativeLinks = true;
-        options.AllowClientGeneratedIds = true;
     }
 
     [Fact]

--- a/test/JsonApiDotNetCoreTests/UnitTests/Links/LinkInclusionTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Links/LinkInclusionTests.cs
@@ -57,7 +57,8 @@ public sealed class LinkInclusionTests
     public void Applies_cascading_settings_for_top_level_links(LinkTypes linksInResourceType, LinkTypes linksInOptions, LinkTypes expected)
     {
         // Arrange
-        var exampleResourceType = new ResourceType(nameof(ExampleResource), typeof(ExampleResource), typeof(int), linksInResourceType);
+        var exampleResourceType = new ResourceType(nameof(ExampleResource), ClientIdGenerationMode.Forbidden, typeof(ExampleResource), typeof(int),
+            linksInResourceType);
 
         var options = new JsonApiOptions
         {
@@ -156,7 +157,8 @@ public sealed class LinkInclusionTests
     public void Applies_cascading_settings_for_resource_links(LinkTypes linksInResourceType, LinkTypes linksInOptions, LinkTypes expected)
     {
         // Arrange
-        var exampleResourceType = new ResourceType(nameof(ExampleResource), typeof(ExampleResource), typeof(int), resourceLinks: linksInResourceType);
+        var exampleResourceType = new ResourceType(nameof(ExampleResource), ClientIdGenerationMode.Forbidden, typeof(ExampleResource), typeof(int),
+            resourceLinks: linksInResourceType);
 
         var options = new JsonApiOptions
         {
@@ -316,7 +318,8 @@ public sealed class LinkInclusionTests
         LinkTypes linksInOptions, LinkTypes expected)
     {
         // Arrange
-        var exampleResourceType = new ResourceType(nameof(ExampleResource), typeof(ExampleResource), typeof(int), relationshipLinks: linksInResourceType);
+        var exampleResourceType = new ResourceType(nameof(ExampleResource), ClientIdGenerationMode.Forbidden, typeof(ExampleResource), typeof(int),
+            relationshipLinks: linksInResourceType);
 
         var options = new JsonApiOptions
         {


### PR DESCRIPTION
Obsoletes the boolean `IJsonApiOptions.AllowClientGeneratedIds` in favor of the new `IJsonApiOptions.ClientIdGeneration`, which is an enumeration of `{ Forbidden, Allowed, Required }`. An error is now produced when a create-resource request omits the ID while configured to be required.

Client-generated IDs can be overruled per resource type, for example:
```c#
[Resource(ClientIdGeneration = ClientIdGenerationMode.Required)]
public class Article : Identifiable<Guid>
{
    // ...
}
```

Closes #1299

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [x] Documentation updated
