### PR TITLE
Enable setting the "describedby" top-level link

### DIFF
--- a/src/JsonApiDotNetCore/Configuration/JsonApiApplicationBuilder.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiApplicationBuilder.cs
@@ -168,6 +168,7 @@ internal sealed class JsonApiApplicationBuilder : IJsonApiApplicationBuilder
         _services.TryAddScoped<ISparseFieldSetCache, SparseFieldSetCache>();
         _services.TryAddScoped<IQueryLayerComposer, QueryLayerComposer>();
         _services.TryAddScoped<IInverseNavigationResolver, InverseNavigationResolver>();
+        _services.TryAddSingleton<IDocumentDescriptionLinkProvider, NoDocumentDescriptionLinkProvider>();
     }
 
     private void AddMiddlewareLayer()

--- a/src/JsonApiDotNetCore/Serialization/Response/IDocumentDescriptionLinkProvider.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/IDocumentDescriptionLinkProvider.cs
@@ -1,0 +1,17 @@
+using JsonApiDotNetCore.Configuration;
+
+namespace JsonApiDotNetCore.Serialization.Response;
+
+/// <summary>
+/// Provides the value for the "describedby" link in https://jsonapi.org/format/#document-top-level.
+/// </summary>
+public interface IDocumentDescriptionLinkProvider
+{
+    /// <summary>
+    /// Gets the URL for the "describedby" link, or <c>null</c> when unavailable.
+    /// </summary>
+    /// <remarks>
+    /// The returned URL can be absolute or relative. If possible, it gets converted based on <see cref="IJsonApiOptions.UseRelativeLinks" />.
+    /// </remarks>
+    string? GetUrl();
+}

--- a/src/JsonApiDotNetCore/Serialization/Response/NoDocumentDescriptionLinkProvider.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/NoDocumentDescriptionLinkProvider.cs
@@ -1,0 +1,15 @@
+namespace JsonApiDotNetCore.Serialization.Response;
+
+/// <summary>
+/// Provides no value for the "describedby" link in https://jsonapi.org/format/#document-top-level.
+/// </summary>
+public sealed class NoDocumentDescriptionLinkProvider : IDocumentDescriptionLinkProvider
+{
+    /// <summary>
+    /// Always returns <c>null</c>.
+    /// </summary>
+    public string? GetUrl()
+    {
+        return null;
+    }
+}

--- a/src/JsonApiDotNetCore/Serialization/Response/UriNormalizer.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/UriNormalizer.cs
@@ -1,0 +1,80 @@
+namespace JsonApiDotNetCore.Serialization.Response;
+
+internal sealed class UriNormalizer
+{
+    /// <summary>
+    /// Converts a URL to absolute or relative format, if possible.
+    /// </summary>
+    /// <param name="sourceUrl">
+    /// The absolute or relative URL to normalize.
+    /// </param>
+    /// <param name="preferRelative">
+    /// Whether to convert <paramref name="sourceUrl" /> to absolute or relative format.
+    /// </param>
+    /// <param name="requestUri">
+    /// The URL of the current HTTP request, whose path and query string are discarded.
+    /// </param>
+    public string Normalize(string sourceUrl, bool preferRelative, Uri requestUri)
+    {
+        var sourceUri = new Uri(sourceUrl, UriKind.RelativeOrAbsolute);
+        Uri baseUri = RemovePathFromAbsoluteUri(requestUri);
+
+        if (!sourceUri.IsAbsoluteUri && !preferRelative)
+        {
+            var absoluteUri = new Uri(baseUri, sourceUrl);
+            return absoluteUri.AbsoluteUri;
+        }
+
+        if (sourceUri.IsAbsoluteUri && preferRelative)
+        {
+            if (AreSameServer(baseUri, sourceUri))
+            {
+                Uri relativeUri = baseUri.MakeRelativeUri(sourceUri);
+                return relativeUri.ToString();
+            }
+        }
+
+        return sourceUrl;
+    }
+
+    private static Uri RemovePathFromAbsoluteUri(Uri uri)
+    {
+        var requestUriBuilder = new UriBuilder(uri)
+        {
+            Path = null
+        };
+
+        return requestUriBuilder.Uri;
+    }
+
+    private static bool AreSameServer(Uri left, Uri right)
+    {
+        // Custom implementation because Uri.Equals() ignores the casing of username/password.
+
+        string leftScheme = left.GetComponents(UriComponents.Scheme, UriFormat.UriEscaped);
+        string rightScheme = right.GetComponents(UriComponents.Scheme, UriFormat.UriEscaped);
+
+        if (!string.Equals(leftScheme, rightScheme, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string leftServer = left.GetComponents(UriComponents.HostAndPort, UriFormat.UriEscaped);
+        string rightServer = right.GetComponents(UriComponents.HostAndPort, UriFormat.UriEscaped);
+
+        if (!string.Equals(leftServer, rightServer, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string leftUserInfo = left.GetComponents(UriComponents.UserInfo, UriFormat.UriEscaped);
+        string rightUserInfo = right.GetComponents(UriComponents.UserInfo, UriFormat.UriEscaped);
+
+        if (!string.Equals(leftUserInfo, rightUserInfo))
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/AbsoluteLinksWithNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/AbsoluteLinksWithNamespaceTests.cs
@@ -58,6 +58,7 @@ public sealed class AbsoluteLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Links.ShouldNotBeNull();
@@ -101,6 +102,7 @@ public sealed class AbsoluteLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
 
@@ -167,6 +169,7 @@ public sealed class AbsoluteLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         string albumLink = $"{HostPrefix}{PathPrefix}/photoAlbums/{photo.Album.StringId}";
 
@@ -211,6 +214,7 @@ public sealed class AbsoluteLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
 
@@ -259,6 +263,7 @@ public sealed class AbsoluteLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Links.Should().BeNull();
@@ -293,6 +298,7 @@ public sealed class AbsoluteLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
         responseDocument.Data.ManyValue[0].Links.Should().BeNull();
@@ -354,6 +360,7 @@ public sealed class AbsoluteLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Links.ShouldNotBeNull();
@@ -437,6 +444,7 @@ public sealed class AbsoluteLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         string photoLink = $"{HostPrefix}{PathPrefix}/photos/{existingPhoto.StringId}";
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/AbsoluteLinksWithoutNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/AbsoluteLinksWithoutNamespaceTests.cs
@@ -58,6 +58,7 @@ public sealed class AbsoluteLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Links.ShouldNotBeNull();
@@ -101,6 +102,7 @@ public sealed class AbsoluteLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
 
@@ -167,6 +169,7 @@ public sealed class AbsoluteLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         string albumLink = $"{HostPrefix}{PathPrefix}/photoAlbums/{photo.Album.StringId}";
 
@@ -211,6 +214,7 @@ public sealed class AbsoluteLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
 
@@ -259,6 +263,7 @@ public sealed class AbsoluteLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Links.Should().BeNull();
@@ -293,6 +298,7 @@ public sealed class AbsoluteLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
         responseDocument.Data.ManyValue[0].Links.Should().BeNull();
@@ -354,6 +360,7 @@ public sealed class AbsoluteLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Links.ShouldNotBeNull();
@@ -437,6 +444,7 @@ public sealed class AbsoluteLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         string photoLink = $"{HostPrefix}{PathPrefix}/photos/{existingPhoto.StringId}";
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/DocumentDescriptionLinkTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/DocumentDescriptionLinkTests.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using FluentAssertions;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Serialization.Objects;
+using JsonApiDotNetCore.Serialization.Response;
+using Microsoft.Extensions.DependencyInjection;
+using TestBuildingBlocks;
+using Xunit;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.Links;
+
+public sealed class DocumentDescriptionLinkTests : IClassFixture<IntegrationTestContext<TestableStartup<LinksDbContext>, LinksDbContext>>
+{
+    private readonly IntegrationTestContext<TestableStartup<LinksDbContext>, LinksDbContext> _testContext;
+
+    public DocumentDescriptionLinkTests(IntegrationTestContext<TestableStartup<LinksDbContext>, LinksDbContext> testContext)
+    {
+        _testContext = testContext;
+
+        testContext.UseController<PhotosController>();
+
+        testContext.ConfigureServices(services => services.AddSingleton<IDocumentDescriptionLinkProvider, TestDocumentDescriptionLinkProvider>());
+    }
+
+    [Fact]
+    public async Task Get_primary_resource_by_ID_converts_relative_documentation_link_to_absolute()
+    {
+        // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.UseRelativeLinks = false;
+
+        var provider = (TestDocumentDescriptionLinkProvider)_testContext.Factory.Services.GetRequiredService<IDocumentDescriptionLinkProvider>();
+        provider.Link = "description/json-schema?version=v1.0";
+
+        string route = $"/photos/{Unknown.StringId.For<Photo, Guid>()}";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NotFound);
+
+        responseDocument.Links.ShouldNotBeNull();
+        responseDocument.Links.DescribedBy.Should().Be("http://localhost/description/json-schema?version=v1.0");
+    }
+
+    [Fact]
+    public async Task Get_primary_resource_by_ID_converts_absolute_documentation_link_to_relative()
+    {
+        // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.UseRelativeLinks = true;
+
+        var provider = (TestDocumentDescriptionLinkProvider)_testContext.Factory.Services.GetRequiredService<IDocumentDescriptionLinkProvider>();
+        provider.Link = "http://localhost:80/description/json-schema?version=v1.0";
+
+        string route = $"/photos/{Unknown.StringId.For<Photo, Guid>()}";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NotFound);
+
+        responseDocument.Links.ShouldNotBeNull();
+        responseDocument.Links.DescribedBy.Should().Be("description/json-schema?version=v1.0");
+    }
+
+    [Fact]
+    public async Task Get_primary_resource_by_ID_cannot_convert_absolute_documentation_link_to_relative()
+    {
+        // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.UseRelativeLinks = true;
+
+        var provider = (TestDocumentDescriptionLinkProvider)_testContext.Factory.Services.GetRequiredService<IDocumentDescriptionLinkProvider>();
+        provider.Link = "https://docs.api.com/description/json-schema?version=v1.0";
+
+        string route = $"/photos/{Unknown.StringId.For<Photo, Guid>()}";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NotFound);
+
+        responseDocument.Links.ShouldNotBeNull();
+        responseDocument.Links.DescribedBy.Should().Be("https://docs.api.com/description/json-schema?version=v1.0");
+    }
+
+    private sealed class TestDocumentDescriptionLinkProvider : IDocumentDescriptionLinkProvider
+    {
+        public string? Link { get; set; }
+
+        public string? GetUrl()
+        {
+            return Link;
+        }
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/RelativeLinksWithNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/RelativeLinksWithNamespaceTests.cs
@@ -58,6 +58,7 @@ public sealed class RelativeLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Links.ShouldNotBeNull();
@@ -101,6 +102,7 @@ public sealed class RelativeLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
 
@@ -167,6 +169,7 @@ public sealed class RelativeLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         string albumLink = $"{HostPrefix}{PathPrefix}/photoAlbums/{photo.Album.StringId}";
 
@@ -211,6 +214,7 @@ public sealed class RelativeLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
 
@@ -259,6 +263,7 @@ public sealed class RelativeLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Links.Should().BeNull();
@@ -293,6 +298,7 @@ public sealed class RelativeLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
         responseDocument.Data.ManyValue[0].Links.Should().BeNull();
@@ -354,6 +360,7 @@ public sealed class RelativeLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Links.ShouldNotBeNull();
@@ -437,6 +444,7 @@ public sealed class RelativeLinksWithNamespaceTests : IClassFixture<IntegrationT
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         string photoLink = $"{HostPrefix}{PathPrefix}/photos/{existingPhoto.StringId}";
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/RelativeLinksWithoutNamespaceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/RelativeLinksWithoutNamespaceTests.cs
@@ -58,6 +58,7 @@ public sealed class RelativeLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Links.ShouldNotBeNull();
@@ -101,6 +102,7 @@ public sealed class RelativeLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
 
@@ -167,6 +169,7 @@ public sealed class RelativeLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         string albumLink = $"{HostPrefix}{PathPrefix}/photoAlbums/{photo.Album.StringId}";
 
@@ -211,6 +214,7 @@ public sealed class RelativeLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
 
@@ -259,6 +263,7 @@ public sealed class RelativeLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Links.Should().BeNull();
@@ -293,6 +298,7 @@ public sealed class RelativeLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().Be(responseDocument.Links.Self);
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
         responseDocument.Data.ManyValue[0].Links.Should().BeNull();
@@ -354,6 +360,7 @@ public sealed class RelativeLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Links.ShouldNotBeNull();
@@ -437,6 +444,7 @@ public sealed class RelativeLinksWithoutNamespaceTests : IClassFixture<Integrati
         responseDocument.Links.Last.Should().BeNull();
         responseDocument.Links.Prev.Should().BeNull();
         responseDocument.Links.Next.Should().BeNull();
+        responseDocument.Links.DescribedBy.Should().BeNull();
 
         string photoLink = $"{HostPrefix}{PathPrefix}/photos/{existingPhoto.StringId}";
 

--- a/test/JsonApiDotNetCoreTests/UnitTests/Links/LinkInclusionTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Links/LinkInclusionTests.cs
@@ -88,7 +88,10 @@ public sealed class LinkInclusionTests
         var linkGenerator = new FakeLinkGenerator();
         var controllerResourceMapping = new FakeControllerResourceMapping();
         var paginationParser = new PaginationParser();
-        var linkBuilder = new LinkBuilder(options, request, paginationContext, httpContextAccessor, linkGenerator, controllerResourceMapping, paginationParser);
+        var documentDescriptionLinkProvider = new NoDocumentDescriptionLinkProvider();
+
+        var linkBuilder = new LinkBuilder(options, request, paginationContext, httpContextAccessor, linkGenerator, controllerResourceMapping, paginationParser,
+            documentDescriptionLinkProvider);
 
         // Act
         TopLevelLinks? topLevelLinks = linkBuilder.GetTopLevelLinks();
@@ -171,7 +174,10 @@ public sealed class LinkInclusionTests
         var linkGenerator = new FakeLinkGenerator();
         var controllerResourceMapping = new FakeControllerResourceMapping();
         var paginationParser = new PaginationParser();
-        var linkBuilder = new LinkBuilder(options, request, paginationContext, httpContextAccessor, linkGenerator, controllerResourceMapping, paginationParser);
+        var documentDescriptionLinkProvider = new NoDocumentDescriptionLinkProvider();
+
+        var linkBuilder = new LinkBuilder(options, request, paginationContext, httpContextAccessor, linkGenerator, controllerResourceMapping, paginationParser,
+            documentDescriptionLinkProvider);
 
         // Act
         ResourceLinks? resourceLinks = linkBuilder.GetResourceLinks(exampleResourceType, new ExampleResource());
@@ -332,7 +338,10 @@ public sealed class LinkInclusionTests
         var linkGenerator = new FakeLinkGenerator();
         var controllerResourceMapping = new FakeControllerResourceMapping();
         var paginationParser = new PaginationParser();
-        var linkBuilder = new LinkBuilder(options, request, paginationContext, httpContextAccessor, linkGenerator, controllerResourceMapping, paginationParser);
+        var documentDescriptionLinkProvider = new NoDocumentDescriptionLinkProvider();
+
+        var linkBuilder = new LinkBuilder(options, request, paginationContext, httpContextAccessor, linkGenerator, controllerResourceMapping, paginationParser,
+            documentDescriptionLinkProvider);
 
         var relationship = new HasOneAttribute
         {

--- a/test/JsonApiDotNetCoreTests/UnitTests/Links/UriNormalizerTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Links/UriNormalizerTests.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using JsonApiDotNetCore.Serialization.Response;
+using Xunit;
+
+namespace JsonApiDotNetCoreTests.UnitTests.Links;
+
+public sealed class UriNormalizerTests
+{
+    [Theory]
+    [InlineData("some/path", "http://localhost")]
+    [InlineData("some?version=1", "http://localhost")]
+    public void Keeps_relative_URL_relative(string sourceUrl, string requestUrl)
+    {
+        // Arrange
+        var normalizer = new UriNormalizer();
+
+        // Act
+        string result = normalizer.Normalize(sourceUrl, true, new Uri(requestUrl));
+
+        // Assert
+        result.Should().Be(sourceUrl);
+    }
+
+    [Theory]
+    [InlineData("some/path", "http://localhost", "http://localhost/some/path")]
+    [InlineData("some/path", "https://api-server.com", "https://api-server.com/some/path")]
+    [InlineData("some/path", "https://user:pass@api-server.com:9999", "https://user:pass@api-server.com:9999/some/path")]
+    [InlineData("some/path", "http://localhost/api/articles?debug=true#anchor", "http://localhost/some/path")]
+    [InlineData("some?version=1", "http://localhost/api/articles/1?debug=true#anchor", "http://localhost/some?version=1")]
+    public void Makes_relative_URL_absolute(string sourceUrl, string requestUrl, string expected)
+    {
+        // Arrange
+        var normalizer = new UriNormalizer();
+
+        // Act
+        string result = normalizer.Normalize(sourceUrl, false, new Uri(requestUrl));
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("http://localhost/some/path", "http://api-server.com")]
+    [InlineData("http://localhost/some/path", "https://localhost")]
+    [InlineData("http://localhost:8080/some/path", "http://localhost")]
+    [InlineData("http://user:pass@localhost/some/path?version=1", "http://localhost")]
+    [InlineData("http://user:pass@localhost/some/path?version=1", "http://USER:PASS@localhost")]
+    public void Keeps_absolute_URL_absolute(string sourceUrl, string requestUrl)
+    {
+        // Arrange
+        var normalizer = new UriNormalizer();
+
+        // Act
+        string result = normalizer.Normalize(sourceUrl, true, new Uri(requestUrl));
+
+        // Assert
+        result.Should().Be(sourceUrl);
+    }
+
+    [Theory]
+    [InlineData("http://localhost/some/path", "http://localhost/api/articles/1", "some/path")]
+    [InlineData("http://api-server.com/some/path", "http://api-server.com/api/articles/1", "some/path")]
+    [InlineData("https://localhost/some/path", "https://localhost/api/articles/1", "some/path")]
+    [InlineData("https://localhost:443/some/path", "https://localhost/api/articles/1", "some/path")]
+    [InlineData("https://localhost/some/path", "https://localhost:443/api/articles/1", "some/path")]
+    [InlineData("HTTPS://LOCALHOST/some/path", "https://localhost:443/api/articles/1", "some/path")]
+    public void Makes_absolute_URL_relative(string sourceUrl, string requestUrl, string expected)
+    {
+        // Arrange
+        var normalizer = new UriNormalizer();
+
+        // Act
+        string result = normalizer.Normalize(sourceUrl, true, new Uri(requestUrl));
+
+        // Assert
+        result.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
This PR enables to plug in a custom `IDocumentDescriptionLinkProvider`, which is used to set the "describedby" [top-level link](https://jsonapi.org/format/#document-top-level).

While the default implementation doesn't do anything, this building block is required for our OpenAPI integration.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
