### PR TITLE
Remove unused PGPASSWORD environment variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,6 @@ concurrency:
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  # The Windows runner image has PostgreSQL pre-installed and sets the PGPASSWORD environment variable to "root".
-  # This conflicts with the default password "postgres", which is used by ikalnytskyi/action-setup-postgres.
-  # Because action-setup-postgres forgets to update the environment variable accordingly, we do so here.
-  PGPASSWORD: "postgres"
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Tune GitHub-hosted runner network
       uses: smorimoto/tune-github-hosted-runner-network@v1
     - name: Setup PostgreSQL
-      uses: ikalnytskyi/action-setup-postgres@v4
+      uses: ikalnytskyi/action-setup-postgres@v5
       with:
         username: postgres
         password: postgres


### PR DESCRIPTION
Removes special handling of the PGPASSWORD environment variable during cibuild. It was used with AppVeyor, but the code depending on that no longer exists.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
