### PR TITLE
Reduce tests verbosity in cibuild

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,6 +127,13 @@ jobs:
       run: |
         dotnet build --no-restore --configuration Release /p:VersionSuffix=$env:PACKAGE_VERSION_SUFFIX
     - name: Test
+      env:
+        # Override log levels, to reduce logging output when running tests in ci-build.
+        Logging__LogLevel__Microsoft.Hosting.Lifetime: 'None'
+        Logging__LogLevel__Microsoft.AspNetCore.Hosting.Diagnostics: 'None'
+        Logging__LogLevel__Microsoft.Extensions.Hosting.Internal.Host: 'None'
+        Logging__LogLevel__Microsoft.EntityFrameworkCore.Database.Command: 'None'
+        Logging__LogLevel__JsonApiDotNetCore: 'None'
       run: |
         dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage" --logger "GitHubActions;summary.includeSkippedTests=true"
     - name: Upload coverage to codecov.io

--- a/test/DapperTests/IntegrationTests/DapperTestContext.cs
+++ b/test/DapperTests/IntegrationTests/DapperTestContext.cs
@@ -69,6 +69,10 @@ public sealed class DapperTestContext : IntegrationTest
             {
                 if (_testOutputHelper != null)
                 {
+#if !DEBUG
+                    // Reduce logging output when running tests in ci-build.
+                    loggingBuilder.ClearProviders();
+#endif
                     loggingBuilder.Services.AddSingleton<ILoggerProvider>(_ => new XUnitLoggerProvider(_testOutputHelper, "DapperExample."));
                 }
             });

--- a/test/TestBuildingBlocks/IntegrationTestContext.cs
+++ b/test/TestBuildingBlocks/IntegrationTestContext.cs
@@ -83,8 +83,8 @@ public class IntegrationTestContext<TStartup, TDbContext> : IntegrationTest
             });
         });
 
-        // We have placed an appsettings.json in the TestBuildingBlock project folder and set the content root to there. Note that controllers
-        // are not discovered in the content root but are registered manually using IntegrationTestContext.UseController.
+        // We have placed an appsettings.json in the TestBuildingBlocks project directory and set the content root to there. Note that
+        // controllers are not discovered in the content root, but are registered manually using IntegrationTestContext.UseController.
         WebApplicationFactory<TStartup> factoryWithConfiguredContentRoot =
             factory.WithWebHostBuilder(builder => builder.UseSolutionRelativeContentRoot($"test/{nameof(TestBuildingBlocks)}"));
 
@@ -161,8 +161,8 @@ public class IntegrationTestContext<TStartup, TDbContext> : IntegrationTest
                 .CreateDefaultBuilder(null)
                 .ConfigureAppConfiguration(builder =>
                 {
-                    // For tests asserting on log output, we discard the logging settings from appsettings.json.
-                    // But using appsettings.json for all other tests makes it easy to quickly toggle when debugging.
+                    // For tests asserting on log output, we discard the log levels from appsettings.json and environment variables.
+                    // But using appsettings.json for all other tests makes it easy to quickly toggle when debugging tests.
                     if (_loggingConfiguration != null)
                     {
                         builder.Sources.Clear();


### PR DESCRIPTION
This PR reduces logging output when running tests in ci-build, by setting environment variables that override log levels from appsettings.json.

#### QUALITY CHECKLIST
- [X] Changes implemented in code
- [X] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [X] Adapted tests
- [ ] N/A: Documentation updated