### PR TITLE
Add missing documentation for type parameters

### DIFF
--- a/src/JsonApiDotNetCore/Queries/Expressions/QueryExpressionVisitor.cs
+++ b/src/JsonApiDotNetCore/Queries/Expressions/QueryExpressionVisitor.cs
@@ -5,6 +5,12 @@ namespace JsonApiDotNetCore.Queries.Expressions;
 /// <summary>
 /// Implements the visitor design pattern that enables traversing a <see cref="QueryExpression" /> tree.
 /// </summary>
+/// <typeparam name="TArgument">
+/// The type to use for passing custom state between visit methods.
+/// </typeparam>
+/// <typeparam name="TResult">
+/// The type that is returned from visit methods.
+/// </typeparam>
 [PublicAPI]
 public abstract class QueryExpressionVisitor<TArgument, TResult>
 {

--- a/src/JsonApiDotNetCore/Repositories/DbContextResolver.cs
+++ b/src/JsonApiDotNetCore/Repositories/DbContextResolver.cs
@@ -4,6 +4,9 @@ using Microsoft.EntityFrameworkCore;
 namespace JsonApiDotNetCore.Repositories;
 
 /// <inheritdoc cref="IDbContextResolver" />
+/// <typeparam name="TDbContext">
+/// The type of the <see cref="DbContext" /> to resolve.
+/// </typeparam>
 [PublicAPI]
 public sealed class DbContextResolver<TDbContext> : IDbContextResolver
     where TDbContext : DbContext

--- a/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
+++ b/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
@@ -21,6 +21,12 @@ namespace JsonApiDotNetCore.Repositories;
 /// <summary>
 /// Implements the foundational Repository layer in the JsonApiDotNetCore architecture that uses Entity Framework Core.
 /// </summary>
+/// <typeparam name="TResource">
+/// The resource type.
+/// </typeparam>
+/// <typeparam name="TId">
+/// The resource identifier type.
+/// </typeparam>
 [PublicAPI]
 public class EntityFrameworkCoreRepository<TResource, TId> : IResourceRepository<TResource, TId>, IRepositorySupportsTransaction
     where TResource : class, IIdentifiable<TId>

--- a/src/JsonApiDotNetCore/Resources/IResourceChangeTracker.cs
+++ b/src/JsonApiDotNetCore/Resources/IResourceChangeTracker.cs
@@ -3,6 +3,9 @@ namespace JsonApiDotNetCore.Resources;
 /// <summary>
 /// Used to determine whether additional changes to a resource (side effects), not specified in a POST or PATCH request, have been applied.
 /// </summary>
+/// <typeparam name="TResource">
+/// The resource type.
+/// </typeparam>
 public interface IResourceChangeTracker<in TResource>
     where TResource : class, IIdentifiable
 {

--- a/src/JsonApiDotNetCore/Resources/QueryStringParameterHandlers.cs
+++ b/src/JsonApiDotNetCore/Resources/QueryStringParameterHandlers.cs
@@ -6,4 +6,7 @@ namespace JsonApiDotNetCore.Resources;
 /// This is an alias type intended to simplify the implementation's method signature. See
 /// <see cref="IResourceDefinition{TResource, TId}.OnRegisterQueryableHandlersForQueryStringParameters" /> for usage details.
 /// </summary>
+/// <typeparam name="TResource">
+/// The resource type.
+/// </typeparam>
 public sealed class QueryStringParameterHandlers<TResource> : Dictionary<string, Func<IQueryable<TResource>, StringValues, IQueryable<TResource>>>;

--- a/src/JsonApiDotNetCore/Serialization/Objects/SingleOrManyData.cs
+++ b/src/JsonApiDotNetCore/Serialization/Objects/SingleOrManyData.cs
@@ -9,6 +9,9 @@ namespace JsonApiDotNetCore.Serialization.Objects;
 /// Represents the value of the "data" element, which is either null, a single object or an array of objects. Add
 /// <see cref="SingleOrManyDataConverterFactory" /> to <see cref="JsonSerializerOptions.Converters" /> to properly roundtrip.
 /// </summary>
+/// <typeparam name="T">
+/// The type of elements being wrapped, typically <see cref="ResourceIdentifierObject" /> or <see cref="ResourceObject" />.
+/// </typeparam>
 [PublicAPI]
 public readonly struct SingleOrManyData<T>
     // The "new()" constraint exists for parity with SingleOrManyDataConverterFactory, which creates empty instances


### PR DESCRIPTION
This PR adds missing documentation for type parameters. These show up in IDE completions (IntelliSense) an the API browser on the documentation website.

Closes #{ISSUE_NUMBER}

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
