### PR TITLE
Remove building an intermediate service provider at startup

### DIFF
--- a/src/JsonApiDotNetCore/Configuration/InjectablesAssemblyScanner.cs
+++ b/src/JsonApiDotNetCore/Configuration/InjectablesAssemblyScanner.cs
@@ -1,0 +1,129 @@
+using System.Reflection;
+using JsonApiDotNetCore.Repositories;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace JsonApiDotNetCore.Configuration;
+
+/// <summary>
+/// Scans assemblies for injectables (types that implement <see cref="IResourceService{TResource,TId}" />,
+/// <see cref="IResourceRepository{TResource,TId}" /> or <see cref="IResourceDefinition{TResource,TId}" />) and registers them in the IoC container.
+/// </summary>
+internal sealed class InjectablesAssemblyScanner
+{
+    internal static readonly HashSet<Type> ServiceUnboundInterfaces =
+    [
+        typeof(IResourceService<,>),
+        typeof(IResourceCommandService<,>),
+        typeof(IResourceQueryService<,>),
+        typeof(IGetAllService<,>),
+        typeof(IGetByIdService<,>),
+        typeof(IGetSecondaryService<,>),
+        typeof(IGetRelationshipService<,>),
+        typeof(ICreateService<,>),
+        typeof(IAddToRelationshipService<,>),
+        typeof(IUpdateService<,>),
+        typeof(ISetRelationshipService<,>),
+        typeof(IDeleteService<,>),
+        typeof(IRemoveFromRelationshipService<,>)
+    ];
+
+    internal static readonly HashSet<Type> RepositoryUnboundInterfaces =
+    [
+        typeof(IResourceRepository<,>),
+        typeof(IResourceWriteRepository<,>),
+        typeof(IResourceReadRepository<,>)
+    ];
+
+    internal static readonly HashSet<Type> ResourceDefinitionUnboundInterfaces = [typeof(IResourceDefinition<,>)];
+
+    private readonly ResourceDescriptorAssemblyCache _assemblyCache;
+    private readonly IServiceCollection _services;
+    private readonly TypeLocator _typeLocator = new();
+
+    public InjectablesAssemblyScanner(ResourceDescriptorAssemblyCache assemblyCache, IServiceCollection services)
+    {
+        ArgumentGuard.NotNull(assemblyCache);
+        ArgumentGuard.NotNull(services);
+
+        _assemblyCache = assemblyCache;
+        _services = services;
+    }
+
+    public void DiscoverInjectables()
+    {
+        IReadOnlyCollection<ResourceDescriptor> descriptors = _assemblyCache.GetResourceDescriptors();
+        IReadOnlyCollection<Assembly> assemblies = _assemblyCache.GetAssemblies();
+
+        foreach (Assembly assembly in assemblies)
+        {
+            AddDbContextResolvers(assembly);
+            AddInjectables(descriptors, assembly);
+        }
+    }
+
+    private void AddDbContextResolvers(Assembly assembly)
+    {
+        IEnumerable<Type> dbContextTypes = _typeLocator.GetDerivedTypes(assembly, typeof(DbContext));
+
+        foreach (Type dbContextType in dbContextTypes)
+        {
+            Type dbContextResolverClosedType = typeof(DbContextResolver<>).MakeGenericType(dbContextType);
+            _services.TryAddScoped(typeof(IDbContextResolver), dbContextResolverClosedType);
+        }
+    }
+
+    private void AddInjectables(IEnumerable<ResourceDescriptor> resourceDescriptors, Assembly assembly)
+    {
+        foreach (ResourceDescriptor resourceDescriptor in resourceDescriptors)
+        {
+            AddServices(assembly, resourceDescriptor);
+            AddRepositories(assembly, resourceDescriptor);
+            AddResourceDefinitions(assembly, resourceDescriptor);
+        }
+    }
+
+    private void AddServices(Assembly assembly, ResourceDescriptor resourceDescriptor)
+    {
+        foreach (Type serviceUnboundInterface in ServiceUnboundInterfaces)
+        {
+            RegisterImplementations(assembly, serviceUnboundInterface, resourceDescriptor);
+        }
+    }
+
+    private void AddRepositories(Assembly assembly, ResourceDescriptor resourceDescriptor)
+    {
+        foreach (Type repositoryUnboundInterface in RepositoryUnboundInterfaces)
+        {
+            RegisterImplementations(assembly, repositoryUnboundInterface, resourceDescriptor);
+        }
+    }
+
+    private void AddResourceDefinitions(Assembly assembly, ResourceDescriptor resourceDescriptor)
+    {
+        foreach (Type resourceDefinitionUnboundInterface in ResourceDefinitionUnboundInterfaces)
+        {
+            RegisterImplementations(assembly, resourceDefinitionUnboundInterface, resourceDescriptor);
+        }
+    }
+
+    private void RegisterImplementations(Assembly assembly, Type interfaceType, ResourceDescriptor resourceDescriptor)
+    {
+        Type[] typeArguments =
+        [
+            resourceDescriptor.ResourceClrType,
+            resourceDescriptor.IdClrType
+        ];
+
+        (Type implementationType, Type serviceInterface)? result = _typeLocator.GetContainerRegistrationFromAssembly(assembly, interfaceType, typeArguments);
+
+        if (result != null)
+        {
+            (Type implementationType, Type serviceInterface) = result.Value;
+            _services.TryAddScoped(serviceInterface, implementationType);
+        }
+    }
+}

--- a/src/JsonApiDotNetCore/Configuration/ResourcesAssemblyScanner.cs
+++ b/src/JsonApiDotNetCore/Configuration/ResourcesAssemblyScanner.cs
@@ -1,0 +1,29 @@
+using JsonApiDotNetCore.Resources;
+
+namespace JsonApiDotNetCore.Configuration;
+
+/// <summary>
+/// Scans assemblies for types that implement <see cref="IIdentifiable{TId}" /> and adds them to the resource graph.
+/// </summary>
+internal sealed class ResourcesAssemblyScanner
+{
+    private readonly ResourceDescriptorAssemblyCache _assemblyCache;
+    private readonly ResourceGraphBuilder _resourceGraphBuilder;
+
+    public ResourcesAssemblyScanner(ResourceDescriptorAssemblyCache assemblyCache, ResourceGraphBuilder resourceGraphBuilder)
+    {
+        ArgumentGuard.NotNull(assemblyCache);
+        ArgumentGuard.NotNull(resourceGraphBuilder);
+
+        _assemblyCache = assemblyCache;
+        _resourceGraphBuilder = resourceGraphBuilder;
+    }
+
+    public void DiscoverResources()
+    {
+        foreach (ResourceDescriptor resourceDescriptor in _assemblyCache.GetResourceDescriptors())
+        {
+            _resourceGraphBuilder.Add(resourceDescriptor.ResourceClrType, resourceDescriptor.IdClrType);
+        }
+    }
+}

--- a/src/JsonApiDotNetCore/Configuration/ServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore/Configuration/ServiceCollectionExtensions.cs
@@ -43,7 +43,7 @@ public static class ServiceCollectionExtensions
         Action<ServiceDiscoveryFacade>? configureAutoDiscovery, Action<ResourceGraphBuilder>? configureResources, IMvcCoreBuilder? mvcBuilder,
         ICollection<Type> dbContextTypes)
     {
-        using var applicationBuilder = new JsonApiApplicationBuilder(services, mvcBuilder ?? services.AddMvcCore());
+        var applicationBuilder = new JsonApiApplicationBuilder(services, mvcBuilder ?? services.AddMvcCore());
 
         applicationBuilder.ConfigureJsonApiOptions(configureOptions);
         applicationBuilder.ConfigureAutoDiscovery(configureAutoDiscovery);
@@ -61,7 +61,7 @@ public static class ServiceCollectionExtensions
     {
         ArgumentGuard.NotNull(services);
 
-        RegisterTypeForUnboundInterfaces(services, typeof(TService), ServiceDiscoveryFacade.ServiceUnboundInterfaces);
+        RegisterTypeForUnboundInterfaces(services, typeof(TService), InjectablesAssemblyScanner.ServiceUnboundInterfaces);
 
         return services;
     }
@@ -74,7 +74,7 @@ public static class ServiceCollectionExtensions
     {
         ArgumentGuard.NotNull(services);
 
-        RegisterTypeForUnboundInterfaces(services, typeof(TRepository), ServiceDiscoveryFacade.RepositoryUnboundInterfaces);
+        RegisterTypeForUnboundInterfaces(services, typeof(TRepository), InjectablesAssemblyScanner.RepositoryUnboundInterfaces);
 
         return services;
     }
@@ -87,7 +87,7 @@ public static class ServiceCollectionExtensions
     {
         ArgumentGuard.NotNull(services);
 
-        RegisterTypeForUnboundInterfaces(services, typeof(TResourceDefinition), ServiceDiscoveryFacade.ResourceDefinitionUnboundInterfaces);
+        RegisterTypeForUnboundInterfaces(services, typeof(TResourceDefinition), InjectablesAssemblyScanner.ResourceDefinitionUnboundInterfaces);
 
         return services;
     }

--- a/src/JsonApiDotNetCore/Configuration/ServiceDiscoveryFacade.cs
+++ b/src/JsonApiDotNetCore/Configuration/ServiceDiscoveryFacade.cs
@@ -1,66 +1,23 @@
 using System.Reflection;
-using JetBrains.Annotations;
-using JsonApiDotNetCore.Repositories;
-using JsonApiDotNetCore.Resources;
-using JsonApiDotNetCore.Services;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 
 namespace JsonApiDotNetCore.Configuration;
 
 /// <summary>
-/// Scans for types like resources, services, repositories and resource definitions in an assembly and registers them to the IoC container.
+/// Provides auto-discovery by scanning assemblies for resources and related injectables.
 /// </summary>
-[PublicAPI]
 public sealed class ServiceDiscoveryFacade
 {
-    internal static readonly HashSet<Type> ServiceUnboundInterfaces =
-    [
-        typeof(IResourceService<,>),
-        typeof(IResourceCommandService<,>),
-        typeof(IResourceQueryService<,>),
-        typeof(IGetAllService<,>),
-        typeof(IGetByIdService<,>),
-        typeof(IGetSecondaryService<,>),
-        typeof(IGetRelationshipService<,>),
-        typeof(ICreateService<,>),
-        typeof(IAddToRelationshipService<,>),
-        typeof(IUpdateService<,>),
-        typeof(ISetRelationshipService<,>),
-        typeof(IDeleteService<,>),
-        typeof(IRemoveFromRelationshipService<,>)
-    ];
+    private readonly ResourceDescriptorAssemblyCache _assemblyCache;
 
-    internal static readonly HashSet<Type> RepositoryUnboundInterfaces =
-    [
-        typeof(IResourceRepository<,>),
-        typeof(IResourceWriteRepository<,>),
-        typeof(IResourceReadRepository<,>)
-    ];
-
-    internal static readonly HashSet<Type> ResourceDefinitionUnboundInterfaces = [typeof(IResourceDefinition<,>)];
-
-    private readonly ILogger<ServiceDiscoveryFacade> _logger;
-    private readonly IServiceCollection _services;
-    private readonly ResourceGraphBuilder _resourceGraphBuilder;
-    private readonly ResourceDescriptorAssemblyCache _assemblyCache = new();
-    private readonly TypeLocator _typeLocator = new();
-
-    public ServiceDiscoveryFacade(IServiceCollection services, ResourceGraphBuilder resourceGraphBuilder, ILoggerFactory loggerFactory)
+    internal ServiceDiscoveryFacade(ResourceDescriptorAssemblyCache assemblyCache)
     {
-        ArgumentGuard.NotNull(services);
-        ArgumentGuard.NotNull(resourceGraphBuilder);
-        ArgumentGuard.NotNull(loggerFactory);
+        ArgumentGuard.NotNull(assemblyCache);
 
-        _logger = loggerFactory.CreateLogger<ServiceDiscoveryFacade>();
-        _services = services;
-        _resourceGraphBuilder = resourceGraphBuilder;
+        _assemblyCache = assemblyCache;
     }
 
     /// <summary>
-    /// Mark the calling assembly for scanning of resources and injectables.
+    /// Includes the calling assembly for auto-discovery of resources and related injectables.
     /// </summary>
     public ServiceDiscoveryFacade AddCurrentAssembly()
     {
@@ -68,102 +25,13 @@ public sealed class ServiceDiscoveryFacade
     }
 
     /// <summary>
-    /// Mark the specified assembly for scanning of resources and injectables.
+    /// Includes the specified assembly for auto-discovery of resources and related injectables.
     /// </summary>
     public ServiceDiscoveryFacade AddAssembly(Assembly assembly)
     {
         ArgumentGuard.NotNull(assembly);
 
         _assemblyCache.RegisterAssembly(assembly);
-        _logger.LogDebug($"Registering assembly '{assembly.FullName}' for discovery of resources and injectables.");
-
         return this;
-    }
-
-    internal void DiscoverResources()
-    {
-        foreach (ResourceDescriptor resourceDescriptor in _assemblyCache.GetResourceDescriptors())
-        {
-            AddResource(resourceDescriptor);
-        }
-    }
-
-    internal void DiscoverInjectables()
-    {
-        IReadOnlyCollection<ResourceDescriptor> descriptors = _assemblyCache.GetResourceDescriptors();
-        IReadOnlyCollection<Assembly> assemblies = _assemblyCache.GetAssemblies();
-
-        foreach (Assembly assembly in assemblies)
-        {
-            AddDbContextResolvers(assembly);
-            AddInjectables(descriptors, assembly);
-        }
-    }
-
-    private void AddInjectables(IReadOnlyCollection<ResourceDescriptor> resourceDescriptors, Assembly assembly)
-    {
-        foreach (ResourceDescriptor resourceDescriptor in resourceDescriptors)
-        {
-            AddServices(assembly, resourceDescriptor);
-            AddRepositories(assembly, resourceDescriptor);
-            AddResourceDefinitions(assembly, resourceDescriptor);
-        }
-    }
-
-    private void AddDbContextResolvers(Assembly assembly)
-    {
-        IEnumerable<Type> dbContextTypes = _typeLocator.GetDerivedTypes(assembly, typeof(DbContext));
-
-        foreach (Type dbContextType in dbContextTypes)
-        {
-            Type dbContextResolverClosedType = typeof(DbContextResolver<>).MakeGenericType(dbContextType);
-            _services.TryAddScoped(typeof(IDbContextResolver), dbContextResolverClosedType);
-        }
-    }
-
-    private void AddResource(ResourceDescriptor resourceDescriptor)
-    {
-        _resourceGraphBuilder.Add(resourceDescriptor.ResourceClrType, resourceDescriptor.IdClrType);
-    }
-
-    private void AddServices(Assembly assembly, ResourceDescriptor resourceDescriptor)
-    {
-        foreach (Type serviceUnboundInterface in ServiceUnboundInterfaces)
-        {
-            RegisterImplementations(assembly, serviceUnboundInterface, resourceDescriptor);
-        }
-    }
-
-    private void AddRepositories(Assembly assembly, ResourceDescriptor resourceDescriptor)
-    {
-        foreach (Type repositoryUnboundInterface in RepositoryUnboundInterfaces)
-        {
-            RegisterImplementations(assembly, repositoryUnboundInterface, resourceDescriptor);
-        }
-    }
-
-    private void AddResourceDefinitions(Assembly assembly, ResourceDescriptor resourceDescriptor)
-    {
-        foreach (Type resourceDefinitionUnboundInterface in ResourceDefinitionUnboundInterfaces)
-        {
-            RegisterImplementations(assembly, resourceDefinitionUnboundInterface, resourceDescriptor);
-        }
-    }
-
-    private void RegisterImplementations(Assembly assembly, Type interfaceType, ResourceDescriptor resourceDescriptor)
-    {
-        Type[] typeArguments =
-        [
-            resourceDescriptor.ResourceClrType,
-            resourceDescriptor.IdClrType
-        ];
-
-        (Type implementationType, Type serviceInterface)? result = _typeLocator.GetContainerRegistrationFromAssembly(assembly, interfaceType, typeArguments);
-
-        if (result != null)
-        {
-            (Type implementationType, Type serviceInterface) = result.Value;
-            _services.TryAddScoped(serviceInterface, implementationType);
-        }
     }
 }


### PR DESCRIPTION
This PR removes building an intermediate service provider at startup, which is considered an anti-pattern, leading to occasional compatibility issues.

This unblocks use in [Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/) (more specifically, its usage of `AddNpgsqlDataSource`, which throws an `ObjectDisposedException`) and fixes #1082.

While `AddNpgsqlDataSource` (from the `Npgsql.DependencyInjection` NuGet package) works in a regular API project, it fails in our integration tests (tracked at https://github.com/npgsql/efcore.pg/issues/2542#issuecomment-1867016840).

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
