### PR TITLE
Remove Moq usage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,6 @@
   <PropertyGroup>
     <CoverletVersion>6.0.*</CoverletVersion>
     <GitHubActionsTestLoggerVersion>2.3.*</GitHubActionsTestLoggerVersion>
-    <MoqVersion>4.18.*</MoqVersion>
     <TestSdkVersion>17.7.*</TestSdkVersion>
   </PropertyGroup>
 </Project>

--- a/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
@@ -23,10 +23,12 @@ public sealed class JsonApiMiddleware
     private static readonly MediaTypeHeaderValue MediaType = MediaTypeHeaderValue.Parse(HeaderConstants.MediaType);
     private static readonly MediaTypeHeaderValue AtomicOperationsMediaType = MediaTypeHeaderValue.Parse(HeaderConstants.AtomicOperationsMediaType);
 
-    private readonly RequestDelegate _next;
+    private readonly RequestDelegate? _next;
 
-    public JsonApiMiddleware(RequestDelegate next, IHttpContextAccessor httpContextAccessor)
+    public JsonApiMiddleware(RequestDelegate? next, IHttpContextAccessor httpContextAccessor)
     {
+        ArgumentGuard.NotNull(httpContextAccessor);
+
         _next = next;
 
         var session = new AspNetCodeTimerSession(httpContextAccessor);
@@ -77,9 +79,12 @@ public sealed class JsonApiMiddleware
                 httpContext.RegisterJsonApiRequest();
             }
 
-            using (CodeTimingSessionManager.Current.Measure("Subsequent middleware"))
+            if (_next != null)
             {
-                await _next(httpContext);
+                using (CodeTimingSessionManager.Current.Measure("Subsequent middleware"))
+                {
+                    await _next(httpContext);
+                }
             }
         }
 

--- a/src/JsonApiDotNetCore/Properties/AssemblyInfo.cs
+++ b/src/JsonApiDotNetCore/Properties/AssemblyInfo.cs
@@ -3,5 +3,3 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Benchmarks")]
 [assembly: InternalsVisibleTo("JsonApiDotNetCoreTests")]
 [assembly: InternalsVisibleTo("UnitTests")]
-[assembly: InternalsVisibleTo("DiscoveryTests")]
-[assembly: InternalsVisibleTo("TestBuildingBlocks")]

--- a/test/DiscoveryTests/DiscoveryTests.csproj
+++ b/test/DiscoveryTests/DiscoveryTests.csproj
@@ -12,6 +12,5 @@
     <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)" PrivateAssets="All" />
     <PackageReference Include="GitHubActionsTestLogger" Version="$(GitHubActionsTestLoggerVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>
 </Project>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -12,6 +12,5 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="$(GitHubActionsTestLoggerVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EFCoreVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Remove usage of [Moq](https://github.com/moq/moq) in tests, due to all the [commotion](https://steven-giesel.com/blogPost/1939d20c-2493-4bf7-9636-96436283fb72) around SponsorLink. We had minimal usage, and the rewrite was easy. It's always nice to reduce our set of dependencies.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
