### PR TITLE
OpenAPI: Fix "id" parameter in URL to be string

### DIFF
--- a/docs/usage/openapi-client.md
+++ b/docs/usage/openapi-client.md
@@ -94,7 +94,7 @@ The next steps describe how to generate a JSON:API client library and use our pa
         person => person.FirstName))
     {
         // Workaround for https://github.com/RicoSuter/NSwag/issues/2499.
-        await TranslateAsync(async () => await apiClient.PatchPersonAsync(1, null, patchRequest));
+        await TranslateAsync(async () => await apiClient.PatchPersonAsync(patchRequest.Data.Id, null, patchRequest));
 
         // The sent request looks like this:
         // {

--- a/src/Examples/JsonApiDotNetCoreExample/Properties/launchSettings.json
+++ b/src/Examples/JsonApiDotNetCoreExample/Properties/launchSettings.json
@@ -12,7 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "api/todoItems?include=owner,assignee,tags&filter=equals(priority,'High')",
+      "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -20,7 +20,7 @@
     "Kestrel": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/todoItems?include=owner,assignee,tags&filter=equals(priority,'High')",
+      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:44340;http://localhost:14140",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/Examples/JsonApiDotNetCoreExampleClient/OpenAPIs/swagger.json
+++ b/src/Examples/JsonApiDotNetCoreExampleClient/OpenAPIs/swagger.json
@@ -152,8 +152,7 @@
             "description": "The identifier of the person to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -203,8 +202,7 @@
             "description": "The identifier of the person to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -246,8 +244,7 @@
             "description": "The identifier of the person to update.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -319,8 +316,7 @@
             "description": "The identifier of the person to delete.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -348,8 +344,7 @@
             "description": "The identifier of the person whose related todoItems to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -399,8 +394,7 @@
             "description": "The identifier of the person whose related todoItems to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -444,8 +438,7 @@
             "description": "The identifier of the person whose related todoItem identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -495,8 +488,7 @@
             "description": "The identifier of the person whose related todoItem identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -538,8 +530,7 @@
             "description": "The identifier of the person to add todoItems to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -585,8 +576,7 @@
             "description": "The identifier of the person whose assignedTodoItems relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -632,8 +622,7 @@
             "description": "The identifier of the person to remove todoItems from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -681,8 +670,7 @@
             "description": "The identifier of the person whose related todoItems to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -732,8 +720,7 @@
             "description": "The identifier of the person whose related todoItems to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -777,8 +764,7 @@
             "description": "The identifier of the person whose related todoItem identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -828,8 +814,7 @@
             "description": "The identifier of the person whose related todoItem identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -871,8 +856,7 @@
             "description": "The identifier of the person to add todoItems to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -918,8 +902,7 @@
             "description": "The identifier of the person whose ownedTodoItems relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -965,8 +948,7 @@
             "description": "The identifier of the person to remove todoItems from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -1147,8 +1129,7 @@
             "description": "The identifier of the tag to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -1198,8 +1179,7 @@
             "description": "The identifier of the tag to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -1241,8 +1221,7 @@
             "description": "The identifier of the tag to update.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -1314,8 +1293,7 @@
             "description": "The identifier of the tag to delete.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -1343,8 +1321,7 @@
             "description": "The identifier of the tag whose related todoItems to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -1394,8 +1371,7 @@
             "description": "The identifier of the tag whose related todoItems to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -1439,8 +1415,7 @@
             "description": "The identifier of the tag whose related todoItem identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -1490,8 +1465,7 @@
             "description": "The identifier of the tag whose related todoItem identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -1533,8 +1507,7 @@
             "description": "The identifier of the tag to add todoItems to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -1580,8 +1553,7 @@
             "description": "The identifier of the tag whose todoItems relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -1627,8 +1599,7 @@
             "description": "The identifier of the tag to remove todoItems from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -1809,8 +1780,7 @@
             "description": "The identifier of the todoItem to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -1860,8 +1830,7 @@
             "description": "The identifier of the todoItem to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -1903,8 +1872,7 @@
             "description": "The identifier of the todoItem to update.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -1976,8 +1944,7 @@
             "description": "The identifier of the todoItem to delete.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -2005,8 +1972,7 @@
             "description": "The identifier of the todoItem whose related person to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -2056,8 +2022,7 @@
             "description": "The identifier of the todoItem whose related person to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -2101,8 +2066,7 @@
             "description": "The identifier of the todoItem whose related person identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -2152,8 +2116,7 @@
             "description": "The identifier of the todoItem whose related person identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -2195,8 +2158,7 @@
             "description": "The identifier of the todoItem whose assignee relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -2244,8 +2206,7 @@
             "description": "The identifier of the todoItem whose related person to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -2295,8 +2256,7 @@
             "description": "The identifier of the todoItem whose related person to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -2340,8 +2300,7 @@
             "description": "The identifier of the todoItem whose related person identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -2391,8 +2350,7 @@
             "description": "The identifier of the todoItem whose related person identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -2434,8 +2392,7 @@
             "description": "The identifier of the todoItem whose owner relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -2483,8 +2440,7 @@
             "description": "The identifier of the todoItem whose related tags to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -2534,8 +2490,7 @@
             "description": "The identifier of the todoItem whose related tags to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -2579,8 +2534,7 @@
             "description": "The identifier of the todoItem whose related tag identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -2630,8 +2584,7 @@
             "description": "The identifier of the todoItem whose related tag identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -2673,8 +2626,7 @@
             "description": "The identifier of the todoItem to add tags to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -2720,8 +2672,7 @@
             "description": "The identifier of the todoItem whose tags relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -2767,8 +2718,7 @@
             "description": "The identifier of the todoItem to remove tags from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],

--- a/src/Examples/JsonApiDotNetCoreExampleClient/Program.cs
+++ b/src/Examples/JsonApiDotNetCoreExampleClient/Program.cs
@@ -31,7 +31,7 @@ var patchRequest = new PersonPatchRequestDocument
 using (apiClient.WithPartialAttributeSerialization<PersonPatchRequestDocument, PersonAttributesInPatchRequest>(patchRequest, person => person.FirstName))
 {
     // Workaround for https://github.com/RicoSuter/NSwag/issues/2499.
-    await TranslateAsync(() => apiClient.PatchPersonAsync(1, null, patchRequest));
+    await TranslateAsync(() => apiClient.PatchPersonAsync(patchRequest.Data.Id, null, patchRequest));
 }
 
 Console.WriteLine("Press any key to close.");

--- a/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/JsonApiSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/JsonApiSchemaGenerator.cs
@@ -22,10 +22,7 @@ internal sealed class JsonApiSchemaGenerator : ISchemaGenerator
         typeof(ResourcePatchRequestDocument<>),
         typeof(ResourceIdentifierCollectionResponseDocument<>),
         typeof(ResourceIdentifierResponseDocument<>),
-        typeof(NullableResourceIdentifierResponseDocument<>),
-        typeof(ToManyRelationshipInRequest<>),
-        typeof(ToOneRelationshipInRequest<>),
-        typeof(NullableToOneRelationshipInRequest<>)
+        typeof(NullableResourceIdentifierResponseDocument<>)
     ];
 
     private static readonly Type[] JsonApiDocumentWithNullableDataOpenTypes =

--- a/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/ResourceFieldObjectSchemaBuilder.cs
+++ b/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/ResourceFieldObjectSchemaBuilder.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.OpenApi.JsonApiMetadata;
 using JsonApiDotNetCore.OpenApi.JsonApiObjects.Relationships;
 using JsonApiDotNetCore.OpenApi.JsonApiObjects.ResourceObjects;
@@ -171,7 +172,7 @@ internal sealed class ResourceFieldObjectSchemaBuilder
 
         if (!ResourceIdentifierObjectSchemaExists(resourceIdentifierObjectType))
         {
-            GenerateResourceIdentifierObjectSchema(resourceIdentifierObjectType);
+            GenerateResourceIdentifierObjectSchema(resourceIdentifierObjectType, relationship.RightType);
         }
     }
 
@@ -180,7 +181,7 @@ internal sealed class ResourceFieldObjectSchemaBuilder
         return _schemaRepositoryAccessor.Current.TryLookupByType(resourceIdentifierObjectType, out _);
     }
 
-    private void GenerateResourceIdentifierObjectSchema(Type resourceIdentifierObjectType)
+    private void GenerateResourceIdentifierObjectSchema(Type resourceIdentifierObjectType, ResourceType resourceType)
     {
         OpenApiSchema referenceSchemaForResourceIdentifierObject =
             _defaultSchemaGenerator.GenerateSchema(resourceIdentifierObjectType, _schemaRepositoryAccessor.Current);
@@ -188,7 +189,6 @@ internal sealed class ResourceFieldObjectSchemaBuilder
         OpenApiSchema fullSchemaForResourceIdentifierObject =
             _schemaRepositoryAccessor.Current.Schemas[referenceSchemaForResourceIdentifierObject.Reference.Id];
 
-        Type resourceType = resourceIdentifierObjectType.GetGenericArguments()[0];
         fullSchemaForResourceIdentifierObject.Properties[JsonApiPropertyName.Type] = _resourceTypeSchemaGenerator.Get(resourceType);
     }
 

--- a/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/ResourceObjectSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/ResourceObjectSchemaGenerator.cs
@@ -38,8 +38,7 @@ internal sealed class ResourceObjectSchemaGenerator
         _resourceGraph = resourceGraph;
         _options = options;
         _schemaRepositoryAccessor = schemaRepositoryAccessor;
-
-        _resourceTypeSchemaGenerator = new ResourceTypeSchemaGenerator(schemaRepositoryAccessor, resourceGraph, options.SerializerOptions.PropertyNamingPolicy);
+        _resourceTypeSchemaGenerator = new ResourceTypeSchemaGenerator(schemaRepositoryAccessor, options.SerializerOptions.PropertyNamingPolicy);
 
         _resourceFieldObjectSchemaBuilderFactory = resourceTypeInfo => new ResourceFieldObjectSchemaBuilder(resourceTypeInfo, schemaRepositoryAccessor,
             defaultSchemaGenerator, _resourceTypeSchemaGenerator, resourceFieldValidationMetadataProvider);
@@ -102,7 +101,7 @@ internal sealed class ResourceObjectSchemaGenerator
 
     private void SetResourceType(OpenApiSchema fullSchemaForResourceObject, ResourceType resourceType)
     {
-        fullSchemaForResourceObject.Properties[JsonApiPropertyName.Type] = _resourceTypeSchemaGenerator.Get(resourceType.ClrType);
+        fullSchemaForResourceObject.Properties[JsonApiPropertyName.Type] = _resourceTypeSchemaGenerator.Get(resourceType);
 
         fullSchemaForResourceObject.Description = _resourceObjectDocumentationReader.GetDocumentationForType(resourceType);
     }

--- a/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/ResourceTypeSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/ResourceTypeSchemaGenerator.cs
@@ -41,7 +41,8 @@ internal sealed class ResourceTypeSchemaGenerator
             Enum = new List<IOpenApiAny>
             {
                 new OpenApiString(resourceType.PublicName)
-            }
+            },
+            AdditionalPropertiesAllowed = false
         };
 
         string schemaId = GetSchemaId(resourceType);

--- a/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/ResourceTypeSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi/SwaggerComponents/ResourceTypeSchemaGenerator.cs
@@ -10,30 +10,25 @@ internal sealed class ResourceTypeSchemaGenerator
 {
     private const string ResourceTypeSchemaIdTemplate = "[ResourceName] Resource Type";
     private readonly ISchemaRepositoryAccessor _schemaRepositoryAccessor;
-    private readonly IResourceGraph _resourceGraph;
     private readonly JsonNamingPolicy? _namingPolicy;
     private readonly Dictionary<Type, OpenApiSchema> _resourceClrTypeSchemaCache = [];
 
-    public ResourceTypeSchemaGenerator(ISchemaRepositoryAccessor schemaRepositoryAccessor, IResourceGraph resourceGraph, JsonNamingPolicy? namingPolicy)
+    public ResourceTypeSchemaGenerator(ISchemaRepositoryAccessor schemaRepositoryAccessor, JsonNamingPolicy? namingPolicy)
     {
         ArgumentGuard.NotNull(schemaRepositoryAccessor);
-        ArgumentGuard.NotNull(resourceGraph);
 
         _schemaRepositoryAccessor = schemaRepositoryAccessor;
-        _resourceGraph = resourceGraph;
         _namingPolicy = namingPolicy;
     }
 
-    public OpenApiSchema Get(Type resourceClrType)
+    public OpenApiSchema Get(ResourceType resourceType)
     {
-        ArgumentGuard.NotNull(resourceClrType);
+        ArgumentGuard.NotNull(resourceType);
 
-        if (_resourceClrTypeSchemaCache.TryGetValue(resourceClrType, out OpenApiSchema? extendedReferenceSchema))
+        if (_resourceClrTypeSchemaCache.TryGetValue(resourceType.ClrType, out OpenApiSchema? extendedReferenceSchema))
         {
             return extendedReferenceSchema;
         }
-
-        ResourceType resourceType = _resourceGraph.GetResourceType(resourceClrType);
 
         var fullSchema = new OpenApiSchema
         {

--- a/test/OpenApiClientTests/LegacyClient/swagger.g.json
+++ b/test/OpenApiClientTests/LegacyClient/swagger.g.json
@@ -3470,7 +3470,8 @@
         "enum": [
           "airplanes"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "cabin-area": {
         "enum": [
@@ -3929,7 +3930,8 @@
         "enum": [
           "flight-attendants"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "flight-attendant-secondary-response-document": {
         "required": [
@@ -4411,7 +4413,8 @@
         "enum": [
           "flights"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "jsonapi-object": {
         "type": "object",
@@ -4855,7 +4858,8 @@
         "enum": [
           "passengers"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "to-many-flight-attendant-in-request": {
         "required": [

--- a/test/OpenApiClientTests/NamingConventions/CamelCase/swagger.g.json
+++ b/test/OpenApiClientTests/NamingConventions/CamelCase/swagger.g.json
@@ -1603,7 +1603,8 @@
         "enum": [
           "staffMembers"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "staffMemberSecondaryResponseDocument": {
         "required": [
@@ -2004,7 +2005,8 @@
         "enum": [
           "supermarkets"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "supermarketType": {
         "enum": [

--- a/test/OpenApiClientTests/NamingConventions/CamelCase/swagger.g.json
+++ b/test/OpenApiClientTests/NamingConventions/CamelCase/swagger.g.json
@@ -152,8 +152,7 @@
             "description": "The identifier of the supermarket to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -203,8 +202,7 @@
             "description": "The identifier of the supermarket to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -246,8 +244,7 @@
             "description": "The identifier of the supermarket to update.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -319,8 +316,7 @@
             "description": "The identifier of the supermarket to delete.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -348,8 +344,7 @@
             "description": "The identifier of the supermarket whose related staffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -399,8 +394,7 @@
             "description": "The identifier of the supermarket whose related staffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -444,8 +438,7 @@
             "description": "The identifier of the supermarket whose related staffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -495,8 +488,7 @@
             "description": "The identifier of the supermarket whose related staffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -538,8 +530,7 @@
             "description": "The identifier of the supermarket whose backupStoreManager relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -587,8 +578,7 @@
             "description": "The identifier of the supermarket whose related staffMembers to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -638,8 +628,7 @@
             "description": "The identifier of the supermarket whose related staffMembers to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -683,8 +672,7 @@
             "description": "The identifier of the supermarket whose related staffMember identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -734,8 +722,7 @@
             "description": "The identifier of the supermarket whose related staffMember identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -777,8 +764,7 @@
             "description": "The identifier of the supermarket to add staffMembers to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -824,8 +810,7 @@
             "description": "The identifier of the supermarket whose cashiers relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -871,8 +856,7 @@
             "description": "The identifier of the supermarket to remove staffMembers from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -920,8 +904,7 @@
             "description": "The identifier of the supermarket whose related staffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -971,8 +954,7 @@
             "description": "The identifier of the supermarket whose related staffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1016,8 +998,7 @@
             "description": "The identifier of the supermarket whose related staffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1067,8 +1048,7 @@
             "description": "The identifier of the supermarket whose related staffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1110,8 +1090,7 @@
             "description": "The identifier of the supermarket whose storeManager relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],

--- a/test/OpenApiClientTests/NamingConventions/KebabCase/swagger.g.json
+++ b/test/OpenApiClientTests/NamingConventions/KebabCase/swagger.g.json
@@ -152,8 +152,7 @@
             "description": "The identifier of the supermarket to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -203,8 +202,7 @@
             "description": "The identifier of the supermarket to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -246,8 +244,7 @@
             "description": "The identifier of the supermarket to update.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -319,8 +316,7 @@
             "description": "The identifier of the supermarket to delete.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -348,8 +344,7 @@
             "description": "The identifier of the supermarket whose related staff-member to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -399,8 +394,7 @@
             "description": "The identifier of the supermarket whose related staff-member to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -444,8 +438,7 @@
             "description": "The identifier of the supermarket whose related staff-member identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -495,8 +488,7 @@
             "description": "The identifier of the supermarket whose related staff-member identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -538,8 +530,7 @@
             "description": "The identifier of the supermarket whose backup-store-manager relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -587,8 +578,7 @@
             "description": "The identifier of the supermarket whose related staff-members to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -638,8 +628,7 @@
             "description": "The identifier of the supermarket whose related staff-members to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -683,8 +672,7 @@
             "description": "The identifier of the supermarket whose related staff-member identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -734,8 +722,7 @@
             "description": "The identifier of the supermarket whose related staff-member identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -777,8 +764,7 @@
             "description": "The identifier of the supermarket to add staff-members to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -824,8 +810,7 @@
             "description": "The identifier of the supermarket whose cashiers relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -871,8 +856,7 @@
             "description": "The identifier of the supermarket to remove staff-members from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -920,8 +904,7 @@
             "description": "The identifier of the supermarket whose related staff-member to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -971,8 +954,7 @@
             "description": "The identifier of the supermarket whose related staff-member to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1016,8 +998,7 @@
             "description": "The identifier of the supermarket whose related staff-member identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1067,8 +1048,7 @@
             "description": "The identifier of the supermarket whose related staff-member identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1110,8 +1090,7 @@
             "description": "The identifier of the supermarket whose store-manager relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],

--- a/test/OpenApiClientTests/NamingConventions/KebabCase/swagger.g.json
+++ b/test/OpenApiClientTests/NamingConventions/KebabCase/swagger.g.json
@@ -1603,7 +1603,8 @@
         "enum": [
           "staff-members"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "staff-member-secondary-response-document": {
         "required": [
@@ -2004,7 +2005,8 @@
         "enum": [
           "supermarkets"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "supermarket-type": {
         "enum": [

--- a/test/OpenApiClientTests/NamingConventions/PascalCase/swagger.g.json
+++ b/test/OpenApiClientTests/NamingConventions/PascalCase/swagger.g.json
@@ -152,8 +152,7 @@
             "description": "The identifier of the Supermarket to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -203,8 +202,7 @@
             "description": "The identifier of the Supermarket to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -246,8 +244,7 @@
             "description": "The identifier of the Supermarket to update.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -319,8 +316,7 @@
             "description": "The identifier of the Supermarket to delete.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -348,8 +344,7 @@
             "description": "The identifier of the Supermarket whose related StaffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -399,8 +394,7 @@
             "description": "The identifier of the Supermarket whose related StaffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -444,8 +438,7 @@
             "description": "The identifier of the Supermarket whose related StaffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -495,8 +488,7 @@
             "description": "The identifier of the Supermarket whose related StaffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -538,8 +530,7 @@
             "description": "The identifier of the Supermarket whose BackupStoreManager relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -587,8 +578,7 @@
             "description": "The identifier of the Supermarket whose related StaffMembers to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -638,8 +628,7 @@
             "description": "The identifier of the Supermarket whose related StaffMembers to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -683,8 +672,7 @@
             "description": "The identifier of the Supermarket whose related StaffMember identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -734,8 +722,7 @@
             "description": "The identifier of the Supermarket whose related StaffMember identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -777,8 +764,7 @@
             "description": "The identifier of the Supermarket to add StaffMembers to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -824,8 +810,7 @@
             "description": "The identifier of the Supermarket whose Cashiers relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -871,8 +856,7 @@
             "description": "The identifier of the Supermarket to remove StaffMembers from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -920,8 +904,7 @@
             "description": "The identifier of the Supermarket whose related StaffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -971,8 +954,7 @@
             "description": "The identifier of the Supermarket whose related StaffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1016,8 +998,7 @@
             "description": "The identifier of the Supermarket whose related StaffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1067,8 +1048,7 @@
             "description": "The identifier of the Supermarket whose related StaffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1110,8 +1090,7 @@
             "description": "The identifier of the Supermarket whose StoreManager relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],

--- a/test/OpenApiClientTests/NamingConventions/PascalCase/swagger.g.json
+++ b/test/OpenApiClientTests/NamingConventions/PascalCase/swagger.g.json
@@ -1603,7 +1603,8 @@
         "enum": [
           "StaffMembers"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "StaffMemberSecondaryResponseDocument": {
         "required": [
@@ -2004,7 +2005,8 @@
         "enum": [
           "Supermarkets"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "SupermarketType": {
         "enum": [

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/UpdateResourceTests.cs
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/UpdateResourceTests.cs
@@ -37,7 +37,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         var apiClient = new NrtOffMsvOffClient(wrapper.HttpClient);
 
         // Act
-        Func<Task> action = async () => await apiClient.PatchResourceAsync(Unknown.TypedId.Int32, null, requestDocument);
+        Func<Task> action = async () => await apiClient.PatchResourceAsync(Unknown.StringId.Int32, null, requestDocument);
 
         // Assert
         ExceptionAssertions<JsonSerializationException> assertion = await action.Should().ThrowExactlyAsync<JsonSerializationException>();
@@ -59,7 +59,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         {
             Data = new ResourceDataInPatchRequest
             {
-                Id = "1",
+                Id = Unknown.StringId.Int32,
                 Attributes = _fakers.PatchAttributes.Generate(),
                 Relationships = new ResourceRelationshipsInPatchRequest
                 {
@@ -79,7 +79,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         using IDisposable _ = apiClient.WithPartialAttributeSerialization<ResourcePatchRequestDocument, ResourceAttributesInPatchRequest>(requestDocument);
 
         // Act
-        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(int.Parse(requestDocument.Data.Id), null, requestDocument));
+        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(requestDocument.Data.Id, null, requestDocument));
 
         // Assert
         JsonElement document = wrapper.GetRequestBodyAsJson();
@@ -102,7 +102,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         {
             Data = new ResourceDataInPatchRequest
             {
-                Id = "1",
+                Id = Unknown.StringId.Int32,
                 Attributes = _fakers.PatchAttributes.Generate(),
                 Relationships = new ResourceRelationshipsInPatchRequest
                 {
@@ -120,7 +120,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         var apiClient = new NrtOffMsvOffClient(wrapper.HttpClient);
 
         // Act
-        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(int.Parse(requestDocument.Data.Id), null, requestDocument));
+        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(requestDocument.Data.Id, null, requestDocument));
 
         // Assert
         JsonElement document = wrapper.GetRequestBodyAsJson();

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/swagger.g.json
@@ -152,8 +152,7 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -203,8 +202,7 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -246,8 +244,7 @@
             "description": "The identifier of the resource to update.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -319,8 +316,7 @@
             "description": "The identifier of the resource to delete.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -348,8 +344,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -399,8 +394,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -444,8 +438,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -495,8 +488,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -538,8 +530,7 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -585,8 +576,7 @@
             "description": "The identifier of the resource whose requiredToMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -632,8 +622,7 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -681,8 +670,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -732,8 +720,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -777,8 +764,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -828,8 +814,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -871,8 +856,7 @@
             "description": "The identifier of the resource whose requiredToOne relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -920,8 +904,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -971,8 +954,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1016,8 +998,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1067,8 +1048,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1110,8 +1090,7 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1157,8 +1136,7 @@
             "description": "The identifier of the resource whose toMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1204,8 +1182,7 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1253,8 +1230,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1304,8 +1280,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1349,8 +1324,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1400,8 +1374,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1443,8 +1416,7 @@
             "description": "The identifier of the resource whose toOne relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/swagger.g.json
@@ -1574,7 +1574,8 @@
         "enum": [
           "empties"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "linksInRelationshipObject": {
         "required": [
@@ -2239,7 +2240,8 @@
         "enum": [
           "resources"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "toManyEmptyInRequest": {
         "required": [

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/UpdateResourceTests.cs
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/UpdateResourceTests.cs
@@ -37,7 +37,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         var apiClient = new NrtOffMsvOnClient(wrapper.HttpClient);
 
         // Act
-        Func<Task> action = async () => await apiClient.PatchResourceAsync(Unknown.TypedId.Int32, null, requestDocument);
+        Func<Task> action = async () => await apiClient.PatchResourceAsync(Unknown.StringId.Int32, null, requestDocument);
 
         // Assert
         ExceptionAssertions<JsonSerializationException> assertion = await action.Should().ThrowExactlyAsync<JsonSerializationException>();
@@ -59,7 +59,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         {
             Data = new ResourceDataInPatchRequest
             {
-                Id = "1",
+                Id = Unknown.StringId.Int32,
                 Attributes = _fakers.PatchAttributes.Generate(),
                 Relationships = new ResourceRelationshipsInPatchRequest
                 {
@@ -79,7 +79,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         using IDisposable _ = apiClient.WithPartialAttributeSerialization<ResourcePatchRequestDocument, ResourceAttributesInPatchRequest>(requestDocument);
 
         // Act
-        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(int.Parse(requestDocument.Data.Id), null, requestDocument));
+        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(requestDocument.Data.Id, null, requestDocument));
 
         // Assert
         JsonElement document = wrapper.GetRequestBodyAsJson();
@@ -102,7 +102,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         {
             Data = new ResourceDataInPatchRequest
             {
-                Id = "1",
+                Id = Unknown.StringId.Int32,
                 Attributes = _fakers.PatchAttributes.Generate(),
                 Relationships = new ResourceRelationshipsInPatchRequest
                 {
@@ -120,7 +120,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         var apiClient = new NrtOffMsvOnClient(wrapper.HttpClient);
 
         // Act
-        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(int.Parse(requestDocument.Data.Id), null, requestDocument));
+        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(requestDocument.Data.Id, null, requestDocument));
 
         // Assert
         JsonElement document = wrapper.GetRequestBodyAsJson();

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/swagger.g.json
@@ -1605,7 +1605,8 @@
         "enum": [
           "empties"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "emptySecondaryResponseDocument": {
         "required": [
@@ -2293,7 +2294,8 @@
         "enum": [
           "resources"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "toManyEmptyInRequest": {
         "required": [

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/swagger.g.json
@@ -152,8 +152,7 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -203,8 +202,7 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -246,8 +244,7 @@
             "description": "The identifier of the resource to update.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -319,8 +316,7 @@
             "description": "The identifier of the resource to delete.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -348,8 +344,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -399,8 +394,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -444,8 +438,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -495,8 +488,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -538,8 +530,7 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -585,8 +576,7 @@
             "description": "The identifier of the resource whose requiredToMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -632,8 +622,7 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -681,8 +670,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -732,8 +720,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -777,8 +764,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -828,8 +814,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -871,8 +856,7 @@
             "description": "The identifier of the resource whose requiredToOne relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -920,8 +904,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -971,8 +954,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1016,8 +998,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1067,8 +1048,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1110,8 +1090,7 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1157,8 +1136,7 @@
             "description": "The identifier of the resource whose toMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1204,8 +1182,7 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1253,8 +1230,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1304,8 +1280,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1349,8 +1324,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1400,8 +1374,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1443,8 +1416,7 @@
             "description": "The identifier of the resource whose toOne relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/UpdateResourceTests.cs
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/UpdateResourceTests.cs
@@ -39,7 +39,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         var apiClient = new NrtOnMsvOffClient(wrapper.HttpClient);
 
         // Act
-        Func<Task> action = async () => await apiClient.PatchResourceAsync(Unknown.TypedId.Int32, null, requestDocument);
+        Func<Task> action = async () => await apiClient.PatchResourceAsync(Unknown.StringId.Int32, null, requestDocument);
 
         // Assert
         ExceptionAssertions<JsonSerializationException> assertion = await action.Should().ThrowExactlyAsync<JsonSerializationException>();
@@ -63,7 +63,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         {
             Data = new ResourceDataInPatchRequest
             {
-                Id = "1",
+                Id = Unknown.StringId.Int32,
                 Attributes = _fakers.PatchAttributes.Generate(),
                 Relationships = new ResourceRelationshipsInPatchRequest
                 {
@@ -85,7 +85,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         using IDisposable _ = apiClient.WithPartialAttributeSerialization<ResourcePatchRequestDocument, ResourceAttributesInPatchRequest>(requestDocument);
 
         // Act
-        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(int.Parse(requestDocument.Data.Id), null, requestDocument));
+        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(requestDocument.Data.Id, null, requestDocument));
 
         // Assert
         JsonElement document = wrapper.GetRequestBodyAsJson();
@@ -110,7 +110,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         {
             Data = new ResourceDataInPatchRequest
             {
-                Id = "1",
+                Id = Unknown.StringId.Int32,
                 Attributes = _fakers.PatchAttributes.Generate(),
                 Relationships = new ResourceRelationshipsInPatchRequest
                 {
@@ -130,7 +130,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         var apiClient = new NrtOnMsvOffClient(wrapper.HttpClient);
 
         // Act
-        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(int.Parse(requestDocument.Data.Id), null, requestDocument));
+        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(requestDocument.Data.Id, null, requestDocument));
 
         // Assert
         JsonElement document = wrapper.GetRequestBodyAsJson();

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/swagger.g.json
@@ -152,8 +152,7 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -203,8 +202,7 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -246,8 +244,7 @@
             "description": "The identifier of the resource to update.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -319,8 +316,7 @@
             "description": "The identifier of the resource to delete.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -348,8 +344,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -399,8 +394,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -444,8 +438,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -495,8 +488,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -538,8 +530,7 @@
             "description": "The identifier of the resource whose nonNullableToOne relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -587,8 +578,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -638,8 +628,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -683,8 +672,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -734,8 +722,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -777,8 +764,7 @@
             "description": "The identifier of the resource whose nullableToOne relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -826,8 +812,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -877,8 +862,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -922,8 +906,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -973,8 +956,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1016,8 +998,7 @@
             "description": "The identifier of the resource whose requiredNonNullableToOne relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1065,8 +1046,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1116,8 +1096,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1161,8 +1140,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1212,8 +1190,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1255,8 +1232,7 @@
             "description": "The identifier of the resource whose requiredNullableToOne relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1304,8 +1280,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1355,8 +1330,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1400,8 +1374,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1451,8 +1424,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1494,8 +1466,7 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1541,8 +1512,7 @@
             "description": "The identifier of the resource whose requiredToMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1588,8 +1558,7 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1637,8 +1606,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1688,8 +1656,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1733,8 +1700,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1784,8 +1750,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1827,8 +1792,7 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1874,8 +1838,7 @@
             "description": "The identifier of the resource whose toMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1921,8 +1884,7 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/swagger.g.json
@@ -2073,7 +2073,8 @@
         "enum": [
           "empties"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "emptySecondaryResponseDocument": {
         "required": [
@@ -2834,7 +2835,8 @@
         "enum": [
           "resources"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "toManyEmptyInRequest": {
         "required": [

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/UpdateResourceTests.cs
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/UpdateResourceTests.cs
@@ -39,7 +39,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         var apiClient = new NrtOnMsvOnClient(wrapper.HttpClient);
 
         // Act
-        Func<Task> action = async () => await apiClient.PatchResourceAsync(Unknown.TypedId.Int32, null, requestDocument);
+        Func<Task> action = async () => await apiClient.PatchResourceAsync(Unknown.StringId.Int32, null, requestDocument);
 
         // Assert
         ExceptionAssertions<JsonSerializationException> assertion = await action.Should().ThrowExactlyAsync<JsonSerializationException>();
@@ -63,7 +63,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         {
             Data = new ResourceDataInPatchRequest
             {
-                Id = "1",
+                Id = Unknown.StringId.Int32,
                 Attributes = _fakers.PatchAttributes.Generate(),
                 Relationships = new ResourceRelationshipsInPatchRequest
                 {
@@ -85,7 +85,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         using IDisposable _ = apiClient.WithPartialAttributeSerialization<ResourcePatchRequestDocument, ResourceAttributesInPatchRequest>(requestDocument);
 
         // Act
-        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(int.Parse(requestDocument.Data.Id), null, requestDocument));
+        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(requestDocument.Data.Id, null, requestDocument));
 
         // Assert
         JsonElement document = wrapper.GetRequestBodyAsJson();
@@ -110,7 +110,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         {
             Data = new ResourceDataInPatchRequest
             {
-                Id = "1",
+                Id = Unknown.StringId.Int32,
                 Attributes = _fakers.PatchAttributes.Generate(),
                 Relationships = new ResourceRelationshipsInPatchRequest
                 {
@@ -130,7 +130,7 @@ public sealed class UpdateResourceTests : BaseOpenApiClientTests
         var apiClient = new NrtOnMsvOnClient(wrapper.HttpClient);
 
         // Act
-        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(int.Parse(requestDocument.Data.Id), null, requestDocument));
+        await ApiResponse.TranslateAsync(() => apiClient.PatchResourceAsync(requestDocument.Data.Id, null, requestDocument));
 
         // Assert
         JsonElement document = wrapper.GetRequestBodyAsJson();

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/swagger.g.json
@@ -152,8 +152,7 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -203,8 +202,7 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -246,8 +244,7 @@
             "description": "The identifier of the resource to update.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -319,8 +316,7 @@
             "description": "The identifier of the resource to delete.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -348,8 +344,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -399,8 +394,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -444,8 +438,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -495,8 +488,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -538,8 +530,7 @@
             "description": "The identifier of the resource whose nonNullableToOne relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -587,8 +578,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -638,8 +628,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -683,8 +672,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -734,8 +722,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -777,8 +764,7 @@
             "description": "The identifier of the resource whose nullableToOne relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -826,8 +812,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -877,8 +862,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -922,8 +906,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -973,8 +956,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1016,8 +998,7 @@
             "description": "The identifier of the resource whose requiredNonNullableToOne relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1065,8 +1046,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1116,8 +1096,7 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1161,8 +1140,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1212,8 +1190,7 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1255,8 +1232,7 @@
             "description": "The identifier of the resource whose requiredNullableToOne relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1304,8 +1280,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1355,8 +1330,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1400,8 +1374,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1451,8 +1424,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1494,8 +1466,7 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1541,8 +1512,7 @@
             "description": "The identifier of the resource whose requiredToMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1588,8 +1558,7 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1637,8 +1606,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1688,8 +1656,7 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1733,8 +1700,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1784,8 +1750,7 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           },
           {
@@ -1827,8 +1792,7 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1874,8 +1838,7 @@
             "description": "The identifier of the resource whose toMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],
@@ -1921,8 +1884,7 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32"
+              "type": "string"
             }
           }
         ],

--- a/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/swagger.g.json
+++ b/test/OpenApiClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/swagger.g.json
@@ -2073,7 +2073,8 @@
         "enum": [
           "empties"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "emptySecondaryResponseDocument": {
         "required": [
@@ -2828,7 +2829,8 @@
         "enum": [
           "resources"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "toManyEmptyInRequest": {
         "required": [

--- a/test/OpenApiEndToEndTests/QueryStrings/FilterTests.cs
+++ b/test/OpenApiEndToEndTests/QueryStrings/FilterTests.cs
@@ -84,7 +84,7 @@ public sealed class FilterTests : IClassFixture<IntegrationTestContext<OpenApiSt
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.Id, queryString);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Should().HaveCount(1);
@@ -120,7 +120,7 @@ public sealed class FilterTests : IClassFixture<IntegrationTestContext<OpenApiSt
         };
 
         // Act
-        NodeIdentifierCollectionResponseDocument response = await apiClient.GetNodeChildrenRelationshipAsync(node.Id, queryString);
+        NodeIdentifierCollectionResponseDocument response = await apiClient.GetNodeChildrenRelationshipAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Should().HaveCount(1);
@@ -142,7 +142,7 @@ public sealed class FilterTests : IClassFixture<IntegrationTestContext<OpenApiSt
         };
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(1, queryString);
+        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(Unknown.StringId.Int64, queryString);
 
         // Assert
         ApiException exception = (await action.Should().ThrowExactlyAsync<ApiException>()).Which;

--- a/test/OpenApiEndToEndTests/QueryStrings/PaginationTests.cs
+++ b/test/OpenApiEndToEndTests/QueryStrings/PaginationTests.cs
@@ -80,7 +80,7 @@ public sealed class PaginationTests : IClassFixture<IntegrationTestContext<OpenA
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.Id, queryString);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Should().HaveCount(2);
@@ -114,7 +114,7 @@ public sealed class PaginationTests : IClassFixture<IntegrationTestContext<OpenA
         };
 
         // Act
-        NodeIdentifierCollectionResponseDocument response = await apiClient.GetNodeChildrenRelationshipAsync(node.Id, queryString);
+        NodeIdentifierCollectionResponseDocument response = await apiClient.GetNodeChildrenRelationshipAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Should().HaveCount(1);
@@ -136,7 +136,7 @@ public sealed class PaginationTests : IClassFixture<IntegrationTestContext<OpenA
         };
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(1, queryString);
+        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(Unknown.StringId.Int64, queryString);
 
         // Assert
         ApiException exception = (await action.Should().ThrowExactlyAsync<ApiException>()).Which;
@@ -158,7 +158,7 @@ public sealed class PaginationTests : IClassFixture<IntegrationTestContext<OpenA
         };
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(1, queryString);
+        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(Unknown.StringId.Int64, queryString);
 
         // Assert
         ApiException exception = (await action.Should().ThrowExactlyAsync<ApiException>()).Which;

--- a/test/OpenApiEndToEndTests/QueryStrings/SortTests.cs
+++ b/test/OpenApiEndToEndTests/QueryStrings/SortTests.cs
@@ -81,7 +81,7 @@ public sealed class SortTests : IClassFixture<IntegrationTestContext<OpenApiStar
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.Id, queryString);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Should().HaveCount(2);
@@ -114,7 +114,7 @@ public sealed class SortTests : IClassFixture<IntegrationTestContext<OpenApiStar
         };
 
         // Act
-        NodeIdentifierCollectionResponseDocument response = await apiClient.GetNodeChildrenRelationshipAsync(node.Id, queryString);
+        NodeIdentifierCollectionResponseDocument response = await apiClient.GetNodeChildrenRelationshipAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Should().HaveCount(2);
@@ -135,7 +135,7 @@ public sealed class SortTests : IClassFixture<IntegrationTestContext<OpenApiStar
         };
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(1, queryString);
+        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(Unknown.StringId.Int64, queryString);
 
         // Assert
         ApiException exception = (await action.Should().ThrowExactlyAsync<ApiException>()).Which;

--- a/test/OpenApiEndToEndTests/QueryStrings/SparseFieldSetTests.cs
+++ b/test/OpenApiEndToEndTests/QueryStrings/SparseFieldSetTests.cs
@@ -76,7 +76,7 @@ public sealed class SparseFieldSetTests : IClassFixture<IntegrationTestContext<O
         };
 
         // Act
-        NodePrimaryResponseDocument response = await apiClient.GetNodeAsync(node.Id, queryString);
+        NodePrimaryResponseDocument response = await apiClient.GetNodeAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Id.Should().Be(node.StringId);
@@ -109,7 +109,7 @@ public sealed class SparseFieldSetTests : IClassFixture<IntegrationTestContext<O
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.Id, queryString);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Should().HaveCount(1);
@@ -142,7 +142,7 @@ public sealed class SparseFieldSetTests : IClassFixture<IntegrationTestContext<O
         };
 
         // Act
-        NullableNodeSecondaryResponseDocument response = await apiClient.GetNodeParentAsync(node.Id, queryString);
+        NullableNodeSecondaryResponseDocument response = await apiClient.GetNodeParentAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.ShouldNotBeNull();
@@ -174,7 +174,7 @@ public sealed class SparseFieldSetTests : IClassFixture<IntegrationTestContext<O
         };
 
         // Act
-        NodePrimaryResponseDocument response = await apiClient.GetNodeAsync(node.Id, queryString);
+        NodePrimaryResponseDocument response = await apiClient.GetNodeAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Id.Should().Be(node.StringId);

--- a/test/OpenApiEndToEndTests/QueryStrings/swagger.g.json
+++ b/test/OpenApiEndToEndTests/QueryStrings/swagger.g.json
@@ -152,8 +152,7 @@
             "description": "The identifier of the node to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -203,8 +202,7 @@
             "description": "The identifier of the node to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -246,8 +244,7 @@
             "description": "The identifier of the node to update.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -319,8 +316,7 @@
             "description": "The identifier of the node to delete.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -348,8 +344,7 @@
             "description": "The identifier of the node whose related nodes to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -399,8 +394,7 @@
             "description": "The identifier of the node whose related nodes to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -444,8 +438,7 @@
             "description": "The identifier of the node whose related node identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -495,8 +488,7 @@
             "description": "The identifier of the node whose related node identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -538,8 +530,7 @@
             "description": "The identifier of the node to add nodes to.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -585,8 +576,7 @@
             "description": "The identifier of the node whose children relationship to assign.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -632,8 +622,7 @@
             "description": "The identifier of the node to remove nodes from.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],
@@ -681,8 +670,7 @@
             "description": "The identifier of the node whose related node to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -732,8 +720,7 @@
             "description": "The identifier of the node whose related node to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -777,8 +764,7 @@
             "description": "The identifier of the node whose related node identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -828,8 +814,7 @@
             "description": "The identifier of the node whose related node identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           },
           {
@@ -871,8 +856,7 @@
             "description": "The identifier of the node whose parent relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int64"
+              "type": "string"
             }
           }
         ],

--- a/test/OpenApiEndToEndTests/QueryStrings/swagger.g.json
+++ b/test/OpenApiEndToEndTests/QueryStrings/swagger.g.json
@@ -1387,7 +1387,8 @@
         "enum": [
           "nodes"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "nullableNodeIdentifierResponseDocument": {
         "required": [

--- a/test/OpenApiTests/LegacyOpenApiIntegration/swagger.json
+++ b/test/OpenApiTests/LegacyOpenApiIntegration/swagger.json
@@ -3470,7 +3470,8 @@
         "enum": [
           "airplanes"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "cabin-area": {
         "enum": [
@@ -3929,7 +3930,8 @@
         "enum": [
           "flight-attendants"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "flight-attendant-secondary-response-document": {
         "required": [
@@ -4411,7 +4413,8 @@
         "enum": [
           "flights"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "jsonapi-object": {
         "type": "object",
@@ -4855,7 +4858,8 @@
         "enum": [
           "passengers"
         ],
-        "type": "string"
+        "type": "string",
+        "additionalProperties": false
       },
       "to-many-flight-attendant-in-request": {
         "required": [


### PR DESCRIPTION
This PR corrects the "id" parameter type to be `string` in the JSON:API request URL.

Contributes to #1051:
> Also address the following: When using Identifiable<TId> where TId is other than string, eg int, the generated client will have its id parameter typed as int in methods, which is incorrect: it should always be string.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [x] Documentation updated
