### PR TITLE
Don't crash on empty query string parameter name

### DIFF
--- a/src/JsonApiDotNetCore/QueryStrings/QueryStringReader.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/QueryStringReader.cs
@@ -38,6 +38,11 @@ public sealed class QueryStringReader : IQueryStringReader
 
         foreach ((string parameterName, StringValues parameterValue) in _queryStringAccessor.Query)
         {
+            if (parameterName.Length == 0)
+            {
+                throw new InvalidQueryException("Empty query string parameter name.", null);
+            }
+
             IQueryStringParameterReader? reader = _parameterReaders.FirstOrDefault(nextReader => nextReader.CanRead(parameterName));
 
             if (reader != null)

--- a/src/JsonApiDotNetCore/QueryStrings/QueryStringReader.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/QueryStringReader.cs
@@ -40,7 +40,7 @@ public sealed class QueryStringReader : IQueryStringReader
         {
             if (parameterName.Length == 0)
             {
-                throw new InvalidQueryException("Empty query string parameter name.", null);
+                continue;
             }
 
             IQueryStringParameterReader? reader = _parameterReaders.FirstOrDefault(nextReader => nextReader.CanRead(parameterName));

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/QueryStringTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/QueryStringTests.cs
@@ -63,28 +63,22 @@ public sealed class QueryStringTests : IClassFixture<IntegrationTestContext<Test
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
     }
 
-    [Fact]
-    public async Task Cannot_use_empty_query_string_parameter_name()
+    [Theory]
+    [InlineData("")]
+    [InlineData("foo")]
+    public async Task Should_ignore_query_parameter_with_empty_name(string parameterValue)
     {
         // Arrange
         var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
         options.AllowUnknownQueryStringParameters = false;
 
-        const string route = "calendars?=";
+        string route = $"calendars?={parameterValue}";
 
         // Act
-        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+        (HttpResponseMessage httpResponse, Document _) = await _testContext.ExecuteGetAsync<Document>(route);
 
         // Assert
-        httpResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
-
-        responseDocument.Errors.ShouldHaveCount(1);
-
-        ErrorObject error = responseDocument.Errors[0];
-        error.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        error.Title.Should().Be("Empty query string parameter name.");
-        error.Detail.Should().BeNull();
-        error.Source.Should().BeNull();
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
     }
 
     [Theory]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/QueryStringTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/QueryStringTests.cs
@@ -65,8 +65,8 @@ public sealed class QueryStringTests : IClassFixture<IntegrationTestContext<Test
 
     [Theory]
     [InlineData("")]
-    [InlineData("foo")]
-    public async Task Should_ignore_query_parameter_with_empty_name(string parameterValue)
+    [InlineData("bar")]
+    public async Task Can_use_empty_query_string_parameter_name(string parameterValue)
     {
         // Arrange
         var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/QueryStringTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/QueryStringTests.cs
@@ -63,6 +63,30 @@ public sealed class QueryStringTests : IClassFixture<IntegrationTestContext<Test
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
     }
 
+    [Fact]
+    public async Task Cannot_use_empty_query_string_parameter_name()
+    {
+        // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.AllowUnknownQueryStringParameters = false;
+
+        const string route = "calendars?=";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        error.Title.Should().Be("Empty query string parameter name.");
+        error.Detail.Should().BeNull();
+        error.Source.Should().BeNull();
+    }
+
     [Theory]
     [InlineData("filter")]
     [InlineData("sort")]


### PR DESCRIPTION

Closes #1480 

#### QUALITY CHECKLIST
- [X] Changes implemented in code
- [X] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [X] Adapted tests
- [ ] Documentation updated
