### PR TITLE
Try workaround for flaky network in GitHub hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Tune GitHub-hosted runner network
+      uses: smorimoto/tune-github-hosted-runner-network@v1
     - name: Setup PostgreSQL
       uses: ikalnytskyi/action-setup-postgres@v4
       with:
@@ -181,6 +183,8 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Tune GitHub-hosted runner network
+      uses: smorimoto/tune-github-hosted-runner-network@v1
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
@@ -234,6 +238,8 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Tune GitHub-hosted runner network
+      uses: smorimoto/tune-github-hosted-runner-network@v1
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
@@ -277,6 +283,8 @@ jobs:
       packages: write
       contents: write
     steps:
+    - name: Tune GitHub-hosted runner network
+      uses: smorimoto/tune-github-hosted-runner-network@v1
     - name: Download artifacts
       uses: actions/download-artifact@v3
     - name: Publish to GitHub Packages


### PR DESCRIPTION
We often see macOS builds timeout when contacting localhost during documentation generation.

This is one of the workarounds mentioned at https://github.com/actions/runner-images/issues/1187, so let's see if it helps...

Builds completed:
- [x] 1
- [x] 2
- [x] 3
- [x] 4
- [x] 5
- [x] 6
- [x] 7
- [x] 8
- [x] 9
- [x] 10

#### QUALITY CHECKLIST
- [ ] Changes implemented in code
- [ ] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] Adapted tests
- [ ] Documentation updated
