### PR TITLE
Fix OpenAPI example crash in Visual Studio 2022 v17.9.0

### DIFF
--- a/src/JsonApiDotNetCore.OpenApi/ServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore.OpenApi/ServiceCollectionExtensions.cs
@@ -40,13 +40,14 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<NonPrimaryDocumentTypeFactory>();
         services.TryAddSingleton<ResourceFieldValidationMetadataProvider>();
 
-        services.TryAddSingleton<IApiDescriptionGroupCollectionProvider>(serviceProvider =>
+        // Not using TryAddSingleton, see https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1463.
+        services.Replace(ServiceDescriptor.Singleton<IApiDescriptionGroupCollectionProvider>(serviceProvider =>
         {
             var actionDescriptorCollectionProvider = serviceProvider.GetRequiredService<JsonApiActionDescriptorCollectionProvider>();
             var apiDescriptionProviders = serviceProvider.GetRequiredService<IEnumerable<IApiDescriptionProvider>>();
 
             return new ApiDescriptionGroupCollectionProvider(actionDescriptorCollectionProvider, apiDescriptionProviders);
-        });
+        }));
 
         mvcBuilder.AddApiExplorer();
 


### PR DESCRIPTION
Fixes #1463.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
