### PR TITLE
OpenAPI: Filter endpoints based on GenerateControllerEndpoints usage

### DIFF
--- a/src/JsonApiDotNetCore.OpenApi/JsonApiMetadata/EndpointResolver.cs
+++ b/src/JsonApiDotNetCore.OpenApi/JsonApiMetadata/EndpointResolver.cs
@@ -11,7 +11,6 @@ internal sealed class EndpointResolver
     {
         ArgumentGuard.NotNull(controllerAction);
 
-        // This is a temporary work-around to prevent the JsonApiDotNetCoreExample project from crashing upon startup.
         if (!IsJsonApiController(controllerAction) || IsOperationsController(controllerAction))
         {
             return null;

--- a/src/JsonApiDotNetCore.OpenApi/JsonApiMetadata/JsonApiEndpointMetadataProvider.cs
+++ b/src/JsonApiDotNetCore.OpenApi/JsonApiMetadata/JsonApiEndpointMetadataProvider.cs
@@ -34,7 +34,7 @@ internal sealed class JsonApiEndpointMetadataProvider
 
         if (endpoint == null)
         {
-            throw new NotSupportedException($"Unable to provide metadata for non-JsonApiDotNetCore endpoint '{controllerAction.ReflectedType!.FullName}'.");
+            throw new NotSupportedException($"Unable to provide metadata for non-JSON:API endpoint '{controllerAction.ReflectedType!.FullName}'.");
         }
 
         ResourceType? primaryResourceType = _controllerResourceMapping.GetResourceTypeForController(controllerAction.ReflectedType);

--- a/src/JsonApiDotNetCore.OpenApi/ServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore.OpenApi/ServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
-using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.OpenApi.SwaggerComponents;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -36,18 +34,14 @@ public static class ServiceCollectionExtensions
     private static void AddCustomApiExplorer(IServiceCollection services, IMvcCoreBuilder mvcBuilder)
     {
         services.TryAddSingleton<ResourceFieldValidationMetadataProvider>();
+        services.AddSingleton<JsonApiActionDescriptorCollectionProvider>();
 
-        services.TryAddSingleton<IApiDescriptionGroupCollectionProvider>(provider =>
+        services.TryAddSingleton<IApiDescriptionGroupCollectionProvider>(serviceProvider =>
         {
-            var controllerResourceMapping = provider.GetRequiredService<IControllerResourceMapping>();
-            var actionDescriptorCollectionProvider = provider.GetRequiredService<IActionDescriptorCollectionProvider>();
-            var apiDescriptionProviders = provider.GetRequiredService<IEnumerable<IApiDescriptionProvider>>();
-            var resourceFieldValidationMetadataProvider = provider.GetRequiredService<ResourceFieldValidationMetadataProvider>();
+            var actionDescriptorCollectionProvider = serviceProvider.GetRequiredService<JsonApiActionDescriptorCollectionProvider>();
+            var apiDescriptionProviders = serviceProvider.GetRequiredService<IEnumerable<IApiDescriptionProvider>>();
 
-            JsonApiActionDescriptorCollectionProvider jsonApiActionDescriptorCollectionProvider =
-                new(controllerResourceMapping, actionDescriptorCollectionProvider, resourceFieldValidationMetadataProvider);
-
-            return new ApiDescriptionGroupCollectionProvider(jsonApiActionDescriptorCollectionProvider, apiDescriptionProviders);
+            return new ApiDescriptionGroupCollectionProvider(actionDescriptorCollectionProvider, apiDescriptionProviders);
         });
 
         mvcBuilder.AddApiExplorer();

--- a/test/OpenApiTests/RestrictedControllers/Channel.cs
+++ b/test/OpenApiTests/RestrictedControllers/Channel.cs
@@ -1,0 +1,18 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace OpenApiTests.RestrictedControllers;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+public abstract class Channel : Identifiable<long>
+{
+    [Attr]
+    public string? Name { get; set; }
+
+    [HasOne]
+    public DataStream VideoStream { get; set; } = null!;
+
+    [HasMany]
+    public ISet<DataStream> AudioStreams { get; set; } = new HashSet<DataStream>();
+}

--- a/test/OpenApiTests/RestrictedControllers/DataStream.cs
+++ b/test/OpenApiTests/RestrictedControllers/DataStream.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace OpenApiTests.RestrictedControllers;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "OpenApiTests.RestrictedControllers", GenerateControllerEndpoints = JsonApiEndpoints.None)]
+public sealed class DataStream : Identifiable<long>
+{
+    [Attr]
+    [Required]
+    public ulong? BytesTransmitted { get; set; }
+}

--- a/test/OpenApiTests/RestrictedControllers/DataStreamController.cs
+++ b/test/OpenApiTests/RestrictedControllers/DataStreamController.cs
@@ -1,0 +1,26 @@
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace OpenApiTests.RestrictedControllers;
+
+public sealed class DataStreamController(
+    IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IResourceService<DataStream, long> resourceService)
+    : BaseJsonApiController<DataStream, long>(options, resourceGraph, loggerFactory, resourceService)
+{
+    [HttpGet]
+    [HttpHead]
+    public override Task<IActionResult> GetAsync(CancellationToken cancellationToken)
+    {
+        return base.GetAsync(cancellationToken);
+    }
+
+    [HttpGet("{id}")]
+    [HttpHead("{id}")]
+    public override Task<IActionResult> GetAsync(long id, CancellationToken cancellationToken)
+    {
+        return base.GetAsync(id, cancellationToken);
+    }
+}

--- a/test/OpenApiTests/RestrictedControllers/ReadOnlyChannel.cs
+++ b/test/OpenApiTests/RestrictedControllers/ReadOnlyChannel.cs
@@ -1,0 +1,12 @@
+﻿using JetBrains.Annotations;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace OpenApiTests.RestrictedControllers;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "OpenApiTests.RestrictedControllers", GenerateControllerEndpoints = ControllerEndpoints)]
+public sealed class ReadOnlyChannel : Channel
+{
+    internal const JsonApiEndpoints ControllerEndpoints = JsonApiEndpoints.Query;
+}

--- a/test/OpenApiTests/RestrictedControllers/ReadOnlyResourceChannel.cs
+++ b/test/OpenApiTests/RestrictedControllers/ReadOnlyResourceChannel.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace OpenApiTests.RestrictedControllers;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "OpenApiTests.RestrictedControllers", GenerateControllerEndpoints = ControllerEndpoints)]
+public sealed class ReadOnlyResourceChannel : Channel
+{
+    internal const JsonApiEndpoints ControllerEndpoints = JsonApiEndpoints.GetCollection | JsonApiEndpoints.GetSingle | JsonApiEndpoints.GetSecondary;
+}

--- a/test/OpenApiTests/RestrictedControllers/RelationshipChannel.cs
+++ b/test/OpenApiTests/RestrictedControllers/RelationshipChannel.cs
@@ -1,0 +1,13 @@
+﻿using JetBrains.Annotations;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace OpenApiTests.RestrictedControllers;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "OpenApiTests.RestrictedControllers", GenerateControllerEndpoints = ControllerEndpoints)]
+public sealed class RelationshipChannel : Channel
+{
+    internal const JsonApiEndpoints ControllerEndpoints = JsonApiEndpoints.GetRelationship | JsonApiEndpoints.PostRelationship |
+        JsonApiEndpoints.PatchRelationship | JsonApiEndpoints.DeleteRelationship;
+}

--- a/test/OpenApiTests/RestrictedControllers/RestrictionDbContext.cs
+++ b/test/OpenApiTests/RestrictedControllers/RestrictionDbContext.cs
@@ -1,0 +1,15 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
+
+namespace OpenApiTests.RestrictedControllers;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+public sealed class RestrictionDbContext(DbContextOptions<RestrictionDbContext> options) : TestableDbContext(options)
+{
+    public DbSet<DataStream> DataStreams => Set<DataStream>();
+    public DbSet<ReadOnlyChannel> ReadOnlyChannels => Set<ReadOnlyChannel>();
+    public DbSet<WriteOnlyChannel> WriteOnlyChannels => Set<WriteOnlyChannel>();
+    public DbSet<RelationshipChannel> RelationshipChannels => Set<RelationshipChannel>();
+    public DbSet<ReadOnlyResourceChannel> ReadOnlyResourceChannels => Set<ReadOnlyResourceChannel>();
+}

--- a/test/OpenApiTests/RestrictedControllers/RestrictionFakers.cs
+++ b/test/OpenApiTests/RestrictedControllers/RestrictionFakers.cs
@@ -1,0 +1,38 @@
+using Bogus;
+using JetBrains.Annotations;
+using TestBuildingBlocks;
+
+// @formatter:wrap_chained_method_calls chop_if_long
+// @formatter:wrap_before_first_method_call true
+
+namespace OpenApiTests.RestrictedControllers;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+public sealed class RestrictionFakers : FakerContainer
+{
+    private readonly Lazy<Faker<DataStream>> _lazyDataStreamFaker = new(() => new Faker<DataStream>()
+        .UseSeed(GetFakerSeed())
+        .RuleFor(stream => stream.BytesTransmitted, faker => faker.Random.ULong()));
+
+    private readonly Lazy<Faker<ReadOnlyChannel>> _lazyReadOnlyChannelFaker = new(() => new Faker<ReadOnlyChannel>()
+        .UseSeed(GetFakerSeed())
+        .RuleFor(channel => channel.Name, faker => faker.Lorem.Word()));
+
+    private readonly Lazy<Faker<WriteOnlyChannel>> _lazyWriteOnlyChannelFaker = new(() => new Faker<WriteOnlyChannel>()
+        .UseSeed(GetFakerSeed())
+        .RuleFor(channel => channel.Name, faker => faker.Lorem.Word()));
+
+    private readonly Lazy<Faker<RelationshipChannel>> _lazyRelationshipChannelFaker = new(() => new Faker<RelationshipChannel>()
+        .UseSeed(GetFakerSeed())
+        .RuleFor(channel => channel.Name, faker => faker.Lorem.Word()));
+
+    private readonly Lazy<Faker<ReadOnlyResourceChannel>> _lazyReadOnlyResourceChannelFaker = new(() => new Faker<ReadOnlyResourceChannel>()
+        .UseSeed(GetFakerSeed())
+        .RuleFor(channel => channel.Name, faker => faker.Lorem.Word()));
+
+    public Faker<DataStream> DataStream => _lazyDataStreamFaker.Value;
+    public Faker<ReadOnlyChannel> ReadOnlyChannel => _lazyReadOnlyChannelFaker.Value;
+    public Faker<WriteOnlyChannel> WriteOnlyChannel => _lazyWriteOnlyChannelFaker.Value;
+    public Faker<RelationshipChannel> RelationshipChannel => _lazyRelationshipChannelFaker.Value;
+    public Faker<ReadOnlyResourceChannel> ReadOnlyResourceChannel => _lazyReadOnlyResourceChannelFaker.Value;
+}

--- a/test/OpenApiTests/RestrictedControllers/RestrictionTests.cs
+++ b/test/OpenApiTests/RestrictedControllers/RestrictionTests.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using Humanizer;
+using JsonApiDotNetCore.Controllers;
+using TestBuildingBlocks;
+using Xunit;
+
+#pragma warning disable AV1532 // Loop statement contains nested loop
+
+namespace OpenApiTests.RestrictedControllers;
+
+public sealed class RestrictionTests : IClassFixture<OpenApiTestContext<OpenApiStartup<RestrictionDbContext>, RestrictionDbContext>>
+{
+    private static readonly JsonApiEndpoints[] KnownEndpoints =
+    [
+        JsonApiEndpoints.GetCollection,
+        JsonApiEndpoints.GetSingle,
+        JsonApiEndpoints.GetSecondary,
+        JsonApiEndpoints.GetRelationship,
+        JsonApiEndpoints.Post,
+        JsonApiEndpoints.PostRelationship,
+        JsonApiEndpoints.Patch,
+        JsonApiEndpoints.PatchRelationship,
+        JsonApiEndpoints.Delete,
+        JsonApiEndpoints.DeleteRelationship
+    ];
+
+    private readonly OpenApiTestContext<OpenApiStartup<RestrictionDbContext>, RestrictionDbContext> _testContext;
+
+    public RestrictionTests(OpenApiTestContext<OpenApiStartup<RestrictionDbContext>, RestrictionDbContext> testContext)
+    {
+        _testContext = testContext;
+
+        testContext.UseController<DataStreamController>();
+        testContext.UseController<ReadOnlyChannelsController>();
+        testContext.UseController<WriteOnlyChannelsController>();
+        testContext.UseController<RelationshipChannelsController>();
+        testContext.UseController<ReadOnlyResourceChannelsController>();
+    }
+
+    [Theory]
+    [InlineData(typeof(DataStream), JsonApiEndpoints.GetCollection | JsonApiEndpoints.GetSingle)]
+    [InlineData(typeof(ReadOnlyChannel), ReadOnlyChannel.ControllerEndpoints)]
+    [InlineData(typeof(WriteOnlyChannel), WriteOnlyChannel.ControllerEndpoints)]
+    [InlineData(typeof(RelationshipChannel), RelationshipChannel.ControllerEndpoints)]
+    [InlineData(typeof(ReadOnlyResourceChannel), ReadOnlyResourceChannel.ControllerEndpoints)]
+    public async Task Only_expected_endpoints_are_exposed(Type resourceClrType, JsonApiEndpoints expected)
+    {
+        // Arrange
+        string resourceName = resourceClrType.Name.Camelize().Pluralize();
+
+        var endpointToPathMap = new Dictionary<JsonApiEndpoints, string[]>
+        {
+            [JsonApiEndpoints.GetCollection] =
+            [
+                $"/{resourceName}.get",
+                $"/{resourceName}.head"
+            ],
+            [JsonApiEndpoints.GetSingle] =
+            [
+                $"/{resourceName}/{{id}}.get",
+                $"/{resourceName}/{{id}}.head"
+            ],
+            [JsonApiEndpoints.GetSecondary] =
+            [
+                $"/{resourceName}/{{id}}/audioStreams.get",
+                $"/{resourceName}/{{id}}/audioStreams.head",
+                $"/{resourceName}/{{id}}/videoStream.get",
+                $"/{resourceName}/{{id}}/videoStream.head"
+            ],
+            [JsonApiEndpoints.GetRelationship] =
+            [
+                $"/{resourceName}/{{id}}/relationships/audioStreams.get",
+                $"/{resourceName}/{{id}}/relationships/audioStreams.head",
+                $"/{resourceName}/{{id}}/relationships/videoStream.get",
+                $"/{resourceName}/{{id}}/relationships/videoStream.head"
+            ],
+            [JsonApiEndpoints.Post] = [$"/{resourceName}.post"],
+            [JsonApiEndpoints.PostRelationship] = [$"/{resourceName}/{{id}}/relationships/audioStreams.post"],
+            [JsonApiEndpoints.Patch] = [$"/{resourceName}/{{id}}.patch"],
+            [JsonApiEndpoints.PatchRelationship] =
+            [
+                $"/{resourceName}/{{id}}/relationships/audioStreams.patch",
+                $"/{resourceName}/{{id}}/relationships/videoStream.patch"
+            ],
+            [JsonApiEndpoints.Delete] = [$"/{resourceName}/{{id}}.delete"],
+            [JsonApiEndpoints.DeleteRelationship] = [$"/{resourceName}/{{id}}/relationships/audioStreams.delete"]
+        };
+
+        // Act
+        JsonElement document = await _testContext.GetSwaggerDocumentAsync();
+
+        foreach (JsonApiEndpoints endpoint in KnownEndpoints.Where(value => expected.HasFlag(value)))
+        {
+            string[] pathsExpected = endpointToPathMap[endpoint];
+            string[] pathsNotExpected = endpointToPathMap.Values.SelectMany(paths => paths).Except(pathsExpected).ToArray();
+
+            // Assert
+            foreach (string path in pathsExpected)
+            {
+                document.Should().ContainPath($"paths.{path}");
+            }
+
+            foreach (string path in pathsNotExpected)
+            {
+                document.Should().NotContainPath($"paths{path}");
+            }
+        }
+    }
+}

--- a/test/OpenApiTests/RestrictedControllers/WriteOnlyChannel.cs
+++ b/test/OpenApiTests/RestrictedControllers/WriteOnlyChannel.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace OpenApiTests.RestrictedControllers;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "OpenApiTests.RestrictedControllers", GenerateControllerEndpoints = ControllerEndpoints)]
+public sealed class WriteOnlyChannel : Channel
+{
+    internal const JsonApiEndpoints ControllerEndpoints = JsonApiEndpoints.Command;
+}


### PR DESCRIPTION
This PR filters the listed JSON:API endpoints in the produced swagger.json.

## Auto-generated controllers

When using auto-generated controllers, only the endpoints defined on the resource type are shown. For example:

```c#
[Resource(GenerateControllerEndpoints = JsonApiEndpoints.Post | JsonApiEndpoints.Patch)]
public sealed class Person : Identifiable<long>
{
    // ...
}
```
now _only_ displays the corresponding endpoints:

![image](https://github.com/json-api-dotnet/JsonApiDotNetCore/assets/10324372/9d6aeeda-9e47-456f-b019-c9ba0ac66531)

This means that if you're adding a custom implementation of an action method in your partial class, you need to add its flag on `[Resource]` for it to become listed. If you don't, the method is assumed to exist solely to throw an exception when used.

This is needed because auto-generated controllers derive from `JsonApiController<,>`, which contains all JSON:API controller action methods. At runtime, an exception is thrown when the endpoint is not accessible.

## Hand-written controllers

When not using auto-generated controllers, all exposed endpoints are listed. To hide some, derive from `BaseJsonApiController` instead of `JsonApiController` and include _only_ the action methods that should be exposed by adding attributes like `[HttpGet]`, `[HttpPost]`, etc. There's no way to add action methods that always throw without them being listed.

Closes #1052.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
