### PR TITLE
Optimize query string parsing

### DIFF
--- a/benchmarks/QueryString/QueryStringParserBenchmarks.cs
+++ b/benchmarks/QueryString/QueryStringParserBenchmarks.cs
@@ -89,12 +89,13 @@ public class QueryStringParserBenchmarks
 
     public sealed class QueryStringArgument(string queryString)
     {
-        public string QueryString { get; } = queryString;
-        public IQueryCollection Query { get; } = new QueryCollection(QueryHelpers.ParseQuery(queryString));
+        private readonly string _queryString = queryString;
+
+        internal IQueryCollection Query { get; } = new QueryCollection(QueryHelpers.ParseQuery(queryString));
 
         public override string ToString()
         {
-            return QueryString;
+            return _queryString;
         }
     }
 }

--- a/benchmarks/Tools/FakeRequestQueryStringAccessor.cs
+++ b/benchmarks/Tools/FakeRequestQueryStringAccessor.cs
@@ -1,6 +1,5 @@
 using JsonApiDotNetCore.QueryStrings;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.WebUtilities;
 
 namespace Benchmarks.Tools;
 
@@ -10,9 +9,4 @@ namespace Benchmarks.Tools;
 internal sealed class FakeRequestQueryStringAccessor : IRequestQueryStringAccessor
 {
     public IQueryCollection Query { get; set; } = new QueryCollection();
-
-    public void SetQueryString(string queryString)
-    {
-        Query = new QueryCollection(QueryHelpers.ParseQuery(queryString));
-    }
 }

--- a/benchmarks/Tools/FakeRequestQueryStringAccessor.cs
+++ b/benchmarks/Tools/FakeRequestQueryStringAccessor.cs
@@ -9,7 +9,7 @@ namespace Benchmarks.Tools;
 /// </summary>
 internal sealed class FakeRequestQueryStringAccessor : IRequestQueryStringAccessor
 {
-    public IQueryCollection Query { get; private set; } = new QueryCollection();
+    public IQueryCollection Query { get; set; } = new QueryCollection();
 
     public void SetQueryString(string queryString)
     {

--- a/src/JsonApiDotNetCore/QueryStrings/QueryStringReader.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/QueryStringReader.cs
@@ -42,7 +42,10 @@ public sealed class QueryStringReader : IQueryStringReader
 
             if (reader != null)
             {
-                _logger.LogDebug($"Query string parameter '{parameterName}' with value '{parameterValue}' was accepted by {reader.GetType().Name}.");
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug($"Query string parameter '{parameterName}' with value '{parameterValue}' was accepted by {reader.GetType().Name}.");
+                }
 
                 if (!reader.AllowEmptyValue && string.IsNullOrEmpty(parameterValue))
                 {
@@ -58,7 +61,11 @@ public sealed class QueryStringReader : IQueryStringReader
                 }
 
                 reader.Read(parameterName, parameterValue);
-                _logger.LogDebug($"Query string parameter '{parameterName}' was successfully read.");
+
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug($"Query string parameter '{parameterName}' was successfully read.");
+                }
             }
             else if (!_options.AllowUnknownQueryStringParameters)
             {


### PR DESCRIPTION
#### QUALITY CHECKLIST
- [X] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] Documentation updated

While profiling the query string parsing, 40% of the time was spent in the GC 😬 so I focused on optimizing allocations.

Before
| Method  | argument            | Mean      | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|-------- |-------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
| ReadAll | filt(...)name [121] | 12.347 us | 0.0965 us | 0.2099 us | 0.0610 | 0.0153 |  19.92 KB |

After
| Method  | argument            | Mean      | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|-------- |-------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
| ReadAll | filt(...)name [121] | 10.014 us | 0.1852 us | 0.4143 us | 0.0458 | 0.0153 |  15.84 KB |

You can find the result of each commit in their message.