### PR TITLE
Make it easier to register custom services in the IoC container

### DIFF
--- a/docs/usage/common-pitfalls.md
+++ b/docs/usage/common-pitfalls.md
@@ -87,10 +87,12 @@ Neither sounds very compelling. If stored procedures is what you need, you're be
 Although recommended by Microsoft for hard-written controllers, the opinionated behavior of [`[ApiController]`](https://learn.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-7.0#apicontroller-attribute) violates the JSON:API specification.
 Despite JsonApiDotNetCore trying its best to deal with it, the experience won't be as good as leaving it out.
 
-#### Replace injectable services *after* calling `AddJsonApi()`
-Registering your own services in the IoC container afterwards increases the chances that your replacements will take effect.
-Also, register with `services.AddResourceDefinition/AddResourceService/AddResourceRepository()` instead of `services.AddScoped()`.
+#### Register/override injectable services
+Register your JSON:API resource services, resource definitions and repositories with `services.AddResourceService/AddResourceDefinition/AddResourceRepository()` instead of `services.AddScoped()`.
 When using [Auto-discovery](~/usage/resource-graph.md#auto-discovery), you don't need to register these at all.
+
+> [!NOTE]
+> In older versions of JsonApiDotNetCore, registering your own services in the IoC container *afterwards* increased the chances that your replacements would take effect.
 
 #### Never use the Entity Framework Core In-Memory Database Provider
 When using this provider, many invalid mappings go unnoticed, leading to strange errors or wrong behavior. A real SQL engine fails to create the schema when mappings are invalid.

--- a/src/Examples/MultiDbContextExample/Program.cs
+++ b/src/Examples/MultiDbContextExample/Program.cs
@@ -22,6 +22,9 @@ builder.Services.AddDbContext<DbContextB>(options =>
     SetDbContextDebugOptions(options);
 });
 
+builder.Services.AddResourceRepository<DbContextARepository<ResourceA>>();
+builder.Services.AddResourceRepository<DbContextBRepository<ResourceB>>();
+
 builder.Services.AddJsonApi(options =>
 {
     options.Namespace = "api";
@@ -38,9 +41,6 @@ builder.Services.AddJsonApi(options =>
     typeof(DbContextA),
     typeof(DbContextB)
 });
-
-builder.Services.AddResourceRepository<DbContextARepository<ResourceA>>();
-builder.Services.AddResourceRepository<DbContextBRepository<ResourceB>>();
 
 WebApplication app = builder.Build();
 

--- a/src/Examples/NoEntityFrameworkExample/Program.cs
+++ b/src/Examples/NoEntityFrameworkExample/Program.cs
@@ -5,6 +5,8 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
+builder.Services.AddScoped<IInverseNavigationResolver, InMemoryInverseNavigationResolver>();
+
 builder.Services.AddJsonApi(options =>
 {
     options.Namespace = "api";
@@ -17,8 +19,6 @@ builder.Services.AddJsonApi(options =>
     options.SerializerOptions.WriteIndented = true;
 #endif
 }, discovery => discovery.AddCurrentAssembly());
-
-builder.Services.AddScoped<IInverseNavigationResolver, InMemoryInverseNavigationResolver>();
 
 WebApplication app = builder.Build();
 

--- a/src/JsonApiDotNetCore/Configuration/JsonApiApplicationBuilder.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiApplicationBuilder.cs
@@ -89,7 +89,7 @@ internal sealed class JsonApiApplicationBuilder : IJsonApiApplicationBuilder, ID
 
         _options.SerializerOptions.Converters.Add(new ResourceObjectConverter(resourceGraph));
 
-        _services.AddSingleton(resourceGraph);
+        _services.TryAddSingleton(resourceGraph);
     }
 
     /// <summary>
@@ -109,7 +109,7 @@ internal sealed class JsonApiApplicationBuilder : IJsonApiApplicationBuilder, ID
         if (_options.ValidateModelState)
         {
             _mvcBuilder.AddDataAnnotations();
-            _services.AddSingleton<IModelMetadataProvider, JsonApiModelMetadataProvider>();
+            _services.Replace(new ServiceDescriptor(typeof(IModelMetadataProvider), typeof(JsonApiModelMetadataProvider), ServiceLifetime.Singleton));
         }
     }
 
@@ -130,19 +130,19 @@ internal sealed class JsonApiApplicationBuilder : IJsonApiApplicationBuilder, ID
 
         if (dbContextTypes.Any())
         {
-            _services.AddScoped(typeof(DbContextResolver<>));
+            _services.TryAddScoped(typeof(DbContextResolver<>));
 
             foreach (Type dbContextType in dbContextTypes)
             {
                 Type dbContextResolverClosedType = typeof(DbContextResolver<>).MakeGenericType(dbContextType);
-                _services.AddScoped(typeof(IDbContextResolver), dbContextResolverClosedType);
+                _services.TryAddScoped(typeof(IDbContextResolver), dbContextResolverClosedType);
             }
 
-            _services.AddScoped<IOperationsTransactionFactory, EntityFrameworkCoreTransactionFactory>();
+            _services.TryAddScoped<IOperationsTransactionFactory, EntityFrameworkCoreTransactionFactory>();
         }
         else
         {
-            _services.AddScoped<IOperationsTransactionFactory, MissingTransactionFactory>();
+            _services.TryAddScoped<IOperationsTransactionFactory, MissingTransactionFactory>();
         }
 
         AddResourceLayer();
@@ -153,46 +153,46 @@ internal sealed class JsonApiApplicationBuilder : IJsonApiApplicationBuilder, ID
         AddQueryStringLayer();
         AddOperationsLayer();
 
-        _services.AddScoped(typeof(IResourceChangeTracker<>), typeof(ResourceChangeTracker<>));
-        _services.AddScoped<IPaginationContext, PaginationContext>();
-        _services.AddScoped<IEvaluatedIncludeCache, EvaluatedIncludeCache>();
-        _services.AddScoped<ISparseFieldSetCache, SparseFieldSetCache>();
-        _services.AddScoped<IQueryLayerComposer, QueryLayerComposer>();
-        _services.AddScoped<IInverseNavigationResolver, InverseNavigationResolver>();
+        _services.TryAddScoped(typeof(IResourceChangeTracker<>), typeof(ResourceChangeTracker<>));
+        _services.TryAddScoped<IPaginationContext, PaginationContext>();
+        _services.TryAddScoped<IEvaluatedIncludeCache, EvaluatedIncludeCache>();
+        _services.TryAddScoped<ISparseFieldSetCache, SparseFieldSetCache>();
+        _services.TryAddScoped<IQueryLayerComposer, QueryLayerComposer>();
+        _services.TryAddScoped<IInverseNavigationResolver, InverseNavigationResolver>();
     }
 
     private void AddMiddlewareLayer()
     {
-        _services.AddSingleton<IJsonApiOptions>(_options);
-        _services.AddSingleton<IJsonApiApplicationBuilder>(this);
-        _services.AddSingleton<IExceptionHandler, ExceptionHandler>();
-        _services.AddScoped<IAsyncJsonApiExceptionFilter, AsyncJsonApiExceptionFilter>();
-        _services.AddScoped<IAsyncQueryStringActionFilter, AsyncQueryStringActionFilter>();
-        _services.AddScoped<IAsyncConvertEmptyActionResultFilter, AsyncConvertEmptyActionResultFilter>();
-        _services.AddSingleton<IJsonApiInputFormatter, JsonApiInputFormatter>();
-        _services.AddSingleton<IJsonApiOutputFormatter, JsonApiOutputFormatter>();
-        _services.AddSingleton<IJsonApiRoutingConvention, JsonApiRoutingConvention>();
-        _services.AddSingleton<IControllerResourceMapping>(sp => sp.GetRequiredService<IJsonApiRoutingConvention>());
-        _services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
-        _services.AddScoped<IJsonApiRequest, JsonApiRequest>();
-        _services.AddScoped<IJsonApiWriter, JsonApiWriter>();
-        _services.AddScoped<IJsonApiReader, JsonApiReader>();
-        _services.AddScoped<ITargetedFields, TargetedFields>();
+        _services.TryAddSingleton<IJsonApiOptions>(_options);
+        _services.TryAddSingleton<IJsonApiApplicationBuilder>(this);
+        _services.TryAddSingleton<IExceptionHandler, ExceptionHandler>();
+        _services.TryAddScoped<IAsyncJsonApiExceptionFilter, AsyncJsonApiExceptionFilter>();
+        _services.TryAddScoped<IAsyncQueryStringActionFilter, AsyncQueryStringActionFilter>();
+        _services.TryAddScoped<IAsyncConvertEmptyActionResultFilter, AsyncConvertEmptyActionResultFilter>();
+        _services.TryAddSingleton<IJsonApiInputFormatter, JsonApiInputFormatter>();
+        _services.TryAddSingleton<IJsonApiOutputFormatter, JsonApiOutputFormatter>();
+        _services.TryAddSingleton<IJsonApiRoutingConvention, JsonApiRoutingConvention>();
+        _services.TryAddSingleton<IControllerResourceMapping>(provider => provider.GetRequiredService<IJsonApiRoutingConvention>());
+        _services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+        _services.TryAddScoped<IJsonApiRequest, JsonApiRequest>();
+        _services.TryAddScoped<IJsonApiWriter, JsonApiWriter>();
+        _services.TryAddScoped<IJsonApiReader, JsonApiReader>();
+        _services.TryAddScoped<ITargetedFields, TargetedFields>();
     }
 
     private void AddResourceLayer()
     {
         RegisterImplementationForInterfaces(ServiceDiscoveryFacade.ResourceDefinitionUnboundInterfaces, typeof(JsonApiResourceDefinition<,>));
 
-        _services.AddScoped<IResourceDefinitionAccessor, ResourceDefinitionAccessor>();
-        _services.AddScoped<IResourceFactory, ResourceFactory>();
+        _services.TryAddScoped<IResourceDefinitionAccessor, ResourceDefinitionAccessor>();
+        _services.TryAddScoped<IResourceFactory, ResourceFactory>();
     }
 
     private void AddRepositoryLayer()
     {
         RegisterImplementationForInterfaces(ServiceDiscoveryFacade.RepositoryUnboundInterfaces, typeof(EntityFrameworkCoreRepository<,>));
 
-        _services.AddScoped<IResourceRepositoryAccessor, ResourceRepositoryAccessor>();
+        _services.TryAddScoped<IResourceRepositoryAccessor, ResourceRepositoryAccessor>();
 
         _services.TryAddTransient<IQueryableBuilder, QueryableBuilder>();
         _services.TryAddTransient<IIncludeClauseBuilder, IncludeClauseBuilder>();
@@ -225,12 +225,12 @@ internal sealed class JsonApiApplicationBuilder : IJsonApiApplicationBuilder, ID
         _services.TryAddTransient<ISparseFieldSetParser, SparseFieldSetParser>();
         _services.TryAddTransient<IPaginationParser, PaginationParser>();
 
-        _services.AddScoped<IIncludeQueryStringParameterReader, IncludeQueryStringParameterReader>();
-        _services.AddScoped<IFilterQueryStringParameterReader, FilterQueryStringParameterReader>();
-        _services.AddScoped<ISortQueryStringParameterReader, SortQueryStringParameterReader>();
-        _services.AddScoped<ISparseFieldSetQueryStringParameterReader, SparseFieldSetQueryStringParameterReader>();
-        _services.AddScoped<IPaginationQueryStringParameterReader, PaginationQueryStringParameterReader>();
-        _services.AddScoped<IResourceDefinitionQueryableParameterReader, ResourceDefinitionQueryableParameterReader>();
+        _services.TryAddScoped<IIncludeQueryStringParameterReader, IncludeQueryStringParameterReader>();
+        _services.TryAddScoped<IFilterQueryStringParameterReader, FilterQueryStringParameterReader>();
+        _services.TryAddScoped<ISortQueryStringParameterReader, SortQueryStringParameterReader>();
+        _services.TryAddScoped<ISparseFieldSetQueryStringParameterReader, SparseFieldSetQueryStringParameterReader>();
+        _services.TryAddScoped<IPaginationQueryStringParameterReader, PaginationQueryStringParameterReader>();
+        _services.TryAddScoped<IResourceDefinitionQueryableParameterReader, ResourceDefinitionQueryableParameterReader>();
 
         RegisterDependentService<IQueryStringParameterReader, IIncludeQueryStringParameterReader>();
         RegisterDependentService<IQueryStringParameterReader, IFilterQueryStringParameterReader>();
@@ -246,50 +246,50 @@ internal sealed class JsonApiApplicationBuilder : IJsonApiApplicationBuilder, ID
         RegisterDependentService<IQueryConstraintProvider, IPaginationQueryStringParameterReader>();
         RegisterDependentService<IQueryConstraintProvider, IResourceDefinitionQueryableParameterReader>();
 
-        _services.AddScoped<IQueryStringReader, QueryStringReader>();
-        _services.AddSingleton<IRequestQueryStringAccessor, RequestQueryStringAccessor>();
+        _services.TryAddScoped<IQueryStringReader, QueryStringReader>();
+        _services.TryAddSingleton<IRequestQueryStringAccessor, RequestQueryStringAccessor>();
     }
 
     private void RegisterDependentService<TCollectionElement, TElementToAdd>()
         where TCollectionElement : class
         where TElementToAdd : TCollectionElement
     {
-        _services.AddScoped<TCollectionElement>(serviceProvider => serviceProvider.GetRequiredService<TElementToAdd>());
+        _services.AddScoped<TCollectionElement>(provider => provider.GetRequiredService<TElementToAdd>());
     }
 
     private void AddSerializationLayer()
     {
-        _services.AddScoped<IResourceIdentifierObjectAdapter, ResourceIdentifierObjectAdapter>();
-        _services.AddScoped<IRelationshipDataAdapter, RelationshipDataAdapter>();
-        _services.AddScoped<IResourceObjectAdapter, ResourceObjectAdapter>();
-        _services.AddScoped<IResourceDataAdapter, ResourceDataAdapter>();
-        _services.AddScoped<IAtomicReferenceAdapter, AtomicReferenceAdapter>();
-        _services.AddScoped<IResourceDataInOperationsRequestAdapter, ResourceDataInOperationsRequestAdapter>();
-        _services.AddScoped<IAtomicOperationObjectAdapter, AtomicOperationObjectAdapter>();
-        _services.AddScoped<IDocumentInResourceOrRelationshipRequestAdapter, DocumentInResourceOrRelationshipRequestAdapter>();
-        _services.AddScoped<IDocumentInOperationsRequestAdapter, DocumentInOperationsRequestAdapter>();
-        _services.AddScoped<IDocumentAdapter, DocumentAdapter>();
+        _services.TryAddScoped<IResourceIdentifierObjectAdapter, ResourceIdentifierObjectAdapter>();
+        _services.TryAddScoped<IRelationshipDataAdapter, RelationshipDataAdapter>();
+        _services.TryAddScoped<IResourceObjectAdapter, ResourceObjectAdapter>();
+        _services.TryAddScoped<IResourceDataAdapter, ResourceDataAdapter>();
+        _services.TryAddScoped<IAtomicReferenceAdapter, AtomicReferenceAdapter>();
+        _services.TryAddScoped<IResourceDataInOperationsRequestAdapter, ResourceDataInOperationsRequestAdapter>();
+        _services.TryAddScoped<IAtomicOperationObjectAdapter, AtomicOperationObjectAdapter>();
+        _services.TryAddScoped<IDocumentInResourceOrRelationshipRequestAdapter, DocumentInResourceOrRelationshipRequestAdapter>();
+        _services.TryAddScoped<IDocumentInOperationsRequestAdapter, DocumentInOperationsRequestAdapter>();
+        _services.TryAddScoped<IDocumentAdapter, DocumentAdapter>();
 
-        _services.AddScoped<ILinkBuilder, LinkBuilder>();
-        _services.AddScoped<IResponseMeta, EmptyResponseMeta>();
-        _services.AddScoped<IMetaBuilder, MetaBuilder>();
-        _services.AddSingleton<IFingerprintGenerator, FingerprintGenerator>();
-        _services.AddSingleton<IETagGenerator, ETagGenerator>();
-        _services.AddScoped<IResponseModelAdapter, ResponseModelAdapter>();
+        _services.TryAddScoped<ILinkBuilder, LinkBuilder>();
+        _services.TryAddScoped<IResponseMeta, EmptyResponseMeta>();
+        _services.TryAddScoped<IMetaBuilder, MetaBuilder>();
+        _services.TryAddSingleton<IFingerprintGenerator, FingerprintGenerator>();
+        _services.TryAddSingleton<IETagGenerator, ETagGenerator>();
+        _services.TryAddScoped<IResponseModelAdapter, ResponseModelAdapter>();
     }
 
     private void AddOperationsLayer()
     {
-        _services.AddScoped(typeof(ICreateProcessor<,>), typeof(CreateProcessor<,>));
-        _services.AddScoped(typeof(IUpdateProcessor<,>), typeof(UpdateProcessor<,>));
-        _services.AddScoped(typeof(IDeleteProcessor<,>), typeof(DeleteProcessor<,>));
-        _services.AddScoped(typeof(IAddToRelationshipProcessor<,>), typeof(AddToRelationshipProcessor<,>));
-        _services.AddScoped(typeof(ISetRelationshipProcessor<,>), typeof(SetRelationshipProcessor<,>));
-        _services.AddScoped(typeof(IRemoveFromRelationshipProcessor<,>), typeof(RemoveFromRelationshipProcessor<,>));
+        _services.TryAddScoped(typeof(ICreateProcessor<,>), typeof(CreateProcessor<,>));
+        _services.TryAddScoped(typeof(IUpdateProcessor<,>), typeof(UpdateProcessor<,>));
+        _services.TryAddScoped(typeof(IDeleteProcessor<,>), typeof(DeleteProcessor<,>));
+        _services.TryAddScoped(typeof(IAddToRelationshipProcessor<,>), typeof(AddToRelationshipProcessor<,>));
+        _services.TryAddScoped(typeof(ISetRelationshipProcessor<,>), typeof(SetRelationshipProcessor<,>));
+        _services.TryAddScoped(typeof(IRemoveFromRelationshipProcessor<,>), typeof(RemoveFromRelationshipProcessor<,>));
 
-        _services.AddScoped<IOperationsProcessor, OperationsProcessor>();
-        _services.AddScoped<IOperationProcessorAccessor, OperationProcessorAccessor>();
-        _services.AddScoped<ILocalIdTracker, LocalIdTracker>();
+        _services.TryAddScoped<IOperationsProcessor, OperationsProcessor>();
+        _services.TryAddScoped<IOperationProcessorAccessor, OperationProcessorAccessor>();
+        _services.TryAddScoped<ILocalIdTracker, LocalIdTracker>();
     }
 
     public void Dispose()

--- a/src/JsonApiDotNetCore/Configuration/ServiceDiscoveryFacade.cs
+++ b/src/JsonApiDotNetCore/Configuration/ServiceDiscoveryFacade.cs
@@ -5,6 +5,7 @@ using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace JsonApiDotNetCore.Configuration;
@@ -119,7 +120,7 @@ public sealed class ServiceDiscoveryFacade
         foreach (Type dbContextType in dbContextTypes)
         {
             Type dbContextResolverClosedType = typeof(DbContextResolver<>).MakeGenericType(dbContextType);
-            _services.AddScoped(typeof(IDbContextResolver), dbContextResolverClosedType);
+            _services.TryAddScoped(typeof(IDbContextResolver), dbContextResolverClosedType);
         }
     }
 
@@ -163,7 +164,7 @@ public sealed class ServiceDiscoveryFacade
         if (result != null)
         {
             (Type implementationType, Type serviceInterface) = result.Value;
-            _services.AddScoped(serviceInterface, implementationType);
+            _services.TryAddScoped(serviceInterface, implementationType);
         }
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Archiving/ArchiveTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Archiving/ArchiveTests.cs
@@ -21,7 +21,7 @@ public sealed class ArchiveTests : IClassFixture<IntegrationTestContext<Testable
         testContext.UseController<TelevisionBroadcastsController>();
         testContext.UseController<BroadcastCommentsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<TelevisionBroadcastDefinition>();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceTests.cs
@@ -27,7 +27,7 @@ public sealed class AtomicCreateResourceTests : IClassFixture<IntegrationTestCon
         testContext.UseController<MusicTracksController>();
         testContext.UseController<PlaylistsController>();
 
-        testContext.ConfigureServicesBeforeStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddSingleton<ISystemClock, FrozenSystemClock>();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithClientGeneratedIdTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Creating/AtomicCreateResourceWithClientGeneratedIdTests.cs
@@ -24,7 +24,7 @@ public sealed class AtomicCreateResourceWithClientGeneratedIdTests
         // These routes need to be registered in ASP.NET for rendering links to resource/relationship endpoints.
         testContext.UseController<TextLanguagesController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<ImplicitlyChangingTextLanguageDefinition>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Links/AtomicAbsoluteLinksTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Links/AtomicAbsoluteLinksTests.cs
@@ -25,7 +25,7 @@ public sealed class AtomicAbsoluteLinksTests : IClassFixture<IntegrationTestCont
         testContext.UseController<TextLanguagesController>();
         testContext.UseController<RecordCompaniesController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddScoped(typeof(IResourceChangeTracker<>), typeof(NeverSameResourceChangeTracker<>));
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Links/AtomicRelativeLinksWithNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Links/AtomicRelativeLinksWithNamespaceTests.cs
@@ -26,7 +26,7 @@ public sealed class AtomicRelativeLinksWithNamespaceTests
         testContext.UseController<TextLanguagesController>();
         testContext.UseController<RecordCompaniesController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddScoped(typeof(IResourceChangeTracker<>), typeof(NeverSameResourceChangeTracker<>));
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/AtomicResourceMetaTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/AtomicResourceMetaTests.cs
@@ -22,7 +22,7 @@ public sealed class AtomicResourceMetaTests : IClassFixture<IntegrationTestConte
 
         testContext.UseController<OperationsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<MusicTrackMetaDefinition>();
             services.AddResourceDefinition<TextLanguageMetaDefinition>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/AtomicResponseMetaTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Meta/AtomicResponseMetaTests.cs
@@ -21,7 +21,7 @@ public sealed class AtomicResponseMetaTests : IClassFixture<IntegrationTestConte
 
         testContext.UseController<OperationsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<ImplicitlyChangingTextLanguageDefinition>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicLoggingTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicLoggingTests.cs
@@ -28,13 +28,9 @@ public sealed class AtomicLoggingTests : IClassFixture<IntegrationTestContext<Te
             options.SetMinimumLevel(LogLevel.Information);
         });
 
-        testContext.ConfigureServicesBeforeStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddSingleton(loggerFactory);
-        });
-
-        testContext.ConfigureServicesAfterStartup(services =>
-        {
             services.AddSingleton<IOperationsTransactionFactory, ThrowingOperationsTransactionFactory>();
         });
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicSerializationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicSerializationTests.cs
@@ -21,7 +21,7 @@ public sealed class AtomicSerializationTests : IClassFixture<IntegrationTestCont
         // These routes need to be registered in ASP.NET for rendering links to resource/relationship endpoints.
         testContext.UseController<TextLanguagesController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<ImplicitlyChangingTextLanguageDefinition>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ModelStateValidation/AtomicModelStateValidationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ModelStateValidation/AtomicModelStateValidationTests.cs
@@ -18,7 +18,7 @@ public sealed class AtomicModelStateValidationTests : IClassFixture<IntegrationT
     {
         _testContext = testContext;
 
-        _testContext.ConfigureServicesBeforeStartup(services =>
+        _testContext.ConfigureServices(services =>
         {
             services.AddSingleton<ISystemClock, FrozenSystemClock>();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/QueryStrings/AtomicQueryStringTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/QueryStrings/AtomicQueryStringTests.cs
@@ -21,10 +21,11 @@ public sealed class AtomicQueryStringTests : IClassFixture<IntegrationTestContex
         testContext.UseController<OperationsController>();
         testContext.UseController<MusicTracksController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
-            services.AddSingleton<ISystemClock, FrozenSystemClock>();
             services.AddResourceDefinition<MusicTrackReleaseDefinition>();
+
+            services.AddSingleton<ISystemClock, FrozenSystemClock>();
         });
     }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/Serialization/AtomicSerializationResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/Serialization/AtomicSerializationResourceDefinitionTests.cs
@@ -22,7 +22,7 @@ public sealed class AtomicSerializationResourceDefinitionTests
 
         testContext.UseController<OperationsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<RecordCompanyDefinition>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/SparseFieldSets/AtomicSparseFieldSetResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/SparseFieldSets/AtomicSparseFieldSetResourceDefinitionTests.cs
@@ -21,7 +21,7 @@ public sealed class AtomicSparseFieldSetResourceDefinitionTests
 
         testContext.UseController<OperationsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<LyricTextDefinition>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Transactions/AtomicTransactionConsistencyTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Transactions/AtomicTransactionConsistencyTests.cs
@@ -21,7 +21,7 @@ public sealed class AtomicTransactionConsistencyTests
 
         testContext.UseController<OperationsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceRepository<PerformerRepository>();
             services.AddResourceRepository<MusicTrackRepository>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Updating/Resources/AtomicUpdateResourceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Updating/Resources/AtomicUpdateResourceTests.cs
@@ -25,7 +25,7 @@ public sealed class AtomicUpdateResourceTests : IClassFixture<IntegrationTestCon
         // These routes need to be registered in ASP.NET for rendering links to resource/relationship endpoints.
         testContext.UseController<TextLanguagesController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<ImplicitlyChangingTextLanguageDefinition>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Blobs/BlobTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Blobs/BlobTests.cs
@@ -19,7 +19,7 @@ public sealed class BlobTests : IClassFixture<IntegrationTestContext<TestableSta
 
         testContext.UseController<ImageContainersController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddScoped(typeof(IResourceChangeTracker<>), typeof(NeverSameResourceChangeTracker<>));
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/CompositeKeyTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/CompositeKeyTests.cs
@@ -21,7 +21,7 @@ public sealed class CompositeKeyTests : IClassFixture<IntegrationTestContext<Tes
         testContext.UseController<EnginesController>();
         testContext.UseController<CarsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceRepository<CarCompositeKeyAwareRepository<Car, string?>>();
             services.AddResourceRepository<CarCompositeKeyAwareRepository<Dealership, int>>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CustomRoutes/ApiControllerAttributeLogTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CustomRoutes/ApiControllerAttributeLogTests.cs
@@ -22,7 +22,7 @@ public sealed class ApiControllerAttributeLogTests : IntegrationTestContext<Test
             options.AddProvider(_loggerFactory);
         });
 
-        ConfigureServicesBeforeStartup(services =>
+        ConfigureServices(services =>
         {
             services.AddSingleton(_loggerFactory);
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/EagerLoading/EagerLoadingTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/EagerLoading/EagerLoadingTests.cs
@@ -21,7 +21,7 @@ public sealed class EagerLoadingTests : IClassFixture<IntegrationTestContext<Tes
         testContext.UseController<StatesController>();
         testContext.UseController<BuildingsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<BuildingDefinition>();
             services.AddResourceRepository<BuildingRepository>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ExceptionHandling/ExceptionHandlerTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ExceptionHandling/ExceptionHandlerTests.cs
@@ -30,14 +30,11 @@ public sealed class ExceptionHandlerTests : IClassFixture<IntegrationTestContext
             options.AddProvider(loggerFactory);
         });
 
-        testContext.ConfigureServicesBeforeStartup(services =>
-        {
-            services.AddSingleton(loggerFactory);
-        });
-
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceService<ConsumerArticleService>();
+
+            services.AddSingleton(loggerFactory);
             services.AddScoped<IExceptionHandler, AlternateExceptionHandler>();
         });
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/ModelStateValidationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/ModelStateValidationTests.cs
@@ -19,7 +19,7 @@ public sealed class ModelStateValidationTests : IClassFixture<IntegrationTestCon
         testContext.UseController<SystemDirectoriesController>();
         testContext.UseController<SystemFilesController>();
 
-        testContext.ConfigureServicesBeforeStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             // Polyfill for missing DateOnly/TimeOnly support in .NET 6 ModelState validation.
             services.AddDateOnlyTimeOnlyStringConverters();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/RequestBody/WorkflowTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/RequestBody/WorkflowTests.cs
@@ -17,7 +17,7 @@ public sealed class WorkflowTests : IClassFixture<IntegrationTestContext<Testabl
 
         testContext.UseController<WorkflowsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<WorkflowDefinition>();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/AbsoluteLinksWithNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/AbsoluteLinksWithNamespaceTests.cs
@@ -25,7 +25,7 @@ public sealed class AbsoluteLinksWithNamespaceTests : IClassFixture<IntegrationT
         testContext.UseController<PhotoAlbumsController>();
         testContext.UseController<PhotosController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddScoped(typeof(IResourceChangeTracker<>), typeof(NeverSameResourceChangeTracker<>));
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/AbsoluteLinksWithoutNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/AbsoluteLinksWithoutNamespaceTests.cs
@@ -25,7 +25,7 @@ public sealed class AbsoluteLinksWithoutNamespaceTests : IClassFixture<Integrati
         testContext.UseController<PhotoAlbumsController>();
         testContext.UseController<PhotosController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddScoped(typeof(IResourceChangeTracker<>), typeof(NeverSameResourceChangeTracker<>));
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/RelativeLinksWithNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/RelativeLinksWithNamespaceTests.cs
@@ -25,7 +25,7 @@ public sealed class RelativeLinksWithNamespaceTests : IClassFixture<IntegrationT
         testContext.UseController<PhotoAlbumsController>();
         testContext.UseController<PhotosController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddScoped(typeof(IResourceChangeTracker<>), typeof(NeverSameResourceChangeTracker<>));
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/RelativeLinksWithoutNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/RelativeLinksWithoutNamespaceTests.cs
@@ -25,7 +25,7 @@ public sealed class RelativeLinksWithoutNamespaceTests : IClassFixture<Integrati
         testContext.UseController<PhotoAlbumsController>();
         testContext.UseController<PhotosController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddScoped(typeof(IResourceChangeTracker<>), typeof(NeverSameResourceChangeTracker<>));
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Logging/LoggingTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Logging/LoggingTests.cs
@@ -27,7 +27,7 @@ public sealed class LoggingTests : IClassFixture<IntegrationTestContext<Testable
             options.SetMinimumLevel(LogLevel.Trace);
         });
 
-        testContext.ConfigureServicesBeforeStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddSingleton(loggerFactory);
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/ResourceMetaTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/ResourceMetaTests.cs
@@ -20,9 +20,10 @@ public sealed class ResourceMetaTests : IClassFixture<IntegrationTestContext<Tes
         testContext.UseController<ProductFamiliesController>();
         testContext.UseController<SupportTicketsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<SupportTicketDefinition>();
+
             services.AddSingleton<ResourceDefinitionHitCounter>();
         });
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/ResponseMetaTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/ResponseMetaTests.cs
@@ -19,7 +19,7 @@ public sealed class ResponseMetaTests : IClassFixture<IntegrationTestContext<Tes
         testContext.UseController<ProductFamiliesController>();
         testContext.UseController<SupportTicketsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddSingleton<IResponseMeta, SupportResponseMeta>();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/TopLevelCountTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/TopLevelCountTests.cs
@@ -21,7 +21,7 @@ public sealed class TopLevelCountTests : IClassFixture<IntegrationTestContext<Te
         testContext.UseController<ProductFamiliesController>();
         testContext.UseController<SupportTicketsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddScoped(typeof(IResourceChangeTracker<>), typeof(NeverSameResourceChangeTracker<>));
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetTests.cs
@@ -20,7 +20,7 @@ public sealed partial class FireForgetTests : IClassFixture<IntegrationTestConte
         testContext.UseController<DomainUsersController>();
         testContext.UseController<DomainGroupsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<FireForgetUserDefinition>();
             services.AddResourceDefinition<FireForgetGroupDefinition>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.cs
@@ -23,7 +23,7 @@ public sealed partial class OutboxTests : IClassFixture<IntegrationTestContext<T
         testContext.UseController<DomainUsersController>();
         testContext.UseController<DomainGroupsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<OutboxUserDefinition>();
             services.AddResourceDefinition<OutboxGroupDefinition>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/MultiTenancyTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/MultiTenancyTests.cs
@@ -25,16 +25,13 @@ public sealed class MultiTenancyTests : IClassFixture<IntegrationTestContext<Tes
         testContext.UseController<WebShopsController>();
         testContext.UseController<WebProductsController>();
 
-        testContext.ConfigureServicesBeforeStartup(services =>
-        {
-            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
-            services.AddScoped<ITenantProvider, RouteTenantProvider>();
-        });
-
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceService<MultiTenantResourceService<WebShop, int>>();
             services.AddResourceService<MultiTenantResourceService<WebProduct, int>>();
+
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+            services.AddScoped<ITenantProvider, RouteTenantProvider>();
         });
 
         var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/IsUpperCase/IsUpperCaseFilterTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/IsUpperCase/IsUpperCaseFilterTests.cs
@@ -20,7 +20,7 @@ public sealed class IsUpperCaseFilterTests : IClassFixture<IntegrationTestContex
 
         testContext.UseController<BlogsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddTransient<IFilterParser, IsUpperCaseFilterParser>();
             services.AddTransient<IWhereClauseBuilder, IsUpperCaseWhereClauseBuilder>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/StringLength/LengthFilterTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/StringLength/LengthFilterTests.cs
@@ -20,7 +20,7 @@ public sealed class LengthFilterTests : IClassFixture<IntegrationTestContext<Tes
 
         testContext.UseController<BlogsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddTransient<IFilterParser, LengthFilterParser>();
             services.AddTransient<IWhereClauseBuilder, LengthWhereClauseBuilder>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/StringLength/LengthSortTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/StringLength/LengthSortTests.cs
@@ -20,7 +20,7 @@ public sealed class LengthSortTests : IClassFixture<IntegrationTestContext<Testa
 
         testContext.UseController<BlogsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddTransient<ISortParser, LengthSortParser>();
             services.AddTransient<IOrderClauseBuilder, LengthOrderClauseBuilder>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/Sum/SumFilterTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/Sum/SumFilterTests.cs
@@ -21,7 +21,7 @@ public sealed class SumFilterTests : IClassFixture<IntegrationTestContext<Testab
         testContext.UseController<BlogsController>();
         testContext.UseController<BlogPostsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddTransient<IFilterParser, SumFilterParser>();
             services.AddTransient<IWhereClauseBuilder, SumWhereClauseBuilder>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/TimeOffset/TimeOffsetTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/TimeOffset/TimeOffsetTests.cs
@@ -25,7 +25,7 @@ public sealed class TimeOffsetTests : IClassFixture<IntegrationTestContext<Testa
         testContext.UseController<CalendarsController>();
         testContext.UseController<RemindersController>();
 
-        testContext.ConfigureServicesBeforeStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddTransient<IFilterParser, TimeOffsetFilterParser>();
             services.AddSingleton<ISystemClock, FrozenSystemClock>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/SparseFieldSets/SparseFieldSetTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/SparseFieldSets/SparseFieldSetTests.cs
@@ -22,13 +22,13 @@ public sealed class SparseFieldSetTests : IClassFixture<IntegrationTestContext<T
         testContext.UseController<BlogsController>();
         testContext.UseController<CalendarsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
-            services.AddSingleton<ResourceCaptureStore>();
-
             services.AddResourceRepository<ResultCapturingRepository<Blog, int>>();
             services.AddResourceRepository<ResultCapturingRepository<BlogPost, int>>();
             services.AddResourceRepository<ResultCapturingRepository<WebAccount, int>>();
+
+            services.AddSingleton<ResourceCaptureStore>();
         });
     }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithClientGeneratedIdTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithClientGeneratedIdTests.cs
@@ -22,7 +22,7 @@ public sealed class CreateResourceWithClientGeneratedIdTests : IClassFixture<Int
         testContext.UseController<WorkItemGroupsController>();
         testContext.UseController<RgbColorsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<ImplicitlyChangingWorkItemGroupDefinition>();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Relationships/RemoveFromToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Relationships/RemoveFromToManyRelationshipTests.cs
@@ -25,7 +25,7 @@ public sealed class RemoveFromToManyRelationshipTests : IClassFixture<Integratio
         testContext.UseController<WorkItemsController>();
         testContext.UseController<WorkItemGroupsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddSingleton<IResourceDefinition<WorkItem, int>, RemoveExtraFromWorkItemDefinition>();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Resources/ReplaceToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Resources/ReplaceToManyRelationshipTests.cs
@@ -22,7 +22,7 @@ public sealed class ReplaceToManyRelationshipTests : IClassFixture<IntegrationTe
         testContext.UseController<WorkItemGroupsController>();
         testContext.UseController<UserAccountsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<ImplicitlyChangingWorkItemDefinition>();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateResourceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateResourceTests.cs
@@ -25,7 +25,7 @@ public sealed class UpdateResourceTests : IClassFixture<IntegrationTestContext<T
         testContext.UseController<UserAccountsController>();
         testContext.UseController<RgbColorsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<ImplicitlyChangingWorkItemDefinition>();
             services.AddResourceDefinition<ImplicitlyChangingWorkItemGroupDefinition>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateToOneRelationshipTests.cs
@@ -22,7 +22,7 @@ public sealed class UpdateToOneRelationshipTests : IClassFixture<IntegrationTest
         testContext.UseController<RgbColorsController>();
         testContext.UseController<UserAccountsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<ImplicitlyChangingWorkItemDefinition>();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceConstructorInjection/ResourceInjectionTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceConstructorInjection/ResourceInjectionTests.cs
@@ -22,7 +22,7 @@ public sealed class ResourceInjectionTests : IClassFixture<IntegrationTestContex
         testContext.UseController<GiftCertificatesController>();
         testContext.UseController<PostOfficesController>();
 
-        testContext.ConfigureServicesBeforeStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddSingleton<ISystemClock, FrozenSystemClock>();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ResourceDefinitionReadTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ResourceDefinitionReadTests.cs
@@ -21,7 +21,7 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
         testContext.UseController<PlanetsController>();
         testContext.UseController<MoonsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<StarDefinition>();
             services.AddResourceDefinition<PlanetDefinition>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/ResourceDefinitionSerializationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/ResourceDefinitionSerializationTests.cs
@@ -22,13 +22,12 @@ public sealed class ResourceDefinitionSerializationTests
         testContext.UseController<StudentsController>();
         testContext.UseController<ScholarshipsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<StudentDefinition>();
 
             services.AddSingleton<IEncryptionService, AesEncryptionService>();
             services.AddSingleton<ResourceDefinitionHitCounter>();
-
             services.AddScoped(typeof(IResourceChangeTracker<>), typeof(NeverSameResourceChangeTracker<>));
         });
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceReadTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceReadTests.cs
@@ -35,7 +35,7 @@ public abstract class ResourceInheritanceReadTests<TDbContext> : IClassFixture<I
         testContext.UseController<ChromeWheelsController>();
         testContext.UseController<CarbonWheelsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddResourceDefinition<WheelSortDefinition>();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceWriteTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceWriteTests.cs
@@ -37,7 +37,7 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
 
         testContext.UseController<VehicleManufacturersController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddSingleton<ResourceTypeCaptureStore<Bike, long>>();
             services.AddResourceDefinition<ResourceTypeCapturingDefinition<Bike, long>>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/DisableQueryStringTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/DisableQueryStringTests.cs
@@ -19,10 +19,10 @@ public sealed class DisableQueryStringTests : IClassFixture<IntegrationTestConte
         testContext.UseController<SofasController>();
         testContext.UseController<PillowsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddScoped<SkipCacheQueryStringParameterReader>();
-            services.AddScoped<IQueryStringParameterReader>(sp => sp.GetRequiredService<SkipCacheQueryStringParameterReader>());
+            services.AddScoped<IQueryStringParameterReader>(provider => provider.GetRequiredService<SkipCacheQueryStringParameterReader>());
         });
     }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/SerializationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/SerializationTests.cs
@@ -23,7 +23,7 @@ public sealed class SerializationTests : IClassFixture<IntegrationTestContext<Te
         testContext.UseController<MeetingAttendeesController>();
         testContext.UseController<MeetingsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
             services.AddScoped(typeof(IResourceChangeTracker<>), typeof(NeverSameResourceChangeTracker<>));
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/SoftDeletion/SoftDeletionTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/SoftDeletion/SoftDeletionTests.cs
@@ -25,15 +25,15 @@ public sealed class SoftDeletionTests : IClassFixture<IntegrationTestContext<Tes
         testContext.UseController<CompaniesController>();
         testContext.UseController<DepartmentsController>();
 
-        testContext.ConfigureServicesAfterStartup(services =>
+        testContext.ConfigureServices(services =>
         {
+            services.AddResourceService<SoftDeletionAwareResourceService<Company, int>>();
+            services.AddResourceService<SoftDeletionAwareResourceService<Department, int>>();
+
             services.AddSingleton<ISystemClock>(new FrozenSystemClock
             {
                 UtcNow = 1.January(2005).AsUtc()
             });
-
-            services.AddResourceService<SoftDeletionAwareResourceService<Company, int>>();
-            services.AddResourceService<SoftDeletionAwareResourceService<Department, int>>();
         });
     }
 

--- a/test/JsonApiDotNetCoreTests/UnitTests/Configuration/ServiceCollectionExtensionsTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Configuration/ServiceCollectionExtensionsTests.cs
@@ -15,12 +15,12 @@ using Microsoft.Extensions.DependencyInjection;
 using TestBuildingBlocks;
 using Xunit;
 
-namespace UnitTests.Extensions;
+namespace JsonApiDotNetCoreTests.UnitTests.Configuration;
 
 public sealed class ServiceCollectionExtensionsTests
 {
     [Fact]
-    public void RegisterResource_DeviatingDbContextPropertyName_RegistersCorrectly()
+    public void Register_resource_from_DbContext_ignores_deviating_DbContext_property_name()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -39,7 +39,7 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddResourceService_Registers_Service_Interfaces_Of_Int32()
+    public void Can_register_resource_service_for_Id_type_Int32()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -63,7 +63,7 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddResourceService_Registers_Service_Interfaces_Of_Guid()
+    public void Can_register_resource_service_for_Id_type_Guid()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -87,7 +87,7 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddResourceService_Throws_If_Type_Does_Not_Implement_Any_Interfaces()
+    public void Cannot_register_resource_service_for_type_that_does_not_implement_required_interfaces()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -101,7 +101,7 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddResourceRepository_Registers_Repository_Interfaces_Of_Int32()
+    public void Can_register_resource_repository_for_Id_type_Int32()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -118,7 +118,7 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddResourceRepository_Registers_Repository_Interfaces_Of_Guid()
+    public void Can_register_resource_repository_for_Id_type_Guid()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -135,7 +135,7 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddResourceDefinition_Registers_Definition_Interface_Of_Int32()
+    public void Can_register_resource_definition_for_Id_type_Int32()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -150,7 +150,7 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddResourceDefinition_Registers_Definition_Interface_Of_Guid()
+    public void Can_register_resource_definition_for_Id_type_Guid()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -162,25 +162,6 @@ public sealed class ServiceCollectionExtensionsTests
         ServiceProvider provider = services.BuildServiceProvider();
 
         provider.GetRequiredService(typeof(IResourceDefinition<ResourceOfGuid, Guid>)).Should().BeOfType<ResourceDefinitionOfGuid>();
-    }
-
-    [Fact]
-    public void AddJsonApi_With_Context_Uses_Resource_Type_Name_If_NoOtherSpecified()
-    {
-        // Arrange
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services.AddDbContext<TestDbContext>(options => options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
-
-        // Act
-        services.AddJsonApi<TestDbContext>();
-
-        // Assert
-        ServiceProvider provider = services.BuildServiceProvider();
-        var resourceGraph = provider.GetRequiredService<IResourceGraph>();
-        ResourceType resourceType = resourceGraph.GetResourceType(typeof(ResourceOfInt32));
-
-        resourceType.PublicName.Should().Be("resourceOfInt32s");
     }
 
     private sealed class ResourceOfInt32 : Identifiable<int>
@@ -594,7 +575,7 @@ public sealed class ServiceCollectionExtensionsTests
     {
         public DbSet<ResourceOfInt32> ResourcesOfInt32 => Set<ResourceOfInt32>();
         public DbSet<ResourceOfGuid> ResourcesOfGuid => Set<ResourceOfGuid>();
-        public DbSet<Person> People => Set<Person>();
+        public DbSet<Person> SetOfPersons => Set<Person>();
 
         public TestDbContext(DbContextOptions<TestDbContext> options)
             : base(options)

--- a/test/TestBuildingBlocks/IntegrationTestContext.cs
+++ b/test/TestBuildingBlocks/IntegrationTestContext.cs
@@ -33,8 +33,7 @@ public class IntegrationTestContext<TStartup, TDbContext> : IntegrationTest
     private readonly Lazy<WebApplicationFactory<TStartup>> _lazyFactory;
     private readonly TestControllerProvider _testControllerProvider = new();
     private Action<ILoggingBuilder>? _loggingConfiguration;
-    private Action<IServiceCollection>? _beforeServicesConfiguration;
-    private Action<IServiceCollection>? _afterServicesConfiguration;
+    private Action<IServiceCollection>? _configureServices;
 
     protected override JsonSerializerOptions SerializerOptions
     {
@@ -74,9 +73,9 @@ public class IntegrationTestContext<TStartup, TDbContext> : IntegrationTest
 
         factory.ConfigureLogging(_loggingConfiguration);
 
-        factory.ConfigureServicesBeforeStartup(services =>
+        factory.ConfigureServices(services =>
         {
-            _beforeServicesConfiguration?.Invoke(services);
+            _configureServices?.Invoke(services);
 
             services.ReplaceControllers(_testControllerProvider);
 
@@ -86,8 +85,6 @@ public class IntegrationTestContext<TStartup, TDbContext> : IntegrationTest
                 SetDbContextDebugOptions(options);
             });
         });
-
-        factory.ConfigureServicesAfterStartup(_afterServicesConfiguration);
 
         // We have placed an appsettings.json in the TestBuildingBlock project folder and set the content root to there. Note that controllers
         // are not discovered in the content root but are registered manually using IntegrationTestContext.UseController.
@@ -114,14 +111,9 @@ public class IntegrationTestContext<TStartup, TDbContext> : IntegrationTest
         _loggingConfiguration = loggingConfiguration;
     }
 
-    public void ConfigureServicesBeforeStartup(Action<IServiceCollection> servicesConfiguration)
+    public void ConfigureServices(Action<IServiceCollection> configureServices)
     {
-        _beforeServicesConfiguration = servicesConfiguration;
-    }
-
-    public void ConfigureServicesAfterStartup(Action<IServiceCollection> servicesConfiguration)
-    {
-        _afterServicesConfiguration = servicesConfiguration;
+        _configureServices = configureServices;
     }
 
     public async Task RunOnDatabaseAsync(Func<TDbContext, Task> asyncAction)
@@ -151,22 +143,16 @@ public class IntegrationTestContext<TStartup, TDbContext> : IntegrationTest
     private sealed class IntegrationTestWebApplicationFactory : WebApplicationFactory<TStartup>
     {
         private Action<ILoggingBuilder>? _loggingConfiguration;
-        private Action<IServiceCollection>? _beforeServicesConfiguration;
-        private Action<IServiceCollection>? _afterServicesConfiguration;
+        private Action<IServiceCollection>? _configureServices;
 
         public void ConfigureLogging(Action<ILoggingBuilder>? loggingConfiguration)
         {
             _loggingConfiguration = loggingConfiguration;
         }
 
-        public void ConfigureServicesBeforeStartup(Action<IServiceCollection>? servicesConfiguration)
+        public void ConfigureServices(Action<IServiceCollection>? configureServices)
         {
-            _beforeServicesConfiguration = servicesConfiguration;
-        }
-
-        public void ConfigureServicesAfterStartup(Action<IServiceCollection>? servicesConfiguration)
-        {
-            _afterServicesConfiguration = servicesConfiguration;
+            _configureServices = configureServices;
         }
 
         protected override IHostBuilder CreateHostBuilder()
@@ -189,15 +175,10 @@ public class IntegrationTestContext<TStartup, TDbContext> : IntegrationTest
                 {
                     webBuilder.ConfigureServices(services =>
                     {
-                        _beforeServicesConfiguration?.Invoke(services);
+                        _configureServices?.Invoke(services);
                     });
 
                     webBuilder.UseStartup<TStartup>();
-
-                    webBuilder.ConfigureServices(services =>
-                    {
-                        _afterServicesConfiguration?.Invoke(services);
-                    });
                 })
                 .ConfigureLogging(options =>
                 {


### PR DESCRIPTION
This PR makes app setup easier. Previously, you often had to register overrides *after* calling `AddJsonApi` (last one wins). With this change, order does not matter anymore. Note that the order of MVC filters still matters, it is unrelated to this change.

Samples have been updated to register _before_ calling `AddJsonApi`, because that works now. And in integration tests, the `ConfigureServicesBeforeStartup`/`ConfigureServicesAfterStartup` methods have been collapsed into one.

Enumerable services are a bit more complicated, so I've added tests for that.

Closes #1347

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [x] Documentation updated
