### PR TITLE
OpenAPI: Auto-generated documentation

### DIFF
--- a/docs/usage/openapi.md
+++ b/docs/usage/openapi.md
@@ -1,6 +1,8 @@
 # OpenAPI
 
-JsonApiDotNetCore provides an extension package that enables you to produce an [OpenAPI specification](https://swagger.io/specification/) for your JSON:API endpoints. This can be used to generate a [documentation website](https://swagger.io/tools/swagger-ui/) or to generate [client libraries](https://openapi-generator.tech/docs/generators/) in various languages. The package provides an integration with [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore).
+JsonApiDotNetCore provides an extension package that enables you to produce an [OpenAPI specification](https://swagger.io/specification/) for your JSON:API endpoints.
+This can be used to generate a [documentation website](https://swagger.io/tools/swagger-ui/) or to generate [client libraries](https://openapi-generator.tech/docs/generators/) in various languages.
+The package provides an integration with [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore).
 
 
 ## Getting started
@@ -35,10 +37,29 @@ By default, the OpenAPI specification will be available at `http://localhost:<po
 
 ## Documentation
 
-Swashbuckle also ships with [SwaggerUI](https://swagger.io/tools/swagger-ui/), which enables to visualize and interact with the API endpoints through a web page. This can be enabled by installing the `Swashbuckle.AspNetCore.SwaggerUI` NuGet package and adding the following to your `Program.cs` file:
+### SwaggerUI
+
+Swashbuckle also ships with [SwaggerUI](https://swagger.io/tools/swagger-ui/), which enables to visualize and interact with the API endpoints through a web page.
+This can be enabled by installing the `Swashbuckle.AspNetCore.SwaggerUI` NuGet package and adding the following to your `Program.cs` file:
 
 ```c#
 app.UseSwaggerUI();
 ```
 
 By default, SwaggerUI will be available at `http://localhost:<port>/swagger`.
+
+### Triple-slash comments
+
+Documentation for JSON:API endpoints is provided out of the box, which shows in SwaggerUI and through IDE IntelliSense in auto-generated clients.
+To also get documentation for your resource classes and their properties, add the following to your project file.
+The `NoWarn` line is optional, which suppresses build warnings for undocumented types and members.
+
+```xml
+  <PropertyGroup>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+```
+
+You can combine this with the documentation that Swagger itself supports, by enabling it as described [here](https://github.com/domaindrivendev/Swashbuckle.AspNetCore#include-descriptions-from-xml-comments).
+This adds documentation for additional types, such as triple-slash comments on enums used in your resource models.

--- a/src/JsonApiDotNetCore.OpenApi/JsonApiOperationIdSelector.cs
+++ b/src/JsonApiDotNetCore.OpenApi/JsonApiOperationIdSelector.cs
@@ -116,7 +116,7 @@ internal sealed class JsonApiOperationIdSelector
         string relationshipName = operationIdTemplate.Contains("[RelationshipName]") ? endpoint.RelativePath.Split("/").Last() : string.Empty;
 
         // @formatter:wrap_chained_method_calls chop_always
-        // @formatter:wrap_before_first_method_call true true
+        // @formatter:wrap_before_first_method_call true
 
         string pascalCaseOperationId = operationIdTemplate
             .Replace("[Method]", method)

--- a/src/JsonApiDotNetCore.OpenApi/ServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore.OpenApi/ServiceCollectionExtensions.cs
@@ -70,6 +70,7 @@ public static class ServiceCollectionExtensions
             SetOperationInfo(swaggerGenOptions, controllerResourceMapping, namingPolicy);
             SetSchemaIdSelector(swaggerGenOptions, resourceGraph, namingPolicy);
             swaggerGenOptions.DocumentFilter<EndpointOrderingFilter>();
+            swaggerGenOptions.OperationFilter<JsonApiOperationDocumentationFilter>();
 
             setupSwaggerGenAction?.Invoke(swaggerGenOptions);
         });

--- a/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/EndpointOrderingFilter.cs
+++ b/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/EndpointOrderingFilter.cs
@@ -16,12 +16,12 @@ internal sealed class EndpointOrderingFilter : IDocumentFilter
         ArgumentGuard.NotNull(swaggerDoc);
         ArgumentGuard.NotNull(context);
 
-        List<KeyValuePair<string, OpenApiPathItem>> orderedEndpoints = swaggerDoc.Paths.OrderBy(GetPrimaryResourcePublicName)
+        List<KeyValuePair<string, OpenApiPathItem>> endpointsInOrder = swaggerDoc.Paths.OrderBy(GetPrimaryResourcePublicName)
             .ThenBy(GetRelationshipName).ThenBy(IsSecondaryEndpoint).ToList();
 
         swaggerDoc.Paths.Clear();
 
-        foreach ((string url, OpenApiPathItem path) in orderedEndpoints)
+        foreach ((string url, OpenApiPathItem path) in endpointsInOrder)
         {
             swaggerDoc.Paths.Add(url, path);
         }

--- a/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/JsonApiOperationDocumentationFilter.cs
+++ b/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/JsonApiOperationDocumentationFilter.cs
@@ -1,0 +1,397 @@
+using System.Net;
+using Humanizer;
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Middleware;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace JsonApiDotNetCore.OpenApi.SwaggerComponents;
+
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+internal sealed class JsonApiOperationDocumentationFilter : IOperationFilter
+{
+    private const string GetPrimaryName = nameof(BaseJsonApiController<Identifiable<int>, int>.GetAsync);
+    private const string GetSecondaryName = nameof(BaseJsonApiController<Identifiable<int>, int>.GetSecondaryAsync);
+    private const string GetRelationshipName = nameof(BaseJsonApiController<Identifiable<int>, int>.GetRelationshipAsync);
+    private const string PostResourceName = nameof(BaseJsonApiController<Identifiable<int>, int>.PostAsync);
+    private const string PostRelationshipName = nameof(BaseJsonApiController<Identifiable<int>, int>.PostRelationshipAsync);
+    private const string PatchResourceName = nameof(BaseJsonApiController<Identifiable<int>, int>.PatchAsync);
+    private const string PatchRelationshipName = nameof(BaseJsonApiController<Identifiable<int>, int>.PatchRelationshipAsync);
+    private const string DeleteResourceName = nameof(BaseJsonApiController<Identifiable<int>, int>.DeleteAsync);
+    private const string DeleteRelationshipName = nameof(BaseJsonApiController<Identifiable<int>, int>.DeleteRelationshipAsync);
+
+    private const string TextCompareETag =
+        "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.";
+
+    private const string TextCompletedSuccessfully = "The operation completed successfully.";
+    private const string TextRequestBodyMissingOrMalformed = "The request body is missing or malformed.";
+    private const string TextRequestBodyIncompatibleType = "A resource type in the request body is incompatible.";
+    private const string TextRequestBodyIncompatibleIdOrType = "A resource type or identifier in the request body is incompatible.";
+    private const string TextRequestBodyValidationFailed = "Validation of the request body failed.";
+
+    private readonly IControllerResourceMapping _controllerResourceMapping;
+    private readonly ResourceFieldValidationMetadataProvider _resourceFieldValidationMetadataProvider;
+
+    public JsonApiOperationDocumentationFilter(IControllerResourceMapping controllerResourceMapping,
+        ResourceFieldValidationMetadataProvider resourceFieldValidationMetadataProvider)
+    {
+        ArgumentGuard.NotNull(controllerResourceMapping);
+        ArgumentGuard.NotNull(resourceFieldValidationMetadataProvider);
+
+        _controllerResourceMapping = controllerResourceMapping;
+        _resourceFieldValidationMetadataProvider = resourceFieldValidationMetadataProvider;
+    }
+
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        ArgumentGuard.NotNull(operation);
+        ArgumentGuard.NotNull(context);
+
+        bool hasHeadVerb = context.ApiDescription.HttpMethod == "HEAD";
+
+        if (hasHeadVerb)
+        {
+            operation.Responses.Clear();
+        }
+
+        ResourceType? resourceType =
+            _controllerResourceMapping.GetResourceTypeForController(context.ApiDescription.ActionDescriptor.GetActionMethod().ReflectedType);
+
+        if (resourceType != null)
+        {
+            string actionName = context.MethodInfo.Name;
+
+            switch (actionName)
+            {
+                case GetPrimaryName or PostResourceName or PatchResourceName or DeleteResourceName:
+                {
+                    switch (actionName)
+                    {
+                        case GetPrimaryName:
+                        {
+                            ApplyGetPrimary(operation, resourceType, hasHeadVerb);
+                            break;
+                        }
+                        case PostResourceName:
+                        {
+                            ApplyPostResource(operation, resourceType);
+                            break;
+                        }
+                        case PatchResourceName:
+                        {
+                            ApplyPatchResource(operation, resourceType);
+                            break;
+                        }
+                        case DeleteResourceName:
+                        {
+                            ApplyDeleteResource(operation, resourceType);
+                            break;
+                        }
+                    }
+
+                    break;
+                }
+                case GetSecondaryName or GetRelationshipName or PostRelationshipName or PatchRelationshipName or DeleteRelationshipName:
+                {
+                    RelationshipAttribute relationship = GetRelationshipFromRoute(context.ApiDescription, resourceType);
+
+                    switch (actionName)
+                    {
+                        case GetSecondaryName:
+                        {
+                            ApplyGetSecondary(operation, relationship, hasHeadVerb);
+                            break;
+                        }
+                        case GetRelationshipName:
+                        {
+                            ApplyGetRelationship(operation, relationship, hasHeadVerb);
+                            break;
+                        }
+                        case PostRelationshipName:
+                        {
+                            ApplyPostRelationship(operation, relationship);
+                            break;
+                        }
+                        case PatchRelationshipName:
+                        {
+                            ApplyPatchRelationship(operation, relationship);
+                            break;
+                        }
+                        case DeleteRelationshipName:
+                        {
+                            ApplyDeleteRelationship(operation, relationship);
+                            break;
+                        }
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+
+    private static void ApplyGetPrimary(OpenApiOperation operation, ResourceType resourceType, bool hasHeadVerb)
+    {
+        if (operation.Parameters.Count == 0)
+        {
+            if (hasHeadVerb)
+            {
+                SetOperationSummary(operation, $"Retrieves a collection of {resourceType} without returning them.");
+                SetOperationRemarks(operation, TextCompareETag);
+                SetResponseDescription(operation.Responses, HttpStatusCode.OK, TextCompletedSuccessfully);
+            }
+            else
+            {
+                SetOperationSummary(operation, $"Retrieves a collection of {resourceType}.");
+
+                SetResponseDescription(operation.Responses, HttpStatusCode.OK,
+                    $"Successfully returns the found {resourceType}, or an empty array if none were found.");
+            }
+        }
+        else if (operation.Parameters.Count == 1)
+        {
+            string singularName = resourceType.PublicName.Singularize();
+
+            if (hasHeadVerb)
+            {
+                SetOperationSummary(operation, $"Retrieves an individual {singularName} by its identifier without returning it.");
+                SetOperationRemarks(operation, TextCompareETag);
+                SetResponseDescription(operation.Responses, HttpStatusCode.OK, TextCompletedSuccessfully);
+            }
+            else
+            {
+                SetOperationSummary(operation, $"Retrieves an individual {singularName} by its identifier.");
+                SetResponseDescription(operation.Responses, HttpStatusCode.OK, $"Successfully returns the found {singularName}.");
+            }
+
+            SetParameterDescription(operation.Parameters[0], $"The identifier of the {singularName} to retrieve.");
+            SetResponseDescription(operation.Responses, HttpStatusCode.NotFound, $"The {singularName} does not exist.");
+        }
+    }
+
+    private void ApplyPostResource(OpenApiOperation operation, ResourceType resourceType)
+    {
+        string singularName = resourceType.PublicName.Singularize();
+
+        SetOperationSummary(operation, $"Creates a new {singularName}.");
+        SetRequestBodyDescription(operation.RequestBody, $"The attributes and relationships of the {singularName} to create.");
+
+        SetResponseDescription(operation.Responses, HttpStatusCode.Created,
+            $"The {singularName} was successfully created, which resulted in additional changes. The newly created {singularName} is returned.");
+
+        SetResponseDescription(operation.Responses, HttpStatusCode.NoContent,
+            $"The {singularName} was successfully created, which did not result in additional changes.");
+
+        SetResponseDescription(operation.Responses, HttpStatusCode.BadRequest, TextRequestBodyMissingOrMalformed);
+        SetResponseDescription(operation.Responses, HttpStatusCode.Conflict, TextRequestBodyIncompatibleType);
+        SetResponseDescription(operation.Responses, HttpStatusCode.UnprocessableEntity, TextRequestBodyValidationFailed);
+    }
+
+    private void ApplyPatchResource(OpenApiOperation operation, ResourceType resourceType)
+    {
+        string singularName = resourceType.PublicName.Singularize();
+
+        SetOperationSummary(operation, $"Updates an existing {singularName}.");
+        SetParameterDescription(operation.Parameters[0], $"The identifier of the {singularName} to update.");
+
+        SetRequestBodyDescription(operation.RequestBody,
+            $"The attributes and relationships of the {singularName} to update. Omitted fields are left unchanged.");
+
+        SetResponseDescription(operation.Responses, HttpStatusCode.OK,
+            $"The {singularName} was successfully updated, which resulted in additional changes. The updated {singularName} is returned.");
+
+        SetResponseDescription(operation.Responses, HttpStatusCode.NoContent,
+            $"The {singularName} was successfully updated, which did not result in additional changes.");
+
+        SetResponseDescription(operation.Responses, HttpStatusCode.NotFound, $"The {singularName} or a related resource does not exist.");
+        SetResponseDescription(operation.Responses, HttpStatusCode.BadRequest, TextRequestBodyMissingOrMalformed);
+        SetResponseDescription(operation.Responses, HttpStatusCode.Conflict, TextRequestBodyIncompatibleIdOrType);
+        SetResponseDescription(operation.Responses, HttpStatusCode.UnprocessableEntity, TextRequestBodyValidationFailed);
+    }
+
+    private void ApplyDeleteResource(OpenApiOperation operation, ResourceType resourceType)
+    {
+        string singularName = resourceType.PublicName.Singularize();
+
+        SetOperationSummary(operation, $"Deletes an existing {singularName} by its identifier.");
+        SetParameterDescription(operation.Parameters[0], $"The identifier of the {singularName} to delete.");
+        SetResponseDescription(operation.Responses, HttpStatusCode.NoContent, $"The {singularName} was successfully deleted.");
+        SetResponseDescription(operation.Responses, HttpStatusCode.NotFound, $"The {singularName} does not exist.");
+    }
+
+    private static void ApplyGetSecondary(OpenApiOperation operation, RelationshipAttribute relationship, bool hasHeadVerb)
+    {
+        string singularLeftName = relationship.LeftType.PublicName.Singularize();
+        string rightName = relationship is HasOneAttribute ? relationship.RightType.PublicName.Singularize() : relationship.RightType.PublicName;
+
+        if (hasHeadVerb)
+        {
+            SetOperationSummary(operation,
+                relationship is HasOneAttribute
+                    ? $"Retrieves the related {rightName} of an individual {singularLeftName}'s {relationship} relationship without returning it."
+                    : $"Retrieves the related {rightName} of an individual {singularLeftName}'s {relationship} relationship without returning them.");
+
+            SetOperationRemarks(operation, TextCompareETag);
+            SetResponseDescription(operation.Responses, HttpStatusCode.OK, TextCompletedSuccessfully);
+        }
+        else
+        {
+            SetOperationSummary(operation, $"Retrieves the related {rightName} of an individual {singularLeftName}'s {relationship} relationship.");
+
+            SetResponseDescription(operation.Responses, HttpStatusCode.OK,
+                relationship is HasOneAttribute
+                    ? $"Successfully returns the found {rightName}, or <c>null</c> if it was not found."
+                    : $"Successfully returns the found {rightName}, or an empty array if none were found.");
+        }
+
+        SetParameterDescription(operation.Parameters[0], $"The identifier of the {singularLeftName} whose related {rightName} to retrieve.");
+        SetResponseDescription(operation.Responses, HttpStatusCode.NotFound, $"The {singularLeftName} does not exist.");
+    }
+
+    private static void ApplyGetRelationship(OpenApiOperation operation, RelationshipAttribute relationship, bool hasHeadVerb)
+    {
+        string singularLeftName = relationship.LeftType.PublicName.Singularize();
+        string singularRightName = relationship.RightType.PublicName.Singularize();
+        string ident = relationship is HasOneAttribute ? "identity" : "identities";
+
+        if (hasHeadVerb)
+        {
+            SetOperationSummary(operation,
+                relationship is HasOneAttribute
+                    ? $"Retrieves the related {singularRightName} {ident} of an individual {singularLeftName}'s {relationship} relationship without returning it."
+                    : $"Retrieves the related {singularRightName} {ident} of an individual {singularLeftName}'s {relationship} relationship without returning them.");
+
+            SetOperationRemarks(operation, TextCompareETag);
+            SetResponseDescription(operation.Responses, HttpStatusCode.OK, TextCompletedSuccessfully);
+        }
+        else
+        {
+            SetOperationSummary(operation,
+                $"Retrieves the related {singularRightName} {ident} of an individual {singularLeftName}'s {relationship} relationship.");
+
+            SetResponseDescription(operation.Responses, HttpStatusCode.OK,
+                relationship is HasOneAttribute
+                    ? $"Successfully returns the found {singularRightName} {ident}, or <c>null</c> if it was not found."
+                    : $"Successfully returns the found {singularRightName} {ident}, or an empty array if none were found.");
+        }
+
+        SetParameterDescription(operation.Parameters[0], $"The identifier of the {singularLeftName} whose related {singularRightName} {ident} to retrieve.");
+        SetResponseDescription(operation.Responses, HttpStatusCode.NotFound, $"The {singularLeftName} does not exist.");
+    }
+
+    private void ApplyPostRelationship(OpenApiOperation operation, RelationshipAttribute relationship)
+    {
+        string singularLeftName = relationship.LeftType.PublicName.Singularize();
+        string rightName = relationship.RightType.PublicName;
+
+        SetOperationSummary(operation, $"Adds existing {rightName} to the {relationship} relationship of an individual {singularLeftName}.");
+        SetParameterDescription(operation.Parameters[0], $"The identifier of the {singularLeftName} to add {rightName} to.");
+        SetRequestBodyDescription(operation.RequestBody, $"The identities of the {rightName} to add to the {relationship} relationship.");
+
+        SetResponseDescription(operation.Responses, HttpStatusCode.NoContent,
+            $"The {rightName} were successfully added, which did not result in additional changes.");
+
+        SetResponseDescription(operation.Responses, HttpStatusCode.NotFound, $"The {singularLeftName} does not exist.");
+        SetResponseDescription(operation.Responses, HttpStatusCode.BadRequest, TextRequestBodyMissingOrMalformed);
+        SetResponseDescription(operation.Responses, HttpStatusCode.Conflict, TextRequestBodyIncompatibleType);
+    }
+
+    private void ApplyPatchRelationship(OpenApiOperation operation, RelationshipAttribute relationship)
+    {
+        bool isOptional = _resourceFieldValidationMetadataProvider.IsNullable(relationship);
+        string singularLeftName = relationship.LeftType.PublicName.Singularize();
+        string rightName = relationship is HasOneAttribute ? relationship.RightType.PublicName.Singularize() : relationship.RightType.PublicName;
+
+        SetOperationSummary(operation,
+            relationship is HasOneAttribute
+                ? isOptional
+                    ? $"Clears or assigns an existing {rightName} to the {relationship} relationship of an individual {singularLeftName}."
+                    : $"Assigns an existing {rightName} to the {relationship} relationship of an individual {singularLeftName}."
+                : $"Assigns existing {rightName} to the {relationship} relationship of an individual {singularLeftName}.");
+
+        SetParameterDescription(operation.Parameters[0],
+            isOptional
+                ? $"The identifier of the {singularLeftName} whose {relationship} relationship to assign or clear."
+                : $"The identifier of the {singularLeftName} whose {relationship} relationship to assign.");
+
+        SetRequestBodyDescription(operation.RequestBody,
+            relationship is HasOneAttribute
+                ? isOptional
+                    ? $"The identity of the {rightName} to assign to the {relationship} relationship, or <c>null</c> to clear the relationship."
+                    : $"The identity of the {rightName} to assign to the {relationship} relationship."
+                : $"The identities of the {rightName} to assign to the {relationship} relationship, or an empty array to clear the relationship.");
+
+        SetResponseDescription(operation.Responses, HttpStatusCode.NoContent,
+            $"The {relationship} relationship was successfully updated, which did not result in additional changes.");
+
+        SetResponseDescription(operation.Responses, HttpStatusCode.NotFound, $"The {singularLeftName} does not exist.");
+        SetResponseDescription(operation.Responses, HttpStatusCode.BadRequest, TextRequestBodyMissingOrMalformed);
+        SetResponseDescription(operation.Responses, HttpStatusCode.Conflict, TextRequestBodyIncompatibleType);
+    }
+
+    private void ApplyDeleteRelationship(OpenApiOperation operation, RelationshipAttribute relationship)
+    {
+        string singularLeftName = relationship.LeftType.PublicName.Singularize();
+        string rightName = relationship.RightType.PublicName;
+
+        SetOperationSummary(operation, $"Removes existing {rightName} from the {relationship} relationship of an individual {singularLeftName}.");
+        SetParameterDescription(operation.Parameters[0], $"The identifier of the {singularLeftName} to remove {rightName} from.");
+        SetRequestBodyDescription(operation.RequestBody, $"The identities of the {rightName} to remove from the {relationship} relationship.");
+
+        SetResponseDescription(operation.Responses, HttpStatusCode.NoContent,
+            $"The {rightName} were successfully removed, which did not result in additional changes.");
+
+        SetResponseDescription(operation.Responses, HttpStatusCode.NotFound, $"The {singularLeftName} does not exist.");
+        SetResponseDescription(operation.Responses, HttpStatusCode.BadRequest, TextRequestBodyMissingOrMalformed);
+        SetResponseDescription(operation.Responses, HttpStatusCode.Conflict, TextRequestBodyIncompatibleType);
+    }
+
+    private static RelationshipAttribute GetRelationshipFromRoute(ApiDescription apiDescription, ResourceType resourceType)
+    {
+        if (apiDescription.RelativePath == null)
+        {
+            throw new UnreachableCodeException();
+        }
+
+        string relationshipName = apiDescription.RelativePath.Split('/').Last();
+        return resourceType.GetRelationshipByPublicName(relationshipName);
+    }
+
+    private static void SetOperationSummary(OpenApiOperation operation, string description)
+    {
+        operation.Summary = XmlCommentsTextHelper.Humanize(description);
+    }
+
+    private static void SetOperationRemarks(OpenApiOperation operation, string description)
+    {
+        operation.Description = XmlCommentsTextHelper.Humanize(description);
+    }
+
+    private static void SetParameterDescription(OpenApiParameter parameter, string description)
+    {
+        parameter.Description = XmlCommentsTextHelper.Humanize(description);
+    }
+
+    private static void SetRequestBodyDescription(OpenApiRequestBody requestBody, string description)
+    {
+        requestBody.Description = XmlCommentsTextHelper.Humanize(description);
+    }
+
+    private static void SetResponseDescription(OpenApiResponses responses, HttpStatusCode statusCode, string description)
+    {
+        string responseCode = ((int)statusCode).ToString();
+
+        if (!responses.TryGetValue(responseCode, out OpenApiResponse? response))
+        {
+            response = new OpenApiResponse();
+            responses.Add(responseCode, response);
+        }
+
+        response.Description = XmlCommentsTextHelper.Humanize(description);
+    }
+}

--- a/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/ResourceObjectDocumentationReader.cs
+++ b/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/ResourceObjectDocumentationReader.cs
@@ -1,0 +1,87 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Xml.XPath;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Resources.Annotations;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace JsonApiDotNetCore.OpenApi.SwaggerComponents;
+
+internal sealed class ResourceObjectDocumentationReader
+{
+    private static readonly ConcurrentDictionary<string, XPathNavigator?> NavigatorsByAssemblyPath = new();
+
+    public string? GetDocumentationForType(ResourceType resourceType)
+    {
+        ArgumentGuard.NotNull(resourceType);
+
+        XPathNavigator? navigator = GetNavigator(resourceType.ClrType.Assembly);
+
+        if (navigator != null)
+        {
+            string typeMemberName = XmlCommentsNodeNameHelper.GetMemberNameForType(resourceType.ClrType);
+            return GetSummary(navigator, typeMemberName);
+        }
+
+        return null;
+    }
+
+    public string? GetDocumentationForAttribute(AttrAttribute attribute)
+    {
+        ArgumentGuard.NotNull(attribute);
+
+        XPathNavigator? navigator = GetNavigator(attribute.Type.ClrType.Assembly);
+
+        if (navigator != null)
+        {
+            string propertyMemberName = XmlCommentsNodeNameHelper.GetMemberNameForFieldOrProperty(attribute.Property);
+            return GetSummary(navigator, propertyMemberName);
+        }
+
+        return null;
+    }
+
+    public string? GetDocumentationForRelationship(RelationshipAttribute relationship)
+    {
+        ArgumentGuard.NotNull(relationship);
+
+        XPathNavigator? navigator = GetNavigator(relationship.Type.ClrType.Assembly);
+
+        if (navigator != null)
+        {
+            string propertyMemberName = XmlCommentsNodeNameHelper.GetMemberNameForFieldOrProperty(relationship.Property);
+            return GetSummary(navigator, propertyMemberName);
+        }
+
+        return null;
+    }
+
+    private static XPathNavigator? GetNavigator(Assembly assembly)
+    {
+        string assemblyPath = assembly.Location;
+
+        if (!string.IsNullOrEmpty(assemblyPath))
+        {
+            return NavigatorsByAssemblyPath.GetOrAdd(assemblyPath, path =>
+            {
+                string documentationPath = Path.ChangeExtension(path, ".xml");
+
+                if (File.Exists(documentationPath))
+                {
+                    var document = new XPathDocument(documentationPath);
+                    return document.CreateNavigator();
+                }
+
+                return null;
+            });
+        }
+
+        return null;
+    }
+
+    private string? GetSummary(XPathNavigator navigator, string memberName)
+    {
+        XPathNavigator? summaryNode = navigator.SelectSingleNode($"/doc/members/member[@name='{memberName}']/summary");
+        return summaryNode != null ? XmlCommentsTextHelper.Humanize(summaryNode.InnerXml) : null;
+    }
+}

--- a/test/OpenApiClientTests/LegacyClient/swagger.g.json
+++ b/test/OpenApiClientTests/LegacyClient/swagger.g.json
@@ -10,10 +10,11 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves a collection of airplanes.",
         "operationId": "get-airplane-collection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found airplanes, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -28,17 +29,12 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves a collection of airplanes without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-airplane-collection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/airplane-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -46,8 +42,10 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Creates a new airplane.",
         "operationId": "post-airplane",
         "requestBody": {
+          "description": "The attributes and relationships of the airplane to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -58,7 +56,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The airplane was successfully created, which resulted in additional changes. The newly created airplane is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -68,7 +66,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The airplane was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -78,11 +85,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves an individual airplane by its identifier.",
         "operationId": "get-airplane",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -91,7 +100,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found airplane.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -99,6 +108,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       },
@@ -106,11 +118,14 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves an individual airplane by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-airplane",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -119,14 +134,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/airplane-primary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       },
@@ -134,11 +145,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Updates an existing airplane.",
         "operationId": "patch-airplane",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane to update.",
             "required": true,
             "schema": {
               "type": "string"
@@ -146,6 +159,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the airplane to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -156,7 +170,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The airplane was successfully updated, which resulted in additional changes. The updated airplane is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -166,7 +180,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The airplane was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The airplane or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -174,11 +200,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Deletes an existing airplane by its identifier.",
         "operationId": "delete-airplane",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane to delete.",
             "required": true,
             "schema": {
               "type": "string"
@@ -187,7 +215,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The airplane was successfully deleted."
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       }
@@ -197,11 +228,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves the related flights of an individual airplane's flights relationship.",
         "operationId": "get-airplane-flights",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane whose related flights to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -210,7 +243,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flights, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -218,6 +251,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       },
@@ -225,11 +261,14 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves the related flights of an individual airplane's flights relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-airplane-flights",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane whose related flights to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -238,14 +277,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       }
@@ -255,11 +290,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves the related flight identities of an individual airplane's flights relationship.",
         "operationId": "get-airplane-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane whose related flight identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -268,7 +305,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -276,6 +313,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       },
@@ -283,11 +323,14 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves the related flight identities of an individual airplane's flights relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-airplane-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane whose related flight identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -296,14 +339,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-identifier-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       },
@@ -311,11 +350,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Adds existing flights to the flights relationship of an individual airplane.",
         "operationId": "post-airplane-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane to add flights to.",
             "required": true,
             "schema": {
               "type": "string"
@@ -323,6 +364,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to add to the flights relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -333,7 +375,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The airplane does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -341,11 +392,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Assigns existing flights to the flights relationship of an individual airplane.",
         "operationId": "patch-airplane-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane whose flights relationship to assign.",
             "required": true,
             "schema": {
               "type": "string"
@@ -353,6 +406,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to assign to the flights relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -363,7 +417,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The airplane does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -371,11 +434,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Removes existing flights from the flights relationship of an individual airplane.",
         "operationId": "delete-airplane-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane to remove flights from.",
             "required": true,
             "schema": {
               "type": "string"
@@ -383,6 +448,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to remove from the flights relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -393,7 +459,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The airplane does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -403,10 +478,11 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves a collection of flight-attendants.",
         "operationId": "get-flight-attendant-collection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendants, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -421,17 +497,12 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves a collection of flight-attendants without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-attendant-collection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-attendant-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -439,8 +510,10 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Creates a new flight-attendant.",
         "operationId": "post-flight-attendant",
         "requestBody": {
+          "description": "The attributes and relationships of the flight-attendant to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -451,7 +524,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The flight-attendant was successfully created, which resulted in additional changes. The newly created flight-attendant is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -461,7 +534,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The flight-attendant was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -471,11 +553,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves an individual flight-attendant by its identifier.",
         "operationId": "get-flight-attendant",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -484,7 +568,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendant.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -492,6 +576,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -499,11 +586,14 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves an individual flight-attendant by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-attendant",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -512,14 +602,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-attendant-primary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -527,11 +613,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Updates an existing flight-attendant.",
         "operationId": "patch-flight-attendant",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to update.",
             "required": true,
             "schema": {
               "type": "string"
@@ -539,6 +627,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the flight-attendant to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -549,7 +638,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The flight-attendant was successfully updated, which resulted in additional changes. The updated flight-attendant is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -559,7 +648,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The flight-attendant was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -567,11 +668,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Deletes an existing flight-attendant by its identifier.",
         "operationId": "delete-flight-attendant",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to delete.",
             "required": true,
             "schema": {
               "type": "string"
@@ -580,7 +683,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flight-attendant was successfully deleted."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       }
@@ -590,11 +696,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flights of an individual flight-attendant's purser-on-flights relationship.",
         "operationId": "get-flight-attendant-purser-on-flights",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flights to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -603,7 +711,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flights, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -611,6 +719,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -618,11 +729,14 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flights of an individual flight-attendant's purser-on-flights relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-attendant-purser-on-flights",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flights to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -631,14 +745,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       }
@@ -648,11 +758,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flight identities of an individual flight-attendant's purser-on-flights relationship.",
         "operationId": "get-flight-attendant-purser-on-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flight identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -661,7 +773,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -669,6 +781,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -676,11 +791,14 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flight identities of an individual flight-attendant's purser-on-flights relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-attendant-purser-on-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flight identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -689,14 +807,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-identifier-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -704,11 +818,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Adds existing flights to the purser-on-flights relationship of an individual flight-attendant.",
         "operationId": "post-flight-attendant-purser-on-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to add flights to.",
             "required": true,
             "schema": {
               "type": "string"
@@ -716,6 +832,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to add to the purser-on-flights relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -726,7 +843,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -734,11 +860,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Assigns existing flights to the purser-on-flights relationship of an individual flight-attendant.",
         "operationId": "patch-flight-attendant-purser-on-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose purser-on-flights relationship to assign.",
             "required": true,
             "schema": {
               "type": "string"
@@ -746,6 +874,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to assign to the purser-on-flights relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -756,7 +885,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The purser-on-flights relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -764,11 +902,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Removes existing flights from the purser-on-flights relationship of an individual flight-attendant.",
         "operationId": "delete-flight-attendant-purser-on-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to remove flights from.",
             "required": true,
             "schema": {
               "type": "string"
@@ -776,6 +916,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to remove from the purser-on-flights relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -786,7 +927,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -796,11 +946,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flights of an individual flight-attendant's scheduled-for-flights relationship.",
         "operationId": "get-flight-attendant-scheduled-for-flights",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flights to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -809,7 +961,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flights, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -817,6 +969,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -824,11 +979,14 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flights of an individual flight-attendant's scheduled-for-flights relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-attendant-scheduled-for-flights",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flights to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -837,14 +995,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       }
@@ -854,11 +1008,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flight identities of an individual flight-attendant's scheduled-for-flights relationship.",
         "operationId": "get-flight-attendant-scheduled-for-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flight identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -867,7 +1023,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -875,6 +1031,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -882,11 +1041,14 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flight identities of an individual flight-attendant's scheduled-for-flights relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-attendant-scheduled-for-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flight identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -895,14 +1057,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-identifier-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -910,11 +1068,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Adds existing flights to the scheduled-for-flights relationship of an individual flight-attendant.",
         "operationId": "post-flight-attendant-scheduled-for-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to add flights to.",
             "required": true,
             "schema": {
               "type": "string"
@@ -922,6 +1082,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to add to the scheduled-for-flights relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -932,7 +1093,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -940,11 +1110,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Assigns existing flights to the scheduled-for-flights relationship of an individual flight-attendant.",
         "operationId": "patch-flight-attendant-scheduled-for-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose scheduled-for-flights relationship to assign.",
             "required": true,
             "schema": {
               "type": "string"
@@ -952,6 +1124,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to assign to the scheduled-for-flights relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -962,7 +1135,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The scheduled-for-flights relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -970,11 +1152,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Removes existing flights from the scheduled-for-flights relationship of an individual flight-attendant.",
         "operationId": "delete-flight-attendant-scheduled-for-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to remove flights from.",
             "required": true,
             "schema": {
               "type": "string"
@@ -982,6 +1166,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to remove from the scheduled-for-flights relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -992,7 +1177,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -1002,10 +1196,11 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves a collection of flights.",
         "operationId": "get-flight-collection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flights, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1020,17 +1215,12 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves a collection of flights without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-collection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -1038,8 +1228,10 @@
         "tags": [
           "flights"
         ],
+        "summary": "Creates a new flight.",
         "operationId": "post-flight",
         "requestBody": {
+          "description": "The attributes and relationships of the flight to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1050,7 +1242,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The flight was successfully created, which resulted in additional changes. The newly created flight is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1060,7 +1252,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The flight was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -1070,11 +1271,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves an individual flight by its identifier.",
         "operationId": "get-flight",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1083,7 +1286,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1091,6 +1294,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1098,11 +1304,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves an individual flight by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1111,14 +1320,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-primary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1126,11 +1331,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Updates an existing flight.",
         "operationId": "patch-flight",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to update.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1138,6 +1345,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the flight to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1148,7 +1356,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The flight was successfully updated, which resulted in additional changes. The updated flight is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1158,7 +1366,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The flight was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -1166,11 +1386,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Deletes an existing flight by its identifier.",
         "operationId": "delete-flight",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to delete.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1179,7 +1401,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flight was successfully deleted."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       }
@@ -1189,11 +1414,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant of an individual flight's backup-purser relationship.",
         "operationId": "get-flight-backup-purser",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1202,7 +1429,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendant, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1210,6 +1437,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1217,11 +1447,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant of an individual flight's backup-purser relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-backup-purser",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1230,14 +1463,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullable-flight-attendant-secondary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       }
@@ -1247,11 +1476,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant identity of an individual flight's backup-purser relationship.",
         "operationId": "get-flight-backup-purser-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant identity to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1260,7 +1491,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendant identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1268,6 +1499,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1275,11 +1509,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant identity of an individual flight's backup-purser relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-backup-purser-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant identity to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1288,14 +1525,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullable-flight-attendant-identifier-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1303,11 +1536,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Clears or assigns an existing flight-attendant to the backup-purser relationship of an individual flight.",
         "operationId": "patch-flight-backup-purser-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose backup-purser relationship to assign or clear.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1315,6 +1550,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the flight-attendant to assign to the backup-purser relationship, or `null` to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1325,7 +1561,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The backup-purser relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -1335,11 +1580,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendants of an individual flight's cabin-crew-members relationship.",
         "operationId": "get-flight-cabin-crew-members",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendants to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1348,7 +1595,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendants, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1356,6 +1603,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1363,11 +1613,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendants of an individual flight's cabin-crew-members relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-cabin-crew-members",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendants to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1376,14 +1629,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-attendant-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       }
@@ -1393,11 +1642,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant identities of an individual flight's cabin-crew-members relationship.",
         "operationId": "get-flight-cabin-crew-members-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1406,7 +1657,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendant identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1414,6 +1665,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1421,11 +1675,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant identities of an individual flight's cabin-crew-members relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-cabin-crew-members-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1434,14 +1691,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-attendant-identifier-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1449,11 +1702,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Adds existing flight-attendants to the cabin-crew-members relationship of an individual flight.",
         "operationId": "post-flight-cabin-crew-members-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to add flight-attendants to.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1461,6 +1716,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flight-attendants to add to the cabin-crew-members relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1471,7 +1727,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flight-attendants were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -1479,11 +1744,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Assigns existing flight-attendants to the cabin-crew-members relationship of an individual flight.",
         "operationId": "patch-flight-cabin-crew-members-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose cabin-crew-members relationship to assign.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1491,6 +1758,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flight-attendants to assign to the cabin-crew-members relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1501,7 +1769,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The cabin-crew-members relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -1509,11 +1786,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Removes existing flight-attendants from the cabin-crew-members relationship of an individual flight.",
         "operationId": "delete-flight-cabin-crew-members-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to remove flight-attendants from.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1521,6 +1800,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flight-attendants to remove from the cabin-crew-members relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1531,7 +1811,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flight-attendants were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -1541,11 +1830,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related passengers of an individual flight's passengers relationship.",
         "operationId": "get-flight-passengers",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related passengers to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1554,7 +1845,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found passengers, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1562,6 +1853,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1569,11 +1863,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related passengers of an individual flight's passengers relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-passengers",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related passengers to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1582,14 +1879,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/passenger-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       }
@@ -1599,11 +1892,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related passenger identities of an individual flight's passengers relationship.",
         "operationId": "get-flight-passengers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related passenger identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1612,7 +1907,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found passenger identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1620,6 +1915,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1627,11 +1925,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related passenger identities of an individual flight's passengers relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-passengers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related passenger identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1640,14 +1941,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/passenger-identifier-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1655,11 +1952,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Adds existing passengers to the passengers relationship of an individual flight.",
         "operationId": "post-flight-passengers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to add passengers to.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1667,6 +1966,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the passengers to add to the passengers relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1677,7 +1977,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The passengers were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -1685,11 +1994,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Assigns existing passengers to the passengers relationship of an individual flight.",
         "operationId": "patch-flight-passengers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose passengers relationship to assign.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1697,6 +2008,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the passengers to assign to the passengers relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1707,7 +2019,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The passengers relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -1715,11 +2036,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Removes existing passengers from the passengers relationship of an individual flight.",
         "operationId": "delete-flight-passengers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to remove passengers from.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1727,6 +2050,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the passengers to remove from the passengers relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1737,7 +2061,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The passengers were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -1747,11 +2080,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant of an individual flight's purser relationship.",
         "operationId": "get-flight-purser",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1760,7 +2095,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendant, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1768,6 +2103,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1775,11 +2113,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant of an individual flight's purser relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-purser",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1788,14 +2129,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-attendant-secondary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       }
@@ -1805,11 +2142,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant identity of an individual flight's purser relationship.",
         "operationId": "get-flight-purser-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant identity to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1818,7 +2157,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendant identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1826,6 +2165,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1833,11 +2175,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant identity of an individual flight's purser relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-purser-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant identity to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1846,14 +2191,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-attendant-identifier-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1861,11 +2202,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Assigns an existing flight-attendant to the purser relationship of an individual flight.",
         "operationId": "patch-flight-purser-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose purser relationship to assign.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1873,6 +2216,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the flight-attendant to assign to the purser relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1883,7 +2227,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The purser relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }

--- a/test/OpenApiClientTests/LegacyClient/swagger.g.json
+++ b/test/OpenApiClientTests/LegacyClient/swagger.g.json
@@ -2259,7 +2259,8 @@
           "LufthansaGroup",
           "AirFranceKlm"
         ],
-        "type": "string"
+        "type": "string",
+        "description": "Lists the various airlines used in this API."
       },
       "airplane-attributes-in-patch-request": {
         "type": "object",
@@ -2349,6 +2350,7 @@
           },
           "manufactured-at": {
             "type": "string",
+            "description": "Gets the day on which this airplane was manufactured.",
             "format": "date-time"
           },
           "is-in-maintenance": {

--- a/test/OpenApiClientTests/LegacyClient/swagger.g.json
+++ b/test/OpenApiClientTests/LegacyClient/swagger.g.json
@@ -76,6 +76,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }
@@ -544,6 +547,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }
@@ -1262,6 +1268,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }

--- a/test/OpenApiClientTests/NamingConventions/CamelCase/swagger.g.json
+++ b/test/OpenApiClientTests/NamingConventions/CamelCase/swagger.g.json
@@ -76,6 +76,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }

--- a/test/OpenApiClientTests/NamingConventions/CamelCase/swagger.g.json
+++ b/test/OpenApiClientTests/NamingConventions/CamelCase/swagger.g.json
@@ -10,10 +10,11 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves a collection of supermarkets.",
         "operationId": "getSupermarketCollection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found supermarkets, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -28,17 +29,12 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves a collection of supermarkets without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headSupermarketCollection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/supermarketCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -46,8 +42,10 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Creates a new supermarket.",
         "operationId": "postSupermarket",
         "requestBody": {
+          "description": "The attributes and relationships of the supermarket to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -58,7 +56,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The supermarket was successfully created, which resulted in additional changes. The newly created supermarket is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -68,7 +66,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The supermarket was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -78,11 +85,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves an individual supermarket by its identifier.",
         "operationId": "getSupermarket",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -92,7 +101,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found supermarket.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -100,6 +109,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -107,11 +119,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves an individual supermarket by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headSupermarket",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -121,14 +136,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/supermarketPrimaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -136,11 +147,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Updates an existing supermarket.",
         "operationId": "patchSupermarket",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket to update.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -149,6 +162,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the supermarket to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -159,7 +173,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The supermarket was successfully updated, which resulted in additional changes. The updated supermarket is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -169,7 +183,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The supermarket was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The supermarket or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -177,11 +203,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Deletes an existing supermarket by its identifier.",
         "operationId": "deleteSupermarket",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket to delete.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -191,7 +219,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The supermarket was successfully deleted."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       }
@@ -201,11 +232,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staffMember of an individual supermarket's backupStoreManager relationship.",
         "operationId": "getSupermarketBackupStoreManager",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staffMember to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -215,7 +248,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found staffMember, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -223,6 +256,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -230,11 +266,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staffMember of an individual supermarket's backupStoreManager relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headSupermarketBackupStoreManager",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staffMember to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -244,14 +283,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableStaffMemberSecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       }
@@ -261,11 +296,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staffMember identity of an individual supermarket's backupStoreManager relationship.",
         "operationId": "getSupermarketBackupStoreManagerRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staffMember identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -275,7 +312,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found staffMember identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -283,6 +320,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -290,11 +330,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staffMember identity of an individual supermarket's backupStoreManager relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headSupermarketBackupStoreManagerRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staffMember identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -304,14 +347,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableStaffMemberIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -319,11 +358,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Clears or assigns an existing staffMember to the backupStoreManager relationship of an individual supermarket.",
         "operationId": "patchSupermarketBackupStoreManagerRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose backupStoreManager relationship to assign or clear.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -332,6 +373,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the staffMember to assign to the backupStoreManager relationship, or `null` to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -342,7 +384,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The backupStoreManager relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -352,11 +403,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staffMembers of an individual supermarket's cashiers relationship.",
         "operationId": "getSupermarketCashiers",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staffMembers to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -366,7 +419,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found staffMembers, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -374,6 +427,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -381,11 +437,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staffMembers of an individual supermarket's cashiers relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headSupermarketCashiers",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staffMembers to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -395,14 +454,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/staffMemberCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       }
@@ -412,11 +467,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staffMember identities of an individual supermarket's cashiers relationship.",
         "operationId": "getSupermarketCashiersRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staffMember identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -426,7 +483,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found staffMember identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -434,6 +491,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -441,11 +501,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staffMember identities of an individual supermarket's cashiers relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headSupermarketCashiersRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staffMember identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -455,14 +518,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/staffMemberIdentifierCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -470,11 +529,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Adds existing staffMembers to the cashiers relationship of an individual supermarket.",
         "operationId": "postSupermarketCashiersRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket to add staffMembers to.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -483,6 +544,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the staffMembers to add to the cashiers relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -493,7 +555,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The staffMembers were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -501,11 +572,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Assigns existing staffMembers to the cashiers relationship of an individual supermarket.",
         "operationId": "patchSupermarketCashiersRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose cashiers relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -514,6 +587,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the staffMembers to assign to the cashiers relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -524,7 +598,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The cashiers relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -532,11 +615,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Removes existing staffMembers from the cashiers relationship of an individual supermarket.",
         "operationId": "deleteSupermarketCashiersRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket to remove staffMembers from.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -545,6 +630,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the staffMembers to remove from the cashiers relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -555,7 +641,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The staffMembers were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -565,11 +660,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staffMember of an individual supermarket's storeManager relationship.",
         "operationId": "getSupermarketStoreManager",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staffMember to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -579,7 +676,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found staffMember, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -587,6 +684,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -594,11 +694,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staffMember of an individual supermarket's storeManager relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headSupermarketStoreManager",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staffMember to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -608,14 +711,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/staffMemberSecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       }
@@ -625,11 +724,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staffMember identity of an individual supermarket's storeManager relationship.",
         "operationId": "getSupermarketStoreManagerRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staffMember identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -639,7 +740,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found staffMember identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -647,6 +748,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -654,11 +758,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staffMember identity of an individual supermarket's storeManager relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headSupermarketStoreManagerRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staffMember identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -668,14 +775,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/staffMemberIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -683,11 +786,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Assigns an existing staffMember to the storeManager relationship of an individual supermarket.",
         "operationId": "patchSupermarketStoreManagerRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose storeManager relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -696,6 +801,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the staffMember to assign to the storeManager relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -706,7 +812,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The storeManager relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }

--- a/test/OpenApiClientTests/NamingConventions/KebabCase/swagger.g.json
+++ b/test/OpenApiClientTests/NamingConventions/KebabCase/swagger.g.json
@@ -76,6 +76,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }

--- a/test/OpenApiClientTests/NamingConventions/KebabCase/swagger.g.json
+++ b/test/OpenApiClientTests/NamingConventions/KebabCase/swagger.g.json
@@ -10,10 +10,11 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves a collection of supermarkets.",
         "operationId": "get-supermarket-collection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found supermarkets, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -28,17 +29,12 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves a collection of supermarkets without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-supermarket-collection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/supermarket-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -46,8 +42,10 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Creates a new supermarket.",
         "operationId": "post-supermarket",
         "requestBody": {
+          "description": "The attributes and relationships of the supermarket to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -58,7 +56,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The supermarket was successfully created, which resulted in additional changes. The newly created supermarket is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -68,7 +66,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The supermarket was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -78,11 +85,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves an individual supermarket by its identifier.",
         "operationId": "get-supermarket",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -92,7 +101,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found supermarket.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -100,6 +109,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -107,11 +119,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves an individual supermarket by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-supermarket",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -121,14 +136,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/supermarket-primary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -136,11 +147,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Updates an existing supermarket.",
         "operationId": "patch-supermarket",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket to update.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -149,6 +162,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the supermarket to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -159,7 +173,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The supermarket was successfully updated, which resulted in additional changes. The updated supermarket is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -169,7 +183,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The supermarket was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The supermarket or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -177,11 +203,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Deletes an existing supermarket by its identifier.",
         "operationId": "delete-supermarket",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket to delete.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -191,7 +219,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The supermarket was successfully deleted."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       }
@@ -201,11 +232,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staff-member of an individual supermarket's backup-store-manager relationship.",
         "operationId": "get-supermarket-backup-store-manager",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staff-member to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -215,7 +248,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found staff-member, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -223,6 +256,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -230,11 +266,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staff-member of an individual supermarket's backup-store-manager relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-supermarket-backup-store-manager",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staff-member to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -244,14 +283,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullable-staff-member-secondary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       }
@@ -261,11 +296,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staff-member identity of an individual supermarket's backup-store-manager relationship.",
         "operationId": "get-supermarket-backup-store-manager-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staff-member identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -275,7 +312,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found staff-member identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -283,6 +320,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -290,11 +330,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staff-member identity of an individual supermarket's backup-store-manager relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-supermarket-backup-store-manager-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staff-member identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -304,14 +347,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullable-staff-member-identifier-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -319,11 +358,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Clears or assigns an existing staff-member to the backup-store-manager relationship of an individual supermarket.",
         "operationId": "patch-supermarket-backup-store-manager-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose backup-store-manager relationship to assign or clear.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -332,6 +373,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the staff-member to assign to the backup-store-manager relationship, or `null` to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -342,7 +384,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The backup-store-manager relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -352,11 +403,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staff-members of an individual supermarket's cashiers relationship.",
         "operationId": "get-supermarket-cashiers",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staff-members to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -366,7 +419,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found staff-members, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -374,6 +427,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -381,11 +437,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staff-members of an individual supermarket's cashiers relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-supermarket-cashiers",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staff-members to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -395,14 +454,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/staff-member-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       }
@@ -412,11 +467,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staff-member identities of an individual supermarket's cashiers relationship.",
         "operationId": "get-supermarket-cashiers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staff-member identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -426,7 +483,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found staff-member identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -434,6 +491,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -441,11 +501,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staff-member identities of an individual supermarket's cashiers relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-supermarket-cashiers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staff-member identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -455,14 +518,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/staff-member-identifier-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -470,11 +529,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Adds existing staff-members to the cashiers relationship of an individual supermarket.",
         "operationId": "post-supermarket-cashiers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket to add staff-members to.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -483,6 +544,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the staff-members to add to the cashiers relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -493,7 +555,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The staff-members were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -501,11 +572,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Assigns existing staff-members to the cashiers relationship of an individual supermarket.",
         "operationId": "patch-supermarket-cashiers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose cashiers relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -514,6 +587,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the staff-members to assign to the cashiers relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -524,7 +598,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The cashiers relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -532,11 +615,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Removes existing staff-members from the cashiers relationship of an individual supermarket.",
         "operationId": "delete-supermarket-cashiers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket to remove staff-members from.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -545,6 +630,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the staff-members to remove from the cashiers relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -555,7 +641,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The staff-members were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -565,11 +660,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staff-member of an individual supermarket's store-manager relationship.",
         "operationId": "get-supermarket-store-manager",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staff-member to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -579,7 +676,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found staff-member, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -587,6 +684,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -594,11 +694,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staff-member of an individual supermarket's store-manager relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-supermarket-store-manager",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staff-member to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -608,14 +711,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/staff-member-secondary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       }
@@ -625,11 +724,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staff-member identity of an individual supermarket's store-manager relationship.",
         "operationId": "get-supermarket-store-manager-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staff-member identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -639,7 +740,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found staff-member identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -647,6 +748,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -654,11 +758,14 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Retrieves the related staff-member identity of an individual supermarket's store-manager relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-supermarket-store-manager-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose related staff-member identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -668,14 +775,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/staff-member-identifier-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
           }
         }
       },
@@ -683,11 +786,13 @@
         "tags": [
           "supermarkets"
         ],
+        "summary": "Assigns an existing staff-member to the store-manager relationship of an individual supermarket.",
         "operationId": "patch-supermarket-store-manager-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the supermarket whose store-manager relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -696,6 +801,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the staff-member to assign to the store-manager relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -706,7 +812,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The store-manager relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }

--- a/test/OpenApiClientTests/NamingConventions/PascalCase/swagger.g.json
+++ b/test/OpenApiClientTests/NamingConventions/PascalCase/swagger.g.json
@@ -76,6 +76,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }

--- a/test/OpenApiClientTests/NamingConventions/PascalCase/swagger.g.json
+++ b/test/OpenApiClientTests/NamingConventions/PascalCase/swagger.g.json
@@ -10,10 +10,11 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves a collection of Supermarkets.",
         "operationId": "GetSupermarketCollection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found Supermarkets, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -28,17 +29,12 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves a collection of Supermarkets without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "HeadSupermarketCollection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SupermarketCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -46,8 +42,10 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Creates a new Supermarket.",
         "operationId": "PostSupermarket",
         "requestBody": {
+          "description": "The attributes and relationships of the Supermarket to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -58,7 +56,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The Supermarket was successfully created, which resulted in additional changes. The newly created Supermarket is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -68,7 +66,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The Supermarket was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -78,11 +85,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves an individual Supermarket by its identifier.",
         "operationId": "GetSupermarket",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -92,7 +101,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found Supermarket.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -100,6 +109,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       },
@@ -107,11 +119,14 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves an individual Supermarket by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "HeadSupermarket",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -121,14 +136,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SupermarketPrimaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       },
@@ -136,11 +147,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Updates an existing Supermarket.",
         "operationId": "PatchSupermarket",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket to update.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -149,6 +162,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the Supermarket to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -159,7 +173,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The Supermarket was successfully updated, which resulted in additional changes. The updated Supermarket is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -169,7 +183,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The Supermarket was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The Supermarket or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -177,11 +203,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Deletes an existing Supermarket by its identifier.",
         "operationId": "DeleteSupermarket",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket to delete.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -191,7 +219,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The Supermarket was successfully deleted."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       }
@@ -201,11 +232,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves the related StaffMember of an individual Supermarket's BackupStoreManager relationship.",
         "operationId": "GetSupermarketBackupStoreManager",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose related StaffMember to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -215,7 +248,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found StaffMember, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -223,6 +256,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       },
@@ -230,11 +266,14 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves the related StaffMember of an individual Supermarket's BackupStoreManager relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "HeadSupermarketBackupStoreManager",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose related StaffMember to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -244,14 +283,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NullableStaffMemberSecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       }
@@ -261,11 +296,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves the related StaffMember identity of an individual Supermarket's BackupStoreManager relationship.",
         "operationId": "GetSupermarketBackupStoreManagerRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose related StaffMember identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -275,7 +312,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found StaffMember identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -283,6 +320,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       },
@@ -290,11 +330,14 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves the related StaffMember identity of an individual Supermarket's BackupStoreManager relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "HeadSupermarketBackupStoreManagerRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose related StaffMember identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -304,14 +347,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NullableStaffMemberIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       },
@@ -319,11 +358,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Clears or assigns an existing StaffMember to the BackupStoreManager relationship of an individual Supermarket.",
         "operationId": "PatchSupermarketBackupStoreManagerRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose BackupStoreManager relationship to assign or clear.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -332,6 +373,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the StaffMember to assign to the BackupStoreManager relationship, or `null` to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -342,7 +384,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The BackupStoreManager relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -352,11 +403,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves the related StaffMembers of an individual Supermarket's Cashiers relationship.",
         "operationId": "GetSupermarketCashiers",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose related StaffMembers to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -366,7 +419,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found StaffMembers, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -374,6 +427,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       },
@@ -381,11 +437,14 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves the related StaffMembers of an individual Supermarket's Cashiers relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "HeadSupermarketCashiers",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose related StaffMembers to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -395,14 +454,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StaffMemberCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       }
@@ -412,11 +467,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves the related StaffMember identities of an individual Supermarket's Cashiers relationship.",
         "operationId": "GetSupermarketCashiersRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose related StaffMember identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -426,7 +483,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found StaffMember identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -434,6 +491,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       },
@@ -441,11 +501,14 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves the related StaffMember identities of an individual Supermarket's Cashiers relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "HeadSupermarketCashiersRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose related StaffMember identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -455,14 +518,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StaffMemberIdentifierCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       },
@@ -470,11 +529,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Adds existing StaffMembers to the Cashiers relationship of an individual Supermarket.",
         "operationId": "PostSupermarketCashiersRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket to add StaffMembers to.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -483,6 +544,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the StaffMembers to add to the Cashiers relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -493,7 +555,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The StaffMembers were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -501,11 +572,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Assigns existing StaffMembers to the Cashiers relationship of an individual Supermarket.",
         "operationId": "PatchSupermarketCashiersRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose Cashiers relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -514,6 +587,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the StaffMembers to assign to the Cashiers relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -524,7 +598,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The Cashiers relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -532,11 +615,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Removes existing StaffMembers from the Cashiers relationship of an individual Supermarket.",
         "operationId": "DeleteSupermarketCashiersRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket to remove StaffMembers from.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -545,6 +630,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the StaffMembers to remove from the Cashiers relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -555,7 +641,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The StaffMembers were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -565,11 +660,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves the related StaffMember of an individual Supermarket's StoreManager relationship.",
         "operationId": "GetSupermarketStoreManager",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose related StaffMember to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -579,7 +676,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found StaffMember, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -587,6 +684,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       },
@@ -594,11 +694,14 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves the related StaffMember of an individual Supermarket's StoreManager relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "HeadSupermarketStoreManager",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose related StaffMember to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -608,14 +711,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StaffMemberSecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       }
@@ -625,11 +724,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves the related StaffMember identity of an individual Supermarket's StoreManager relationship.",
         "operationId": "GetSupermarketStoreManagerRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose related StaffMember identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -639,7 +740,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found StaffMember identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -647,6 +748,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       },
@@ -654,11 +758,14 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Retrieves the related StaffMember identity of an individual Supermarket's StoreManager relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "HeadSupermarketStoreManagerRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose related StaffMember identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -668,14 +775,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StaffMemberIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
           }
         }
       },
@@ -683,11 +786,13 @@
         "tags": [
           "Supermarkets"
         ],
+        "summary": "Assigns an existing StaffMember to the StoreManager relationship of an individual Supermarket.",
         "operationId": "PatchSupermarketStoreManagerRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the Supermarket whose StoreManager relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -696,6 +801,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the StaffMember to assign to the StoreManager relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -706,7 +812,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The StoreManager relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The Supermarket does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/swagger.g.json
@@ -76,6 +76,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/swagger.g.json
@@ -10,10 +10,11 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves a collection of resources.",
         "operationId": "getResourceCollection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found resources, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -28,17 +29,12 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves a collection of resources without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceCollection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/resourceCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -46,8 +42,10 @@
         "tags": [
           "resources"
         ],
+        "summary": "Creates a new resource.",
         "operationId": "postResource",
         "requestBody": {
+          "description": "The attributes and relationships of the resource to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -58,7 +56,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The resource was successfully created, which resulted in additional changes. The newly created resource is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -68,7 +66,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The resource was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -78,11 +85,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves an individual resource by its identifier.",
         "operationId": "getResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -92,7 +101,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found resource.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -100,6 +109,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -107,11 +119,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves an individual resource by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -121,14 +136,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/resourcePrimaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -136,11 +147,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Updates an existing resource.",
         "operationId": "patchResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to update.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -149,6 +162,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the resource to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -159,7 +173,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The resource was successfully updated, which resulted in additional changes. The updated resource is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -169,7 +183,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The resource was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -177,11 +203,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Deletes an existing resource by its identifier.",
         "operationId": "deleteResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to delete.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -191,7 +219,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The resource was successfully deleted."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -201,11 +232,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's requiredToMany relationship.",
         "operationId": "getResourceRequiredToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -215,7 +248,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empties, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -223,6 +256,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -230,11 +266,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's requiredToMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -244,14 +283,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -261,11 +296,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's requiredToMany relationship.",
         "operationId": "getResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -275,7 +312,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -283,6 +320,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -290,11 +330,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's requiredToMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -304,14 +347,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -319,11 +358,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Adds existing empties to the requiredToMany relationship of an individual resource.",
         "operationId": "postResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -332,6 +373,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to add to the requiredToMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -342,7 +384,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -350,11 +401,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns existing empties to the requiredToMany relationship of an individual resource.",
         "operationId": "patchResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose requiredToMany relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -363,6 +416,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to assign to the requiredToMany relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -373,7 +427,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The requiredToMany relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -381,11 +444,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Removes existing empties from the requiredToMany relationship of an individual resource.",
         "operationId": "deleteResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -394,6 +459,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to remove from the requiredToMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -404,7 +470,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -414,11 +489,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's requiredToOne relationship.",
         "operationId": "getResourceRequiredToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -428,7 +505,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -436,6 +513,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -443,11 +523,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's requiredToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -457,14 +540,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableEmptySecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -474,11 +553,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's requiredToOne relationship.",
         "operationId": "getResourceRequiredToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -488,7 +569,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -496,6 +577,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -503,11 +587,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's requiredToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -517,14 +604,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableEmptyIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -532,11 +615,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Clears or assigns an existing empty to the requiredToOne relationship of an individual resource.",
         "operationId": "patchResourceRequiredToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose requiredToOne relationship to assign or clear.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -545,6 +630,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the empty to assign to the requiredToOne relationship, or `null` to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -555,7 +641,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The requiredToOne relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -565,11 +660,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's toMany relationship.",
         "operationId": "getResourceToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -579,7 +676,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empties, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -587,6 +684,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -594,11 +694,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's toMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -608,14 +711,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -625,11 +724,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's toMany relationship.",
         "operationId": "getResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -639,7 +740,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -647,6 +748,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -654,11 +758,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's toMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -668,14 +775,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -683,11 +786,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Adds existing empties to the toMany relationship of an individual resource.",
         "operationId": "postResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -696,6 +801,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to add to the toMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -706,7 +812,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -714,11 +829,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns existing empties to the toMany relationship of an individual resource.",
         "operationId": "patchResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose toMany relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -727,6 +844,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to assign to the toMany relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -737,7 +855,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The toMany relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -745,11 +872,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Removes existing empties from the toMany relationship of an individual resource.",
         "operationId": "deleteResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -758,6 +887,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to remove from the toMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -768,7 +898,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -778,11 +917,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's toOne relationship.",
         "operationId": "getResourceToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -792,7 +933,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -800,6 +941,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -807,11 +951,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's toOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -821,14 +968,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableEmptySecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -838,11 +981,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's toOne relationship.",
         "operationId": "getResourceToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -852,7 +997,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -860,6 +1005,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -867,11 +1015,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's toOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -881,14 +1032,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableEmptyIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -896,11 +1043,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Clears or assigns an existing empty to the toOne relationship of an individual resource.",
         "operationId": "patchResourceToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose toOne relationship to assign or clear.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -909,6 +1058,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the empty to assign to the toOne relationship, or `null` to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -919,7 +1069,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The toOne relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/swagger.g.json
@@ -76,6 +76,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/swagger.g.json
@@ -10,10 +10,11 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves a collection of resources.",
         "operationId": "getResourceCollection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found resources, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -28,17 +29,12 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves a collection of resources without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceCollection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/resourceCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -46,8 +42,10 @@
         "tags": [
           "resources"
         ],
+        "summary": "Creates a new resource.",
         "operationId": "postResource",
         "requestBody": {
+          "description": "The attributes and relationships of the resource to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -58,7 +56,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The resource was successfully created, which resulted in additional changes. The newly created resource is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -68,7 +66,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The resource was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -78,11 +85,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves an individual resource by its identifier.",
         "operationId": "getResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -92,7 +101,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found resource.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -100,6 +109,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -107,11 +119,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves an individual resource by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -121,14 +136,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/resourcePrimaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -136,11 +147,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Updates an existing resource.",
         "operationId": "patchResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to update.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -149,6 +162,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the resource to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -159,7 +173,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The resource was successfully updated, which resulted in additional changes. The updated resource is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -169,7 +183,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The resource was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -177,11 +203,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Deletes an existing resource by its identifier.",
         "operationId": "deleteResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to delete.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -191,7 +219,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The resource was successfully deleted."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -201,11 +232,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's requiredToMany relationship.",
         "operationId": "getResourceRequiredToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -215,7 +248,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empties, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -223,6 +256,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -230,11 +266,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's requiredToMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -244,14 +283,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -261,11 +296,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's requiredToMany relationship.",
         "operationId": "getResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -275,7 +312,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -283,6 +320,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -290,11 +330,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's requiredToMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -304,14 +347,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -319,11 +358,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Adds existing empties to the requiredToMany relationship of an individual resource.",
         "operationId": "postResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -332,6 +373,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to add to the requiredToMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -342,7 +384,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -350,11 +401,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns existing empties to the requiredToMany relationship of an individual resource.",
         "operationId": "patchResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose requiredToMany relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -363,6 +416,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to assign to the requiredToMany relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -373,7 +427,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The requiredToMany relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -381,11 +444,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Removes existing empties from the requiredToMany relationship of an individual resource.",
         "operationId": "deleteResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -394,6 +459,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to remove from the requiredToMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -404,7 +470,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -414,11 +489,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's requiredToOne relationship.",
         "operationId": "getResourceRequiredToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -428,7 +505,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -436,6 +513,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -443,11 +523,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's requiredToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -457,14 +540,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptySecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -474,11 +553,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's requiredToOne relationship.",
         "operationId": "getResourceRequiredToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -488,7 +569,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -496,6 +577,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -503,11 +587,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's requiredToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -517,14 +604,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -532,11 +615,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns an existing empty to the requiredToOne relationship of an individual resource.",
         "operationId": "patchResourceRequiredToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose requiredToOne relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -545,6 +630,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the empty to assign to the requiredToOne relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -555,7 +641,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The requiredToOne relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -565,11 +660,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's toMany relationship.",
         "operationId": "getResourceToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -579,7 +676,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empties, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -587,6 +684,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -594,11 +694,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's toMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -608,14 +711,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -625,11 +724,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's toMany relationship.",
         "operationId": "getResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -639,7 +740,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -647,6 +748,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -654,11 +758,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's toMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -668,14 +775,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -683,11 +786,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Adds existing empties to the toMany relationship of an individual resource.",
         "operationId": "postResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -696,6 +801,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to add to the toMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -706,7 +812,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -714,11 +829,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns existing empties to the toMany relationship of an individual resource.",
         "operationId": "patchResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose toMany relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -727,6 +844,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to assign to the toMany relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -737,7 +855,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The toMany relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -745,11 +872,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Removes existing empties from the toMany relationship of an individual resource.",
         "operationId": "deleteResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -758,6 +887,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to remove from the toMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -768,7 +898,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -778,11 +917,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's toOne relationship.",
         "operationId": "getResourceToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -792,7 +933,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -800,6 +941,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -807,11 +951,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's toOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -821,14 +968,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableEmptySecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -838,11 +981,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's toOne relationship.",
         "operationId": "getResourceToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -852,7 +997,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -860,6 +1005,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -867,11 +1015,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's toOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -881,14 +1032,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableEmptyIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -896,11 +1043,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Clears or assigns an existing empty to the toOne relationship of an individual resource.",
         "operationId": "patchResourceToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose toOne relationship to assign or clear.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -909,6 +1058,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the empty to assign to the toOne relationship, or `null` to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -919,7 +1069,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The toOne relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/swagger.g.json
@@ -76,6 +76,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/swagger.g.json
@@ -10,10 +10,11 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves a collection of resources.",
         "operationId": "getResourceCollection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found resources, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -28,17 +29,12 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves a collection of resources without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceCollection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/resourceCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -46,8 +42,10 @@
         "tags": [
           "resources"
         ],
+        "summary": "Creates a new resource.",
         "operationId": "postResource",
         "requestBody": {
+          "description": "The attributes and relationships of the resource to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -58,7 +56,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The resource was successfully created, which resulted in additional changes. The newly created resource is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -68,7 +66,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The resource was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -78,11 +85,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves an individual resource by its identifier.",
         "operationId": "getResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -92,7 +101,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found resource.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -100,6 +109,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -107,11 +119,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves an individual resource by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -121,14 +136,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/resourcePrimaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -136,11 +147,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Updates an existing resource.",
         "operationId": "patchResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to update.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -149,6 +162,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the resource to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -159,7 +173,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The resource was successfully updated, which resulted in additional changes. The updated resource is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -169,7 +183,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The resource was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -177,11 +203,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Deletes an existing resource by its identifier.",
         "operationId": "deleteResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to delete.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -191,7 +219,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The resource was successfully deleted."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -201,11 +232,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's nonNullableToOne relationship.",
         "operationId": "getResourceNonNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -215,7 +248,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -223,6 +256,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -230,11 +266,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's nonNullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceNonNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -244,14 +283,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptySecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -261,11 +296,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's nonNullableToOne relationship.",
         "operationId": "getResourceNonNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -275,7 +312,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -283,6 +320,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -290,11 +330,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's nonNullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceNonNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -304,14 +347,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -319,11 +358,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns an existing empty to the nonNullableToOne relationship of an individual resource.",
         "operationId": "patchResourceNonNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose nonNullableToOne relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -332,6 +373,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the empty to assign to the nonNullableToOne relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -342,7 +384,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The nonNullableToOne relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -352,11 +403,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's nullableToOne relationship.",
         "operationId": "getResourceNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -366,7 +419,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -374,6 +427,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -381,11 +437,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's nullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -395,14 +454,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableEmptySecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -412,11 +467,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's nullableToOne relationship.",
         "operationId": "getResourceNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -426,7 +483,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -434,6 +491,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -441,11 +501,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's nullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -455,14 +518,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableEmptyIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -470,11 +529,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Clears or assigns an existing empty to the nullableToOne relationship of an individual resource.",
         "operationId": "patchResourceNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose nullableToOne relationship to assign or clear.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -483,6 +544,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the empty to assign to the nullableToOne relationship, or `null` to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -493,7 +555,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The nullableToOne relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -503,11 +574,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's requiredNonNullableToOne relationship.",
         "operationId": "getResourceRequiredNonNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -517,7 +590,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -525,6 +598,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -532,11 +608,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's requiredNonNullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredNonNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -546,14 +625,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptySecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -563,11 +638,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's requiredNonNullableToOne relationship.",
         "operationId": "getResourceRequiredNonNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -577,7 +654,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -585,6 +662,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -592,11 +672,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's requiredNonNullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredNonNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -606,14 +689,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -621,11 +700,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns an existing empty to the requiredNonNullableToOne relationship of an individual resource.",
         "operationId": "patchResourceRequiredNonNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose requiredNonNullableToOne relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -634,6 +715,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the empty to assign to the requiredNonNullableToOne relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -644,7 +726,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The requiredNonNullableToOne relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -654,11 +745,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's requiredNullableToOne relationship.",
         "operationId": "getResourceRequiredNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -668,7 +761,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -676,6 +769,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -683,11 +779,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's requiredNullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -697,14 +796,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableEmptySecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -714,11 +809,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's requiredNullableToOne relationship.",
         "operationId": "getResourceRequiredNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -728,7 +825,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -736,6 +833,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -743,11 +843,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's requiredNullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -757,14 +860,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableEmptyIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -772,11 +871,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Clears or assigns an existing empty to the requiredNullableToOne relationship of an individual resource.",
         "operationId": "patchResourceRequiredNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose requiredNullableToOne relationship to assign or clear.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -785,6 +886,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the empty to assign to the requiredNullableToOne relationship, or `null` to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -795,7 +897,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The requiredNullableToOne relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -805,11 +916,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's requiredToMany relationship.",
         "operationId": "getResourceRequiredToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -819,7 +932,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empties, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -827,6 +940,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -834,11 +950,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's requiredToMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -848,14 +967,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -865,11 +980,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's requiredToMany relationship.",
         "operationId": "getResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -879,7 +996,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -887,6 +1004,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -894,11 +1014,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's requiredToMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -908,14 +1031,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -923,11 +1042,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Adds existing empties to the requiredToMany relationship of an individual resource.",
         "operationId": "postResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -936,6 +1057,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to add to the requiredToMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -946,7 +1068,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -954,11 +1085,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns existing empties to the requiredToMany relationship of an individual resource.",
         "operationId": "patchResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose requiredToMany relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -967,6 +1100,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to assign to the requiredToMany relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -977,7 +1111,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The requiredToMany relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -985,11 +1128,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Removes existing empties from the requiredToMany relationship of an individual resource.",
         "operationId": "deleteResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -998,6 +1143,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to remove from the requiredToMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1008,7 +1154,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -1018,11 +1173,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's toMany relationship.",
         "operationId": "getResourceToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1032,7 +1189,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empties, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1040,6 +1197,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -1047,11 +1207,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's toMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1061,14 +1224,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -1078,11 +1237,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's toMany relationship.",
         "operationId": "getResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1092,7 +1253,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1100,6 +1261,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -1107,11 +1271,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's toMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1121,14 +1288,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -1136,11 +1299,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Adds existing empties to the toMany relationship of an individual resource.",
         "operationId": "postResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1149,6 +1314,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to add to the toMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1159,7 +1325,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -1167,11 +1342,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns existing empties to the toMany relationship of an individual resource.",
         "operationId": "patchResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose toMany relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1180,6 +1357,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to assign to the toMany relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1190,7 +1368,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The toMany relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -1198,11 +1385,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Removes existing empties from the toMany relationship of an individual resource.",
         "operationId": "deleteResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1211,6 +1400,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to remove from the toMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1221,7 +1411,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/swagger.g.json
@@ -76,6 +76,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/swagger.g.json
@@ -10,10 +10,11 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves a collection of resources.",
         "operationId": "getResourceCollection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found resources, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -28,17 +29,12 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves a collection of resources without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceCollection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/resourceCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -46,8 +42,10 @@
         "tags": [
           "resources"
         ],
+        "summary": "Creates a new resource.",
         "operationId": "postResource",
         "requestBody": {
+          "description": "The attributes and relationships of the resource to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -58,7 +56,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The resource was successfully created, which resulted in additional changes. The newly created resource is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -68,7 +66,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The resource was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -78,11 +85,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves an individual resource by its identifier.",
         "operationId": "getResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -92,7 +101,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found resource.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -100,6 +109,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -107,11 +119,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves an individual resource by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -121,14 +136,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/resourcePrimaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -136,11 +147,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Updates an existing resource.",
         "operationId": "patchResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to update.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -149,6 +162,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the resource to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -159,7 +173,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The resource was successfully updated, which resulted in additional changes. The updated resource is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -169,7 +183,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The resource was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -177,11 +203,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Deletes an existing resource by its identifier.",
         "operationId": "deleteResource",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to delete.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -191,7 +219,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The resource was successfully deleted."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -201,11 +232,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's nonNullableToOne relationship.",
         "operationId": "getResourceNonNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -215,7 +248,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -223,6 +256,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -230,11 +266,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's nonNullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceNonNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -244,14 +283,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptySecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -261,11 +296,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's nonNullableToOne relationship.",
         "operationId": "getResourceNonNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -275,7 +312,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -283,6 +320,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -290,11 +330,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's nonNullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceNonNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -304,14 +347,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -319,11 +358,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns an existing empty to the nonNullableToOne relationship of an individual resource.",
         "operationId": "patchResourceNonNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose nonNullableToOne relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -332,6 +373,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the empty to assign to the nonNullableToOne relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -342,7 +384,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The nonNullableToOne relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -352,11 +403,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's nullableToOne relationship.",
         "operationId": "getResourceNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -366,7 +419,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -374,6 +427,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -381,11 +437,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's nullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -395,14 +454,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableEmptySecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -412,11 +467,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's nullableToOne relationship.",
         "operationId": "getResourceNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -426,7 +483,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -434,6 +491,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -441,11 +501,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's nullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -455,14 +518,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullableEmptyIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -470,11 +529,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Clears or assigns an existing empty to the nullableToOne relationship of an individual resource.",
         "operationId": "patchResourceNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose nullableToOne relationship to assign or clear.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -483,6 +544,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the empty to assign to the nullableToOne relationship, or `null` to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -493,7 +555,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The nullableToOne relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -503,11 +574,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's requiredNonNullableToOne relationship.",
         "operationId": "getResourceRequiredNonNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -517,7 +590,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -525,6 +598,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -532,11 +608,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's requiredNonNullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredNonNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -546,14 +625,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptySecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -563,11 +638,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's requiredNonNullableToOne relationship.",
         "operationId": "getResourceRequiredNonNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -577,7 +654,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -585,6 +662,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -592,11 +672,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's requiredNonNullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredNonNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -606,14 +689,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -621,11 +700,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns an existing empty to the requiredNonNullableToOne relationship of an individual resource.",
         "operationId": "patchResourceRequiredNonNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose requiredNonNullableToOne relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -634,6 +715,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the empty to assign to the requiredNonNullableToOne relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -644,7 +726,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The requiredNonNullableToOne relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -654,11 +745,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's requiredNullableToOne relationship.",
         "operationId": "getResourceRequiredNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -668,7 +761,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -676,6 +769,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -683,11 +779,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty of an individual resource's requiredNullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredNullableToOne",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -697,14 +796,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptySecondaryResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -714,11 +809,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's requiredNullableToOne relationship.",
         "operationId": "getResourceRequiredNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -728,7 +825,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -736,6 +833,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -743,11 +843,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identity of an individual resource's requiredNullableToOne relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -757,14 +860,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -772,11 +871,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns an existing empty to the requiredNullableToOne relationship of an individual resource.",
         "operationId": "patchResourceRequiredNullableToOneRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose requiredNullableToOne relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -785,6 +886,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the empty to assign to the requiredNullableToOne relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -795,7 +897,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The requiredNullableToOne relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -805,11 +916,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's requiredToMany relationship.",
         "operationId": "getResourceRequiredToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -819,7 +932,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empties, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -827,6 +940,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -834,11 +950,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's requiredToMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -848,14 +967,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -865,11 +980,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's requiredToMany relationship.",
         "operationId": "getResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -879,7 +996,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -887,6 +1004,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -894,11 +1014,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's requiredToMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -908,14 +1031,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -923,11 +1042,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Adds existing empties to the requiredToMany relationship of an individual resource.",
         "operationId": "postResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -936,6 +1057,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to add to the requiredToMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -946,7 +1068,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -954,11 +1085,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns existing empties to the requiredToMany relationship of an individual resource.",
         "operationId": "patchResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose requiredToMany relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -967,6 +1100,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to assign to the requiredToMany relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -977,7 +1111,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The requiredToMany relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -985,11 +1128,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Removes existing empties from the requiredToMany relationship of an individual resource.",
         "operationId": "deleteResourceRequiredToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -998,6 +1143,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to remove from the requiredToMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1008,7 +1154,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -1018,11 +1173,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's toMany relationship.",
         "operationId": "getResourceToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1032,7 +1189,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empties, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1040,6 +1197,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -1047,11 +1207,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empties of an individual resource's toMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceToMany",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1061,14 +1224,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       }
@@ -1078,11 +1237,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's toMany relationship.",
         "operationId": "getResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1092,7 +1253,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found empty identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1100,6 +1261,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -1107,11 +1271,14 @@
         "tags": [
           "resources"
         ],
+        "summary": "Retrieves the related empty identities of an individual resource's toMany relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "headResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1121,14 +1288,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The resource does not exist."
           }
         }
       },
@@ -1136,11 +1299,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Adds existing empties to the toMany relationship of an individual resource.",
         "operationId": "postResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1149,6 +1314,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to add to the toMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1159,7 +1325,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -1167,11 +1342,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Assigns existing empties to the toMany relationship of an individual resource.",
         "operationId": "patchResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource whose toMany relationship to assign.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1180,6 +1357,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to assign to the toMany relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1190,7 +1368,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The toMany relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -1198,11 +1385,13 @@
         "tags": [
           "resources"
         ],
+        "summary": "Removes existing empties from the toMany relationship of an individual resource.",
         "operationId": "deleteResourceToManyRelationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
               "type": "integer",
@@ -1211,6 +1400,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the empties to remove from the toMany relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1221,7 +1411,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The empties were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }

--- a/test/OpenApiTests/DocComments/DocCommentsDbContext.cs
+++ b/test/OpenApiTests/DocComments/DocCommentsDbContext.cs
@@ -1,0 +1,30 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
+
+// @formatter:wrap_chained_method_calls chop_always
+
+namespace OpenApiTests.DocComments;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+public sealed class DocCommentsDbContext : TestableDbContext
+{
+    public DbSet<Skyscraper> Skyscrapers => Set<Skyscraper>();
+    public DbSet<Elevator> Elevators => Set<Elevator>();
+    public DbSet<Space> Spaces => Set<Space>();
+
+    public DocCommentsDbContext(DbContextOptions<DocCommentsDbContext> options)
+        : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        builder.Entity<Skyscraper>()
+            .HasOne(skyscraper => skyscraper.Elevator)
+            .WithOne(elevator => elevator.ExistsIn)
+            .HasForeignKey<Skyscraper>("ElevatorId");
+
+        base.OnModelCreating(builder);
+    }
+}

--- a/test/OpenApiTests/DocComments/DocCommentsStartup.cs
+++ b/test/OpenApiTests/DocComments/DocCommentsStartup.cs
@@ -1,4 +1,5 @@
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -10,6 +11,12 @@ namespace OpenApiTests.DocComments;
 public sealed class DocCommentsStartup<TDbContext> : OpenApiStartup<TDbContext>
     where TDbContext : TestableDbContext
 {
+    protected override void SetJsonApiOptions(JsonApiOptions options)
+    {
+        options.ClientIdGeneration = ClientIdGenerationMode.Allowed;
+        base.SetJsonApiOptions(options);
+    }
+
     protected override void SetupSwaggerGenAction(SwaggerGenOptions options)
     {
         options.SwaggerDoc("v1", new OpenApiInfo

--- a/test/OpenApiTests/DocComments/DocCommentsStartup.cs
+++ b/test/OpenApiTests/DocComments/DocCommentsStartup.cs
@@ -1,0 +1,32 @@
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using TestBuildingBlocks;
+
+namespace OpenApiTests.DocComments;
+
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+public sealed class DocCommentsStartup<TDbContext> : OpenApiStartup<TDbContext>
+    where TDbContext : TestableDbContext
+{
+    protected override void SetupSwaggerGenAction(SwaggerGenOptions options)
+    {
+        options.SwaggerDoc("v1", new OpenApiInfo
+        {
+            Version = "v1",
+            Title = "Skyscrapers of the world",
+            Description = "A JSON:API service for managing skyscrapers.",
+            Contact = new OpenApiContact
+            {
+                Name = "Report issues",
+                Url = new Uri("https://github.com/json-api-dotnet/JsonApiDotNetCore/issues")
+            },
+            License = new OpenApiLicense
+            {
+                Name = "MIT License",
+                Url = new Uri("https://licenses.nuget.org/MIT")
+            }
+        });
+    }
+}

--- a/test/OpenApiTests/DocComments/DocCommentsStartup.cs
+++ b/test/OpenApiTests/DocComments/DocCommentsStartup.cs
@@ -28,5 +28,7 @@ public sealed class DocCommentsStartup<TDbContext> : OpenApiStartup<TDbContext>
                 Url = new Uri("https://licenses.nuget.org/MIT")
             }
         });
+
+        base.SetupSwaggerGenAction(options);
     }
 }

--- a/test/OpenApiTests/DocComments/DocCommentsTests.cs
+++ b/test/OpenApiTests/DocComments/DocCommentsTests.cs
@@ -1,0 +1,425 @@
+using System.Text.Json;
+using TestBuildingBlocks;
+using Xunit;
+
+// @formatter:max_line_length 250
+
+namespace OpenApiTests.DocComments;
+
+public sealed class DocCommentsTests : IClassFixture<OpenApiTestContext<DocCommentsStartup<DocCommentsDbContext>, DocCommentsDbContext>>
+{
+    private readonly OpenApiTestContext<DocCommentsStartup<DocCommentsDbContext>, DocCommentsDbContext> _testContext;
+
+    public DocCommentsTests(OpenApiTestContext<DocCommentsStartup<DocCommentsDbContext>, DocCommentsDbContext> testContext)
+    {
+        _testContext = testContext;
+
+        testContext.UseController<SkyscrapersController>();
+    }
+
+    [Fact]
+    public async Task API_is_documented()
+    {
+        // Act
+        JsonElement document = await _testContext.GetSwaggerDocumentAsync();
+
+        // Assert
+        document.Should().ContainPath("info").With(infoElement =>
+        {
+            infoElement.Should().HaveProperty("title", "Skyscrapers of the world");
+            infoElement.Should().HaveProperty("description", "A JSON:API service for managing skyscrapers.");
+            infoElement.Should().HaveProperty("version", "v1");
+
+            infoElement.Should().ContainPath("contact").With(contactElement =>
+            {
+                contactElement.Should().HaveProperty("name", "Report issues");
+                contactElement.Should().HaveProperty("url", "https://github.com/json-api-dotnet/JsonApiDotNetCore/issues");
+            });
+
+            infoElement.Should().ContainPath("license").With(contactElement =>
+            {
+                contactElement.Should().HaveProperty("name", "MIT License");
+                contactElement.Should().HaveProperty("url", "https://licenses.nuget.org/MIT");
+            });
+        });
+    }
+
+    [Fact]
+    public async Task Endpoints_are_documented()
+    {
+        // Act
+        JsonElement document = await _testContext.GetSwaggerDocumentAsync();
+
+        // Assert
+        document.Should().ContainPath("paths./skyscrapers").With(skyscrapersElement =>
+        {
+            skyscrapersElement.Should().ContainPath("get").With(getElement =>
+            {
+                getElement.Should().HaveProperty("summary", "Retrieves a collection of skyscrapers.");
+
+                getElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(1);
+                    responseElement.Should().HaveProperty("200.description", "Successfully returns the found skyscrapers, or an empty array if none were found.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("head").With(headElement =>
+            {
+                headElement.Should().HaveProperty("summary", "Retrieves a collection of skyscrapers without returning them.");
+                headElement.Should().HaveProperty("description", "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.");
+
+                headElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(1);
+                    responseElement.Should().HaveProperty("200.description", "The operation completed successfully.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("post").With(postElement =>
+            {
+                postElement.Should().HaveProperty("summary", "Creates a new skyscraper.");
+
+                postElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(5);
+                    responseElement.Should().HaveProperty("201.description", "The skyscraper was successfully created, which resulted in additional changes. The newly created skyscraper is returned.");
+                    responseElement.Should().HaveProperty("204.description", "The skyscraper was successfully created, which did not result in additional changes.");
+                    responseElement.Should().HaveProperty("400.description", "The request body is missing or malformed.");
+                    responseElement.Should().HaveProperty("409.description", "A resource type in the request body is incompatible.");
+                    responseElement.Should().HaveProperty("422.description", "Validation of the request body failed.");
+                });
+            });
+        });
+
+        document.Should().ContainPath("paths./skyscrapers/{id}").With(skyscrapersElement =>
+        {
+            skyscrapersElement.Should().ContainPath("get").With(getElement =>
+            {
+                getElement.Should().HaveProperty("summary", "Retrieves an individual skyscraper by its identifier.");
+
+                getElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper to retrieve.");
+                });
+
+                getElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(2);
+                    responseElement.Should().HaveProperty("200.description", "Successfully returns the found skyscraper.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("head").With(headElement =>
+            {
+                headElement.Should().HaveProperty("summary", "Retrieves an individual skyscraper by its identifier without returning it.");
+                headElement.Should().HaveProperty("description", "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.");
+
+                headElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper to retrieve.");
+                });
+
+                headElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(2);
+                    responseElement.Should().HaveProperty("200.description", "The operation completed successfully.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("patch").With(patchElement =>
+            {
+                patchElement.Should().HaveProperty("summary", "Updates an existing skyscraper.");
+
+                patchElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper to update.");
+                });
+
+                patchElement.Should().HaveProperty("requestBody.description", "The attributes and relationships of the skyscraper to update. Omitted fields are left unchanged.");
+
+                patchElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(6);
+                    responseElement.Should().HaveProperty("200.description", "The skyscraper was successfully updated, which resulted in additional changes. The updated skyscraper is returned.");
+                    responseElement.Should().HaveProperty("204.description", "The skyscraper was successfully updated, which did not result in additional changes.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper or a related resource does not exist.");
+                    responseElement.Should().HaveProperty("400.description", "The request body is missing or malformed.");
+                    responseElement.Should().HaveProperty("409.description", "A resource type or identifier in the request body is incompatible.");
+                    responseElement.Should().HaveProperty("422.description", "Validation of the request body failed.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("delete").With(patchElement =>
+            {
+                patchElement.Should().HaveProperty("summary", "Deletes an existing skyscraper by its identifier.");
+
+                patchElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper to delete.");
+                });
+
+                patchElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(2);
+                    responseElement.Should().HaveProperty("204.description", "The skyscraper was successfully deleted.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                });
+            });
+        });
+
+        document.Should().ContainPath("paths./skyscrapers/{id}/elevator").With(skyscrapersElement =>
+        {
+            skyscrapersElement.Should().ContainPath("get").With(getElement =>
+            {
+                getElement.Should().HaveProperty("summary", "Retrieves the related elevator of an individual skyscraper's elevator relationship.");
+
+                getElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper whose related elevator to retrieve.");
+                });
+
+                getElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(2);
+                    responseElement.Should().HaveProperty("200.description", "Successfully returns the found elevator, or `null` if it was not found.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("head").With(headElement =>
+            {
+                headElement.Should().HaveProperty("summary", "Retrieves the related elevator of an individual skyscraper's elevator relationship without returning it.");
+                headElement.Should().HaveProperty("description", "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.");
+
+                headElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper whose related elevator to retrieve.");
+                });
+
+                headElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(2);
+                    responseElement.Should().HaveProperty("200.description", "The operation completed successfully.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                });
+            });
+        });
+
+        document.Should().ContainPath("paths./skyscrapers/{id}/relationships/elevator").With(skyscrapersElement =>
+        {
+            skyscrapersElement.Should().ContainPath("get").With(getElement =>
+            {
+                getElement.Should().HaveProperty("summary", "Retrieves the related elevator identity of an individual skyscraper's elevator relationship.");
+
+                getElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper whose related elevator identity to retrieve.");
+                });
+
+                getElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(2);
+                    responseElement.Should().HaveProperty("200.description", "Successfully returns the found elevator identity, or `null` if it was not found.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("head").With(headElement =>
+            {
+                headElement.Should().HaveProperty("summary", "Retrieves the related elevator identity of an individual skyscraper's elevator relationship without returning it.");
+                headElement.Should().HaveProperty("description", "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.");
+
+                headElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper whose related elevator identity to retrieve.");
+                });
+
+                headElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(2);
+                    responseElement.Should().HaveProperty("200.description", "The operation completed successfully.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("patch").With(patchElement =>
+            {
+                patchElement.Should().HaveProperty("summary", "Clears or assigns an existing elevator to the elevator relationship of an individual skyscraper.");
+
+                patchElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper whose elevator relationship to assign or clear.");
+                });
+
+                patchElement.Should().HaveProperty("requestBody.description", "The identity of the elevator to assign to the elevator relationship, or `null` to clear the relationship.");
+
+                patchElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(4);
+                    responseElement.Should().HaveProperty("204.description", "The elevator relationship was successfully updated, which did not result in additional changes.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                    responseElement.Should().HaveProperty("400.description", "The request body is missing or malformed.");
+                    responseElement.Should().HaveProperty("409.description", "A resource type in the request body is incompatible.");
+                });
+            });
+        });
+
+        document.Should().ContainPath("paths./skyscrapers/{id}/spaces").With(skyscrapersElement =>
+        {
+            skyscrapersElement.Should().ContainPath("get").With(getElement =>
+            {
+                getElement.Should().HaveProperty("summary", "Retrieves the related spaces of an individual skyscraper's spaces relationship.");
+
+                getElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper whose related spaces to retrieve.");
+                });
+
+                getElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(2);
+                    responseElement.Should().HaveProperty("200.description", "Successfully returns the found spaces, or an empty array if none were found.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("head").With(headElement =>
+            {
+                headElement.Should().HaveProperty("summary", "Retrieves the related spaces of an individual skyscraper's spaces relationship without returning them.");
+                headElement.Should().HaveProperty("description", "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.");
+
+                headElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper whose related spaces to retrieve.");
+                });
+
+                headElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(2);
+                    responseElement.Should().HaveProperty("200.description", "The operation completed successfully.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                });
+            });
+        });
+
+        document.Should().ContainPath("paths./skyscrapers/{id}/relationships/spaces").With(skyscrapersElement =>
+        {
+            skyscrapersElement.Should().ContainPath("get").With(getElement =>
+            {
+                getElement.Should().HaveProperty("summary", "Retrieves the related space identities of an individual skyscraper's spaces relationship.");
+
+                getElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper whose related space identities to retrieve.");
+                });
+
+                getElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(2);
+                    responseElement.Should().HaveProperty("200.description", "Successfully returns the found space identities, or an empty array if none were found.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("head").With(headElement =>
+            {
+                headElement.Should().HaveProperty("summary", "Retrieves the related space identities of an individual skyscraper's spaces relationship without returning them.");
+                headElement.Should().HaveProperty("description", "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.");
+
+                headElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper whose related space identities to retrieve.");
+                });
+
+                headElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(2);
+                    responseElement.Should().HaveProperty("200.description", "The operation completed successfully.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("post").With(patchElement =>
+            {
+                patchElement.Should().HaveProperty("summary", "Adds existing spaces to the spaces relationship of an individual skyscraper.");
+
+                patchElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper to add spaces to.");
+                });
+
+                patchElement.Should().HaveProperty("requestBody.description", "The identities of the spaces to add to the spaces relationship.");
+
+                patchElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(4);
+                    responseElement.Should().HaveProperty("204.description", "The spaces were successfully added, which did not result in additional changes.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                    responseElement.Should().HaveProperty("400.description", "The request body is missing or malformed.");
+                    responseElement.Should().HaveProperty("409.description", "A resource type in the request body is incompatible.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("patch").With(patchElement =>
+            {
+                patchElement.Should().HaveProperty("summary", "Assigns existing spaces to the spaces relationship of an individual skyscraper.");
+
+                patchElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper whose spaces relationship to assign.");
+                });
+
+                patchElement.Should().HaveProperty("requestBody.description", "The identities of the spaces to assign to the spaces relationship, or an empty array to clear the relationship.");
+
+                patchElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(4);
+                    responseElement.Should().HaveProperty("204.description", "The spaces relationship was successfully updated, which did not result in additional changes.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                    responseElement.Should().HaveProperty("400.description", "The request body is missing or malformed.");
+                    responseElement.Should().HaveProperty("409.description", "A resource type in the request body is incompatible.");
+                });
+            });
+
+            skyscrapersElement.Should().ContainPath("delete").With(patchElement =>
+            {
+                patchElement.Should().HaveProperty("summary", "Removes existing spaces from the spaces relationship of an individual skyscraper.");
+
+                patchElement.Should().ContainPath("parameters").With(parametersElement =>
+                {
+                    parametersElement.EnumerateArray().ShouldHaveCount(1);
+                    parametersElement.Should().HaveProperty("[0].description", "The identifier of the skyscraper to remove spaces from.");
+                });
+
+                patchElement.Should().HaveProperty("requestBody.description", "The identities of the spaces to remove from the spaces relationship.");
+
+                patchElement.Should().ContainPath("responses").With(responseElement =>
+                {
+                    responseElement.EnumerateObject().ShouldHaveCount(4);
+                    responseElement.Should().HaveProperty("204.description", "The spaces were successfully removed, which did not result in additional changes.");
+                    responseElement.Should().HaveProperty("404.description", "The skyscraper does not exist.");
+                    responseElement.Should().HaveProperty("400.description", "The request body is missing or malformed.");
+                    responseElement.Should().HaveProperty("409.description", "A resource type in the request body is incompatible.");
+                });
+            });
+        });
+    }
+}

--- a/test/OpenApiTests/DocComments/DocCommentsTests.cs
+++ b/test/OpenApiTests/DocComments/DocCommentsTests.cs
@@ -483,4 +483,17 @@ public sealed class DocCommentsTests : IClassFixture<OpenApiTestContext<DocComme
             schemasElement.Should().HaveProperty("spaceKind.description", "Lists the various kinds of spaces within a skyscraper.");
         });
     }
+
+    [Fact]
+    public async Task Forbidden_status_is_added_when_client_generated_IDs_are_disabled()
+    {
+        // Act
+        JsonElement document = await _testContext.GetSwaggerDocumentAsync();
+
+        // Assert
+        document.Should().ContainPath("paths./elevators.post.responses").With(responseElement =>
+        {
+            responseElement.Should().HaveProperty("403.description", "Client-generated IDs cannot be used at this endpoint.");
+        });
+    }
 }

--- a/test/OpenApiTests/DocComments/DocCommentsTests.cs
+++ b/test/OpenApiTests/DocComments/DocCommentsTests.cs
@@ -15,6 +15,8 @@ public sealed class DocCommentsTests : IClassFixture<OpenApiTestContext<DocComme
         _testContext = testContext;
 
         testContext.UseController<SkyscrapersController>();
+        testContext.UseController<ElevatorsController>();
+        testContext.UseController<SpacesController>();
     }
 
     [Fact]
@@ -420,6 +422,65 @@ public sealed class DocCommentsTests : IClassFixture<OpenApiTestContext<DocComme
                     responseElement.Should().HaveProperty("409.description", "A resource type in the request body is incompatible.");
                 });
             });
+        });
+    }
+
+    [Fact]
+    public async Task Resource_types_are_documented()
+    {
+        // Act
+        JsonElement document = await _testContext.GetSwaggerDocumentAsync();
+
+        // Assert
+        document.Should().ContainPath("components.schemas").With(schemasElement =>
+        {
+            schemasElement.Should().HaveProperty("elevatorDataInPatchRequest.description", "An elevator within a skyscraper.");
+            schemasElement.Should().HaveProperty("elevatorDataInPostRequest.description", "An elevator within a skyscraper.");
+            schemasElement.Should().HaveProperty("elevatorDataInResponse.description", "An elevator within a skyscraper.");
+
+            schemasElement.Should().HaveProperty("skyscraperDataInPatchRequest.description", "A tall, continuously habitable building having multiple floors.");
+            schemasElement.Should().HaveProperty("skyscraperDataInPostRequest.description", "A tall, continuously habitable building having multiple floors.");
+            schemasElement.Should().HaveProperty("skyscraperDataInResponse.description", "A tall, continuously habitable building having multiple floors.");
+
+            schemasElement.Should().HaveProperty("spaceDataInPatchRequest.description", "A space within a skyscraper, such as an office, hotel, residential space, or retail space.");
+            schemasElement.Should().HaveProperty("spaceDataInPostRequest.description", "A space within a skyscraper, such as an office, hotel, residential space, or retail space.");
+            schemasElement.Should().HaveProperty("spaceDataInResponse.description", "A space within a skyscraper, such as an office, hotel, residential space, or retail space.");
+        });
+    }
+
+    [Fact]
+    public async Task Resource_attributes_are_documented()
+    {
+        // Act
+        JsonElement document = await _testContext.GetSwaggerDocumentAsync();
+
+        // Assert
+        document.Should().ContainPath("components.schemas").With(schemasElement =>
+        {
+            schemasElement.Should().HaveProperty("elevatorAttributesInPatchRequest.properties.floorCount.description", "The number of floors this elevator provides access to.");
+            schemasElement.Should().HaveProperty("elevatorAttributesInPostRequest.properties.floorCount.description", "The number of floors this elevator provides access to.");
+            schemasElement.Should().HaveProperty("elevatorAttributesInResponse.properties.floorCount.description", "The number of floors this elevator provides access to.");
+
+            schemasElement.Should().HaveProperty("skyscraperAttributesInPatchRequest.properties.heightInMeters.description", "The height of this building, in meters.");
+            schemasElement.Should().HaveProperty("skyscraperAttributesInPostRequest.properties.heightInMeters.description", "The height of this building, in meters.");
+            schemasElement.Should().HaveProperty("skyscraperAttributesInResponse.properties.heightInMeters.description", "The height of this building, in meters.");
+
+            schemasElement.Should().HaveProperty("spaceAttributesInPatchRequest.properties.floorNumber.description", "The floor number on which this space resides.");
+            schemasElement.Should().HaveProperty("spaceAttributesInPostRequest.properties.floorNumber.description", "The floor number on which this space resides.");
+            schemasElement.Should().HaveProperty("spaceAttributesInResponse.properties.floorNumber.description", "The floor number on which this space resides.");
+        });
+    }
+
+    [Fact]
+    public async Task Enums_are_documented()
+    {
+        // Act
+        JsonElement document = await _testContext.GetSwaggerDocumentAsync();
+
+        // Assert
+        document.Should().ContainPath("components.schemas").With(schemasElement =>
+        {
+            schemasElement.Should().HaveProperty("spaceKind.description", "Lists the various kinds of spaces within a skyscraper.");
         });
     }
 }

--- a/test/OpenApiTests/DocComments/Elevator.cs
+++ b/test/OpenApiTests/DocComments/Elevator.cs
@@ -1,4 +1,5 @@
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 
@@ -8,7 +9,7 @@ namespace OpenApiTests.DocComments;
 /// An elevator within a skyscraper.
 /// </summary>
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-[Resource(ControllerNamespace = "OpenApiTests.DocComments")]
+[Resource(ControllerNamespace = "OpenApiTests.DocComments", ClientIdGeneration = ClientIdGenerationMode.Forbidden)]
 public sealed class Elevator : Identifiable<long>
 {
     /// <summary>

--- a/test/OpenApiTests/DocComments/Elevator.cs
+++ b/test/OpenApiTests/DocComments/Elevator.cs
@@ -1,0 +1,25 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace OpenApiTests.DocComments;
+
+/// <summary>
+/// An elevator within a skyscraper.
+/// </summary>
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "OpenApiTests.DocComments")]
+public sealed class Elevator : Identifiable<long>
+{
+    /// <summary>
+    /// The number of floors this elevator provides access to.
+    /// </summary>
+    [Attr]
+    public int FloorCount { get; set; }
+
+    /// <summary>
+    /// The skyscraper this elevator exists in.
+    /// </summary>
+    [HasOne]
+    public Skyscraper ExistsIn { get; set; } = null!;
+}

--- a/test/OpenApiTests/DocComments/Skyscraper.cs
+++ b/test/OpenApiTests/DocComments/Skyscraper.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace OpenApiTests.DocComments;
+
+/// <summary>
+/// A tall, continuously habitable building having multiple floors.
+/// </summary>
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "OpenApiTests.DocComments")]
+public sealed class Skyscraper : Identifiable<long>
+{
+    /// <summary>
+    /// The height of this building, in meters.
+    /// </summary>
+    [Attr]
+    [Required]
+    public int? HeightInMeters { get; set; }
+
+    /// <summary>
+    /// An optional elevator within this building, providing access to spaces.
+    /// </summary>
+    [HasOne]
+    public Elevator? Elevator { get; set; }
+
+    /// <summary>
+    /// The spaces within this building.
+    /// </summary>
+    [HasMany]
+    public ISet<Space> Spaces { get; set; } = new HashSet<Space>();
+}

--- a/test/OpenApiTests/DocComments/Space.cs
+++ b/test/OpenApiTests/DocComments/Space.cs
@@ -18,6 +18,12 @@ public sealed class Space : Identifiable<long>
     public int FloorNumber { get; set; }
 
     /// <summary>
+    /// The kind of this space.
+    /// </summary>
+    [Attr]
+    public SpaceKind Kind { get; set; }
+
+    /// <summary>
     /// The skyscraper this space exists in.
     /// </summary>
     [HasOne]

--- a/test/OpenApiTests/DocComments/Space.cs
+++ b/test/OpenApiTests/DocComments/Space.cs
@@ -1,0 +1,25 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace OpenApiTests.DocComments;
+
+/// <summary>
+/// A space within a skyscraper, such as an office, hotel, residential space, or retail space.
+/// </summary>
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "OpenApiTests.DocComments")]
+public sealed class Space : Identifiable<long>
+{
+    /// <summary>
+    /// The floor number on which this space resides.
+    /// </summary>
+    [Attr]
+    public int FloorNumber { get; set; }
+
+    /// <summary>
+    /// The skyscraper this space exists in.
+    /// </summary>
+    [HasOne]
+    public Skyscraper ExistsIn { get; set; } = null!;
+}

--- a/test/OpenApiTests/DocComments/SpaceKind.cs
+++ b/test/OpenApiTests/DocComments/SpaceKind.cs
@@ -1,0 +1,15 @@
+using JetBrains.Annotations;
+
+namespace OpenApiTests.DocComments;
+
+/// <summary>
+/// Lists the various kinds of spaces within a skyscraper.
+/// </summary>
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+public enum SpaceKind
+{
+    Office,
+    Hotel,
+    Residential,
+    Retail
+}

--- a/test/OpenApiTests/LegacyOpenApiIntegration/Airline.cs
+++ b/test/OpenApiTests/LegacyOpenApiIntegration/Airline.cs
@@ -2,6 +2,9 @@ using JetBrains.Annotations;
 
 namespace OpenApiTests.LegacyOpenApiIntegration;
 
+/// <summary>
+/// Lists the various airlines used in this API.
+/// </summary>
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
 public enum Airline : byte
 {

--- a/test/OpenApiTests/LegacyOpenApiIntegration/Airplane.cs
+++ b/test/OpenApiTests/LegacyOpenApiIntegration/Airplane.cs
@@ -23,6 +23,9 @@ public sealed class Airplane : Identifiable<string>
     [Attr(Capabilities = AttrCapabilities.AllowView | AttrCapabilities.AllowCreate | AttrCapabilities.AllowChange)]
     public DateTime? LastServicedAt { get; set; }
 
+    /// <summary>
+    /// Gets the day on which this airplane was manufactured.
+    /// </summary>
     [Attr]
     public DateTime ManufacturedAt { get; set; }
 

--- a/test/OpenApiTests/LegacyOpenApiIntegration/LegacyOpenApiIntegrationTests.cs
+++ b/test/OpenApiTests/LegacyOpenApiIntegration/LegacyOpenApiIntegrationTests.cs
@@ -14,7 +14,7 @@ public sealed class LegacyOpenApiIntegrationTests : OpenApiTestContext<LegacyOpe
         UseController<FlightsController>();
         UseController<FlightAttendantsController>();
 
-        SwaggerDocumentOutputPath = "test/OpenApiClientTests/LegacyClient";
+        SwaggerDocumentOutputDirectory = "test/OpenApiClientTests/LegacyClient";
     }
 
     [Fact]

--- a/test/OpenApiTests/LegacyOpenApiIntegration/swagger.json
+++ b/test/OpenApiTests/LegacyOpenApiIntegration/swagger.json
@@ -10,10 +10,11 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves a collection of airplanes.",
         "operationId": "get-airplane-collection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found airplanes, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -28,17 +29,12 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves a collection of airplanes without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-airplane-collection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/airplane-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -46,8 +42,10 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Creates a new airplane.",
         "operationId": "post-airplane",
         "requestBody": {
+          "description": "The attributes and relationships of the airplane to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -58,7 +56,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The airplane was successfully created, which resulted in additional changes. The newly created airplane is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -68,7 +66,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The airplane was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -78,11 +85,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves an individual airplane by its identifier.",
         "operationId": "get-airplane",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -91,7 +100,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found airplane.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -99,6 +108,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       },
@@ -106,11 +118,14 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves an individual airplane by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-airplane",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -119,14 +134,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/airplane-primary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       },
@@ -134,11 +145,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Updates an existing airplane.",
         "operationId": "patch-airplane",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane to update.",
             "required": true,
             "schema": {
               "type": "string"
@@ -146,6 +159,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the airplane to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -156,7 +170,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The airplane was successfully updated, which resulted in additional changes. The updated airplane is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -166,7 +180,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The airplane was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The airplane or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -174,11 +200,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Deletes an existing airplane by its identifier.",
         "operationId": "delete-airplane",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane to delete.",
             "required": true,
             "schema": {
               "type": "string"
@@ -187,7 +215,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The airplane was successfully deleted."
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       }
@@ -197,11 +228,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves the related flights of an individual airplane's flights relationship.",
         "operationId": "get-airplane-flights",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane whose related flights to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -210,7 +243,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flights, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -218,6 +251,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       },
@@ -225,11 +261,14 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves the related flights of an individual airplane's flights relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-airplane-flights",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane whose related flights to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -238,14 +277,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       }
@@ -255,11 +290,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves the related flight identities of an individual airplane's flights relationship.",
         "operationId": "get-airplane-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane whose related flight identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -268,7 +305,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -276,6 +313,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       },
@@ -283,11 +323,14 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Retrieves the related flight identities of an individual airplane's flights relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-airplane-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane whose related flight identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -296,14 +339,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-identifier-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The airplane does not exist."
           }
         }
       },
@@ -311,11 +350,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Adds existing flights to the flights relationship of an individual airplane.",
         "operationId": "post-airplane-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane to add flights to.",
             "required": true,
             "schema": {
               "type": "string"
@@ -323,6 +364,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to add to the flights relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -333,7 +375,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The airplane does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -341,11 +392,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Assigns existing flights to the flights relationship of an individual airplane.",
         "operationId": "patch-airplane-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane whose flights relationship to assign.",
             "required": true,
             "schema": {
               "type": "string"
@@ -353,6 +406,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to assign to the flights relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -363,7 +417,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The airplane does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -371,11 +434,13 @@
         "tags": [
           "airplanes"
         ],
+        "summary": "Removes existing flights from the flights relationship of an individual airplane.",
         "operationId": "delete-airplane-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the airplane to remove flights from.",
             "required": true,
             "schema": {
               "type": "string"
@@ -383,6 +448,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to remove from the flights relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -393,7 +459,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The airplane does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -403,10 +478,11 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves a collection of flight-attendants.",
         "operationId": "get-flight-attendant-collection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendants, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -421,17 +497,12 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves a collection of flight-attendants without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-attendant-collection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-attendant-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -439,8 +510,10 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Creates a new flight-attendant.",
         "operationId": "post-flight-attendant",
         "requestBody": {
+          "description": "The attributes and relationships of the flight-attendant to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -451,7 +524,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The flight-attendant was successfully created, which resulted in additional changes. The newly created flight-attendant is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -461,7 +534,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The flight-attendant was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -471,11 +553,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves an individual flight-attendant by its identifier.",
         "operationId": "get-flight-attendant",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -484,7 +568,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendant.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -492,6 +576,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -499,11 +586,14 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves an individual flight-attendant by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-attendant",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -512,14 +602,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-attendant-primary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -527,11 +613,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Updates an existing flight-attendant.",
         "operationId": "patch-flight-attendant",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to update.",
             "required": true,
             "schema": {
               "type": "string"
@@ -539,6 +627,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the flight-attendant to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -549,7 +638,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The flight-attendant was successfully updated, which resulted in additional changes. The updated flight-attendant is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -559,7 +648,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The flight-attendant was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -567,11 +668,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Deletes an existing flight-attendant by its identifier.",
         "operationId": "delete-flight-attendant",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to delete.",
             "required": true,
             "schema": {
               "type": "string"
@@ -580,7 +683,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flight-attendant was successfully deleted."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       }
@@ -590,11 +696,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flights of an individual flight-attendant's purser-on-flights relationship.",
         "operationId": "get-flight-attendant-purser-on-flights",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flights to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -603,7 +711,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flights, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -611,6 +719,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -618,11 +729,14 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flights of an individual flight-attendant's purser-on-flights relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-attendant-purser-on-flights",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flights to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -631,14 +745,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       }
@@ -648,11 +758,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flight identities of an individual flight-attendant's purser-on-flights relationship.",
         "operationId": "get-flight-attendant-purser-on-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flight identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -661,7 +773,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -669,6 +781,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -676,11 +791,14 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flight identities of an individual flight-attendant's purser-on-flights relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-attendant-purser-on-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flight identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -689,14 +807,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-identifier-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -704,11 +818,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Adds existing flights to the purser-on-flights relationship of an individual flight-attendant.",
         "operationId": "post-flight-attendant-purser-on-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to add flights to.",
             "required": true,
             "schema": {
               "type": "string"
@@ -716,6 +832,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to add to the purser-on-flights relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -726,7 +843,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -734,11 +860,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Assigns existing flights to the purser-on-flights relationship of an individual flight-attendant.",
         "operationId": "patch-flight-attendant-purser-on-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose purser-on-flights relationship to assign.",
             "required": true,
             "schema": {
               "type": "string"
@@ -746,6 +874,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to assign to the purser-on-flights relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -756,7 +885,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The purser-on-flights relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -764,11 +902,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Removes existing flights from the purser-on-flights relationship of an individual flight-attendant.",
         "operationId": "delete-flight-attendant-purser-on-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to remove flights from.",
             "required": true,
             "schema": {
               "type": "string"
@@ -776,6 +916,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to remove from the purser-on-flights relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -786,7 +927,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -796,11 +946,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flights of an individual flight-attendant's scheduled-for-flights relationship.",
         "operationId": "get-flight-attendant-scheduled-for-flights",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flights to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -809,7 +961,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flights, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -817,6 +969,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -824,11 +979,14 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flights of an individual flight-attendant's scheduled-for-flights relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-attendant-scheduled-for-flights",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flights to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -837,14 +995,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       }
@@ -854,11 +1008,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flight identities of an individual flight-attendant's scheduled-for-flights relationship.",
         "operationId": "get-flight-attendant-scheduled-for-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flight identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -867,7 +1023,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -875,6 +1031,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -882,11 +1041,14 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Retrieves the related flight identities of an individual flight-attendant's scheduled-for-flights relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-attendant-scheduled-for-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose related flight identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -895,14 +1057,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-identifier-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
           }
         }
       },
@@ -910,11 +1068,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Adds existing flights to the scheduled-for-flights relationship of an individual flight-attendant.",
         "operationId": "post-flight-attendant-scheduled-for-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to add flights to.",
             "required": true,
             "schema": {
               "type": "string"
@@ -922,6 +1082,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to add to the scheduled-for-flights relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -932,7 +1093,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -940,11 +1110,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Assigns existing flights to the scheduled-for-flights relationship of an individual flight-attendant.",
         "operationId": "patch-flight-attendant-scheduled-for-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant whose scheduled-for-flights relationship to assign.",
             "required": true,
             "schema": {
               "type": "string"
@@ -952,6 +1124,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to assign to the scheduled-for-flights relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -962,7 +1135,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The scheduled-for-flights relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -970,11 +1152,13 @@
         "tags": [
           "flight-attendants"
         ],
+        "summary": "Removes existing flights from the scheduled-for-flights relationship of an individual flight-attendant.",
         "operationId": "delete-flight-attendant-scheduled-for-flights-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight-attendant to remove flights from.",
             "required": true,
             "schema": {
               "type": "string"
@@ -982,6 +1166,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flights to remove from the scheduled-for-flights relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -992,7 +1177,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flights were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight-attendant does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -1002,10 +1196,11 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves a collection of flights.",
         "operationId": "get-flight-collection",
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flights, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1020,17 +1215,12 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves a collection of flights without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-collection",
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
           }
         }
       },
@@ -1038,8 +1228,10 @@
         "tags": [
           "flights"
         ],
+        "summary": "Creates a new flight.",
         "operationId": "post-flight",
         "requestBody": {
+          "description": "The attributes and relationships of the flight to create.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1050,7 +1242,7 @@
         },
         "responses": {
           "201": {
-            "description": "Created",
+            "description": "The flight was successfully created, which resulted in additional changes. The newly created flight is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1060,7 +1252,16 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The flight was successfully created, which did not result in additional changes."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       }
@@ -1070,11 +1271,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves an individual flight by its identifier.",
         "operationId": "get-flight",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1083,7 +1286,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1091,6 +1294,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1098,11 +1304,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves an individual flight by its identifier without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1111,14 +1320,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-primary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1126,11 +1331,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Updates an existing flight.",
         "operationId": "patch-flight",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to update.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1138,6 +1345,7 @@
           }
         ],
         "requestBody": {
+          "description": "The attributes and relationships of the flight to update. Omitted fields are left unchanged.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1148,7 +1356,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The flight was successfully updated, which resulted in additional changes. The updated flight is returned.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1158,7 +1366,19 @@
             }
           },
           "204": {
-            "description": "No Content"
+            "description": "The flight was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight or a related resource does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type or identifier in the request body is incompatible."
+          },
+          "422": {
+            "description": "Validation of the request body failed."
           }
         }
       },
@@ -1166,11 +1386,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Deletes an existing flight by its identifier.",
         "operationId": "delete-flight",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to delete.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1179,7 +1401,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flight was successfully deleted."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       }
@@ -1189,11 +1414,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant of an individual flight's backup-purser relationship.",
         "operationId": "get-flight-backup-purser",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1202,7 +1429,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendant, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1210,6 +1437,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1217,11 +1447,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant of an individual flight's backup-purser relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-backup-purser",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1230,14 +1463,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullable-flight-attendant-secondary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       }
@@ -1247,11 +1476,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant identity of an individual flight's backup-purser relationship.",
         "operationId": "get-flight-backup-purser-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant identity to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1260,7 +1491,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendant identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1268,6 +1499,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1275,11 +1509,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant identity of an individual flight's backup-purser relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-backup-purser-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant identity to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1288,14 +1525,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/nullable-flight-attendant-identifier-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1303,11 +1536,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Clears or assigns an existing flight-attendant to the backup-purser relationship of an individual flight.",
         "operationId": "patch-flight-backup-purser-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose backup-purser relationship to assign or clear.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1315,6 +1550,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the flight-attendant to assign to the backup-purser relationship, or `null` to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1325,7 +1561,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The backup-purser relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -1335,11 +1580,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendants of an individual flight's cabin-crew-members relationship.",
         "operationId": "get-flight-cabin-crew-members",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendants to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1348,7 +1595,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendants, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1356,6 +1603,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1363,11 +1613,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendants of an individual flight's cabin-crew-members relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-cabin-crew-members",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendants to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1376,14 +1629,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-attendant-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       }
@@ -1393,11 +1642,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant identities of an individual flight's cabin-crew-members relationship.",
         "operationId": "get-flight-cabin-crew-members-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1406,7 +1657,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendant identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1414,6 +1665,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1421,11 +1675,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant identities of an individual flight's cabin-crew-members relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-cabin-crew-members-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1434,14 +1691,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-attendant-identifier-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1449,11 +1702,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Adds existing flight-attendants to the cabin-crew-members relationship of an individual flight.",
         "operationId": "post-flight-cabin-crew-members-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to add flight-attendants to.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1461,6 +1716,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flight-attendants to add to the cabin-crew-members relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1471,7 +1727,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flight-attendants were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -1479,11 +1744,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Assigns existing flight-attendants to the cabin-crew-members relationship of an individual flight.",
         "operationId": "patch-flight-cabin-crew-members-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose cabin-crew-members relationship to assign.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1491,6 +1758,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flight-attendants to assign to the cabin-crew-members relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1501,7 +1769,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The cabin-crew-members relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -1509,11 +1786,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Removes existing flight-attendants from the cabin-crew-members relationship of an individual flight.",
         "operationId": "delete-flight-cabin-crew-members-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to remove flight-attendants from.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1521,6 +1800,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the flight-attendants to remove from the cabin-crew-members relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1531,7 +1811,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The flight-attendants were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -1541,11 +1830,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related passengers of an individual flight's passengers relationship.",
         "operationId": "get-flight-passengers",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related passengers to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1554,7 +1845,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found passengers, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1562,6 +1853,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1569,11 +1863,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related passengers of an individual flight's passengers relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-passengers",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related passengers to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1582,14 +1879,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/passenger-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       }
@@ -1599,11 +1892,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related passenger identities of an individual flight's passengers relationship.",
         "operationId": "get-flight-passengers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related passenger identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1612,7 +1907,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found passenger identities, or an empty array if none were found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1620,6 +1915,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1627,11 +1925,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related passenger identities of an individual flight's passengers relationship without returning them.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-passengers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related passenger identities to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1640,14 +1941,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/passenger-identifier-collection-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1655,11 +1952,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Adds existing passengers to the passengers relationship of an individual flight.",
         "operationId": "post-flight-passengers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to add passengers to.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1667,6 +1966,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the passengers to add to the passengers relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1677,7 +1977,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The passengers were successfully added, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -1685,11 +1994,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Assigns existing passengers to the passengers relationship of an individual flight.",
         "operationId": "patch-flight-passengers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose passengers relationship to assign.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1697,6 +2008,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the passengers to assign to the passengers relationship, or an empty array to clear the relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1707,7 +2019,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The passengers relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       },
@@ -1715,11 +2036,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Removes existing passengers from the passengers relationship of an individual flight.",
         "operationId": "delete-flight-passengers-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight to remove passengers from.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1727,6 +2050,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identities of the passengers to remove from the passengers relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1737,7 +2061,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The passengers were successfully removed, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }
@@ -1747,11 +2080,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant of an individual flight's purser relationship.",
         "operationId": "get-flight-purser",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1760,7 +2095,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendant, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1768,6 +2103,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1775,11 +2113,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant of an individual flight's purser relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-purser",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1788,14 +2129,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-attendant-secondary-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       }
@@ -1805,11 +2142,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant identity of an individual flight's purser relationship.",
         "operationId": "get-flight-purser-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant identity to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1818,7 +2157,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Successfully returns the found flight-attendant identity, or `null` if it was not found.",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -1826,6 +2165,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1833,11 +2175,14 @@
         "tags": [
           "flights"
         ],
+        "summary": "Retrieves the related flight-attendant identity of an individual flight's purser relationship without returning it.",
+        "description": "Compare the returned ETag HTTP header with an earlier one to determine if the response has changed since it was fetched.",
         "operationId": "head-flight-purser-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose related flight-attendant identity to retrieve.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1846,14 +2191,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "content": {
-              "application/vnd.api+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/flight-attendant-identifier-response-document"
-                }
-              }
-            }
+            "description": "The operation completed successfully."
+          },
+          "404": {
+            "description": "The flight does not exist."
           }
         }
       },
@@ -1861,11 +2202,13 @@
         "tags": [
           "flights"
         ],
+        "summary": "Assigns an existing flight-attendant to the purser relationship of an individual flight.",
         "operationId": "patch-flight-purser-relationship",
         "parameters": [
           {
             "name": "id",
             "in": "path",
+            "description": "The identifier of the flight whose purser relationship to assign.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1873,6 +2216,7 @@
           }
         ],
         "requestBody": {
+          "description": "The identity of the flight-attendant to assign to the purser relationship.",
           "content": {
             "application/vnd.api+json": {
               "schema": {
@@ -1883,7 +2227,16 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "The purser relationship was successfully updated, which did not result in additional changes."
+          },
+          "404": {
+            "description": "The flight does not exist."
+          },
+          "400": {
+            "description": "The request body is missing or malformed."
+          },
+          "409": {
+            "description": "A resource type in the request body is incompatible."
           }
         }
       }

--- a/test/OpenApiTests/LegacyOpenApiIntegration/swagger.json
+++ b/test/OpenApiTests/LegacyOpenApiIntegration/swagger.json
@@ -2259,7 +2259,8 @@
           "LufthansaGroup",
           "AirFranceKlm"
         ],
-        "type": "string"
+        "type": "string",
+        "description": "Lists the various airlines used in this API."
       },
       "airplane-attributes-in-patch-request": {
         "type": "object",
@@ -2349,6 +2350,7 @@
           },
           "manufactured-at": {
             "type": "string",
+            "description": "Gets the day on which this airplane was manufactured.",
             "format": "date-time"
           },
           "is-in-maintenance": {

--- a/test/OpenApiTests/LegacyOpenApiIntegration/swagger.json
+++ b/test/OpenApiTests/LegacyOpenApiIntegration/swagger.json
@@ -76,6 +76,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }
@@ -544,6 +547,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }
@@ -1262,6 +1268,9 @@
           },
           "422": {
             "description": "Validation of the request body failed."
+          },
+          "403": {
+            "description": "Client-generated IDs cannot be used at this endpoint."
           }
         }
       }

--- a/test/OpenApiTests/NamingConventions/CamelCase/CamelCaseTests.cs
+++ b/test/OpenApiTests/NamingConventions/CamelCase/CamelCaseTests.cs
@@ -13,7 +13,7 @@ public sealed class CamelCaseTests : IClassFixture<OpenApiTestContext<CamelCaseN
         _testContext = testContext;
 
         testContext.UseController<SupermarketsController>();
-        testContext.SwaggerDocumentOutputPath = "test/OpenApiClientTests/NamingConventions/CamelCase";
+        testContext.SwaggerDocumentOutputDirectory = "test/OpenApiClientTests/NamingConventions/CamelCase";
     }
 
     [Fact]

--- a/test/OpenApiTests/NamingConventions/KebabCase/KebabCaseTests.cs
+++ b/test/OpenApiTests/NamingConventions/KebabCase/KebabCaseTests.cs
@@ -13,7 +13,7 @@ public sealed class KebabCaseTests : IClassFixture<OpenApiTestContext<KebabCaseN
         _testContext = testContext;
 
         testContext.UseController<SupermarketsController>();
-        testContext.SwaggerDocumentOutputPath = "test/OpenApiClientTests/NamingConventions/KebabCase";
+        testContext.SwaggerDocumentOutputDirectory = "test/OpenApiClientTests/NamingConventions/KebabCase";
     }
 
     [Fact]

--- a/test/OpenApiTests/NamingConventions/PascalCase/PascalCaseTests.cs
+++ b/test/OpenApiTests/NamingConventions/PascalCase/PascalCaseTests.cs
@@ -14,7 +14,7 @@ public sealed class PascalCaseTests
         _testContext = testContext;
 
         testContext.UseController<SupermarketsController>();
-        testContext.SwaggerDocumentOutputPath = "test/OpenApiClientTests/NamingConventions/PascalCase";
+        testContext.SwaggerDocumentOutputDirectory = "test/OpenApiClientTests/NamingConventions/PascalCase";
     }
 
     [Fact]

--- a/test/OpenApiTests/OpenApiStartup.cs
+++ b/test/OpenApiTests/OpenApiStartup.cs
@@ -2,6 +2,7 @@ using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.OpenApi;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Swashbuckle.AspNetCore.SwaggerGen;
 using TestBuildingBlocks;
 
 namespace OpenApiTests;
@@ -15,7 +16,11 @@ public class OpenApiStartup<TDbContext> : TestableStartup<TDbContext>
 
         services.AddJsonApi<TDbContext>(SetJsonApiOptions, mvcBuilder: mvcBuilder);
 
-        services.AddOpenApi(mvcBuilder);
+        services.AddOpenApi(mvcBuilder, SetupSwaggerGenAction);
+    }
+
+    protected virtual void SetupSwaggerGenAction(SwaggerGenOptions options)
+    {
     }
 
     public override void Configure(IApplicationBuilder app)

--- a/test/OpenApiTests/OpenApiStartup.cs
+++ b/test/OpenApiTests/OpenApiStartup.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.OpenApi;
 using Microsoft.AspNetCore.Builder;
@@ -21,6 +22,8 @@ public class OpenApiStartup<TDbContext> : TestableStartup<TDbContext>
 
     protected virtual void SetupSwaggerGenAction(SwaggerGenOptions options)
     {
+        string documentationPath = Path.ChangeExtension(Assembly.GetExecutingAssembly().Location, ".xml");
+        options.IncludeXmlComments(documentationPath);
     }
 
     public override void Configure(IApplicationBuilder app)

--- a/test/OpenApiTests/OpenApiTestContext.cs
+++ b/test/OpenApiTests/OpenApiTestContext.cs
@@ -12,7 +12,7 @@ public class OpenApiTestContext<TStartup, TDbContext> : IntegrationTestContext<T
 {
     private readonly Lazy<Task<JsonElement>> _lazySwaggerDocument;
 
-    internal string? SwaggerDocumentOutputPath { private get; set; }
+    internal string? SwaggerDocumentOutputDirectory { private get; set; }
 
     public OpenApiTestContext()
     {
@@ -30,9 +30,9 @@ public class OpenApiTestContext<TStartup, TDbContext> : IntegrationTestContext<T
 
         JsonElement rootElement = ParseSwaggerDocument(content);
 
-        if (SwaggerDocumentOutputPath != null)
+        if (SwaggerDocumentOutputDirectory != null)
         {
-            string absoluteOutputPath = GetSwaggerDocumentAbsoluteOutputPath(SwaggerDocumentOutputPath);
+            string absoluteOutputPath = GetSwaggerDocumentAbsoluteOutputPath(SwaggerDocumentOutputDirectory);
             await WriteToDiskAsync(absoluteOutputPath, rootElement);
         }
 

--- a/test/OpenApiTests/OpenApiTests.csproj
+++ b/test/OpenApiTests/OpenApiTests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(TargetFrameworkName)</TargetFramework>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/NullabilityTests.cs
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/NullabilityTests.cs
@@ -14,7 +14,7 @@ public sealed class NullabilityTests : IClassFixture<OpenApiTestContext<MsvOffSt
         _testContext = testContext;
 
         testContext.UseController<NrtOffResourcesController>();
-        testContext.SwaggerDocumentOutputPath = "test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff";
+        testContext.SwaggerDocumentOutputDirectory = "test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff";
     }
 
     [Theory]

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/NullabilityTests.cs
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/NullabilityTests.cs
@@ -14,7 +14,7 @@ public sealed class NullabilityTests : IClassFixture<OpenApiTestContext<OpenApiS
         _testContext = testContext;
 
         testContext.UseController<NrtOffResourcesController>();
-        testContext.SwaggerDocumentOutputPath = "test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn";
+        testContext.SwaggerDocumentOutputDirectory = "test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn";
     }
 
     [Theory]

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/NullabilityTests.cs
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/NullabilityTests.cs
@@ -14,7 +14,7 @@ public sealed class NullabilityTests : IClassFixture<OpenApiTestContext<MsvOffSt
         _testContext = testContext;
 
         testContext.UseController<NrtOnResourcesController>();
-        testContext.SwaggerDocumentOutputPath = "test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff";
+        testContext.SwaggerDocumentOutputDirectory = "test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff";
     }
 
     [Theory]

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/NullabilityTests.cs
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/NullabilityTests.cs
@@ -14,7 +14,7 @@ public sealed class NullabilityTests : IClassFixture<OpenApiTestContext<OpenApiS
         _testContext = testContext;
 
         testContext.UseController<NrtOnResourcesController>();
-        testContext.SwaggerDocumentOutputPath = "test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn";
+        testContext.SwaggerDocumentOutputDirectory = "test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn";
     }
 
     [Theory]

--- a/test/TestBuildingBlocks/JsonElementAssertionExtensions.cs
+++ b/test/TestBuildingBlocks/JsonElementAssertionExtensions.cs
@@ -116,6 +116,11 @@ public static class JsonElementAssertionExtensions
             }
         }
 
+        public void HaveProperty(string propertyName, string propertyValue)
+        {
+            _subject.Should().ContainPath(propertyName).With(element => element.Should().Be(propertyValue));
+        }
+
         public void ContainArrayElement(string value)
         {
             _subject.ValueKind.Should().Be(JsonValueKind.Array);


### PR DESCRIPTION
This PR adds auto-generated documentation for JSON:API endpoints, resource types, and attributes to the OAS file. Comments on relationships are currently ignored, due to a limitation in OAS 3.0. This can likely be worked around by using `allOf` operators. The same limitation applies to attributes of enum types.

The comments on endpoints (expanded controller action methods) are hardcoded. Triple-slash comments on resource classes and their properties are extracted by loading the `.xml` file next to their assembly. Add `<GenerateDocumentationFile>true</GenerateDocumentationFile>` to your project file to make this work. To get additional documentation, such as triple-slash comments on enum types, call `SwaggerGenOptions.IncludeXmlComments()` as described [here](https://github.com/domaindrivendev/Swashbuckle.AspNetCore#include-descriptions-from-xml-comments).

Adding partial controllers to your project and decorating the action methods with custom triple-slash comments is possible. They will override the hardcoded descriptions, but to a certain degree. It won't work for endpoints that take a relationship name, due to relationship expansion at runtime.

Additionally, this PR adds in all the applicable HTTP status codes that JsonApiDotNetCore returns per endpoint. And it fixes the bug where response bodies are shown for HEAD requests.

## Demo

Screenshots below for an API comprising of skyscrapers, spaces, and elevators.

### Endpoints

![image](https://github.com/json-api-dotnet/JsonApiDotNetCore/assets/10324372/4e308b04-b3b4-4216-829e-086891a2560b)

### Parameters and response codes

![image](https://github.com/json-api-dotnet/JsonApiDotNetCore/assets/10324372/96b7c224-5135-4a10-881e-13728af32139)

### Triple-slash comments from resource type and attributes

```c#
/// <summary>
/// A tall, continuously habitable building having multiple floors.
/// </summary>
[UsedImplicitly(ImplicitUseTargetFlags.Members)]
[Resource]
public sealed class Skyscraper : Identifiable<long>
{
    /// <summary>
    /// The height of this building, in meters.
    /// </summary>
    [Attr]
    [Required]
    public int? HeightInMeters { get; set; }

    /// <summary>
    /// An optional elevator within this building, providing access to spaces.
    /// </summary>
    [HasOne]
    public Elevator? Elevator { get; set; }

    /// <summary>
    /// The spaces within this building.
    /// </summary>
    [HasMany]
    public ISet<Space> Spaces { get; set; } = new HashSet<Space>();
}
```

![image](https://github.com/json-api-dotnet/JsonApiDotNetCore/assets/10324372/de0542c8-f118-4882-bc28-a07368b96379)

### IntelliSense on generated C# client

![image](https://github.com/json-api-dotnet/JsonApiDotNetCore/assets/10324372/1bd65d4e-e29f-457f-8328-c4920bd8a9a3)

![image](https://github.com/json-api-dotnet/JsonApiDotNetCore/assets/10324372/eeb4a455-9c7f-43a8-8b96-5ff90930d25b)

Closes #1053.
Fixes #1369.
Fixes #1368.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [x] NA: Documentation updated
