### PR TITLE
Update Resharper to RC1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2023.3.0-eap08",
+      "version": "2023.3.0-rc01",
       "commands": [
         "jb"
       ]

--- a/test/JsonApiDotNetCoreTests/UnitTests/Configuration/DependencyContainerRegistrationTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Configuration/DependencyContainerRegistrationTests.cs
@@ -15,9 +15,6 @@ using Microsoft.Extensions.Primitives;
 using TestBuildingBlocks;
 using Xunit;
 
-// Workaround for Resharper bug at https://youtrack.jetbrains.com/issue/RSRP-494909/Breaking-UsedImplicitly-and-PublicAPI-on-types-no-longer-respected.
-// ReSharper disable PropertyCanBeMadeInitOnly.Local
-
 namespace JsonApiDotNetCoreTests.UnitTests.Configuration;
 
 public sealed class DependencyContainerRegistrationTests

--- a/test/JsonApiDotNetCoreTests/UnitTests/FieldChains/FieldChainPatternInheritanceMatchTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/FieldChains/FieldChainPatternInheritanceMatchTests.cs
@@ -10,9 +10,6 @@ using TestBuildingBlocks;
 using Xunit;
 using Xunit.Abstractions;
 
-// Workaround for Resharper bug at https://youtrack.jetbrains.com/issue/RSRP-494909/Breaking-UsedImplicitly-and-PublicAPI-on-types-no-longer-respected.
-// ReSharper disable PropertyCanBeMadeInitOnly.Local
-
 // ReSharper disable InconsistentNaming
 #pragma warning disable AV1706 // Identifier contains an abbreviation or is too short
 

--- a/test/JsonApiDotNetCoreTests/UnitTests/FieldChains/FieldChainPatternMatchTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/FieldChains/FieldChainPatternMatchTests.cs
@@ -10,9 +10,6 @@ using TestBuildingBlocks;
 using Xunit;
 using Xunit.Abstractions;
 
-// Workaround for Resharper bug at https://youtrack.jetbrains.com/issue/RSRP-494909/Breaking-UsedImplicitly-and-PublicAPI-on-types-no-longer-respected.
-// ReSharper disable PropertyCanBeMadeInitOnly.Local
-
 // ReSharper disable InconsistentNaming
 #pragma warning disable AV1706 // Identifier contains an abbreviation or is too short
 

--- a/test/JsonApiDotNetCoreTests/UnitTests/Middleware/JsonApiMiddlewareTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Middleware/JsonApiMiddlewareTests.cs
@@ -13,9 +13,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using TestBuildingBlocks;
 using Xunit;
 
-// Workaround for Resharper bug at https://youtrack.jetbrains.com/issue/RSRP-494909/Breaking-UsedImplicitly-and-PublicAPI-on-types-no-longer-respected.
-// ReSharper disable PropertyCanBeMadeInitOnly.Local
-
 #pragma warning disable AV1561 // Signature contains too many parameters
 
 namespace JsonApiDotNetCoreTests.UnitTests.Middleware;

--- a/test/JsonApiDotNetCoreTests/UnitTests/ModelStateValidation/ModelStateValidationTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/ModelStateValidation/ModelStateValidationTests.cs
@@ -10,9 +10,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using TestBuildingBlocks;
 using Xunit;
 
-// Workaround for Resharper bug at https://youtrack.jetbrains.com/issue/RSRP-494909/Breaking-UsedImplicitly-and-PublicAPI-on-types-no-longer-respected.
-// ReSharper disable PropertyCanBeMadeInitOnly.Local
-
 namespace JsonApiDotNetCoreTests.UnitTests.ModelStateValidation;
 
 public sealed class ModelStateValidationTests

--- a/test/JsonApiDotNetCoreTests/UnitTests/ResourceDefinitions/CreateSortExpressionFromLambdaTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/ResourceDefinitions/CreateSortExpressionFromLambdaTests.cs
@@ -11,9 +11,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using TestBuildingBlocks;
 using Xunit;
 
-// Workaround for Resharper bug at https://youtrack.jetbrains.com/issue/RSRP-494909/Breaking-UsedImplicitly-and-PublicAPI-on-types-no-longer-respected.
-// ReSharper disable PropertyCanBeMadeInitOnly.Local
-
 namespace JsonApiDotNetCoreTests.UnitTests.ResourceDefinitions;
 
 public sealed class CreateSortExpressionFromLambdaTests

--- a/test/JsonApiDotNetCoreTests/UnitTests/ResourceGraph/ResourceGraphBuilderTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/ResourceGraph/ResourceGraphBuilderTests.cs
@@ -10,9 +10,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using TestBuildingBlocks;
 using Xunit;
 
-// Workaround for Resharper bug at https://youtrack.jetbrains.com/issue/RSRP-494909/Breaking-UsedImplicitly-and-PublicAPI-on-types-no-longer-respected.
-// ReSharper disable PropertyCanBeMadeInitOnly.Local
-
 namespace JsonApiDotNetCoreTests.UnitTests.ResourceGraph;
 
 public sealed class ResourceGraphBuilderTests

--- a/test/JsonApiDotNetCoreTests/UnitTests/Serialization/Response/IncompleteResourceGraphTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Serialization/Response/IncompleteResourceGraphTests.cs
@@ -10,9 +10,6 @@ using JsonApiDotNetCore.Serialization.Response;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-// Workaround for Resharper bug at https://youtrack.jetbrains.com/issue/RSRP-494909/Breaking-UsedImplicitly-and-PublicAPI-on-types-no-longer-respected.
-// ReSharper disable PropertyCanBeMadeInitOnly.Local
-
 namespace JsonApiDotNetCoreTests.UnitTests.Serialization.Response;
 
 public sealed class IncompleteResourceGraphTests

--- a/test/NoEntityFrameworkTests/NullSafeExpressionRewriterTests.cs
+++ b/test/NoEntityFrameworkTests/NullSafeExpressionRewriterTests.cs
@@ -6,9 +6,6 @@ using JsonApiDotNetCore.Resources.Annotations;
 using NoEntityFrameworkExample;
 using Xunit;
 
-// Workaround for Resharper bug at https://youtrack.jetbrains.com/issue/RSRP-494909/Breaking-UsedImplicitly-and-PublicAPI-on-types-no-longer-respected.
-// ReSharper disable PropertyCanBeMadeInitOnly.Local
-
 namespace NoEntityFrameworkTests;
 
 public sealed class NullSafeExpressionRewriterTests


### PR DESCRIPTION
Updates Resharper from 2023.3.0 EAP8 to RC1 and reverts some workarounds.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
