### PR TITLE
Move back [FromBody] and [Required] to derived controllers

### DIFF
--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiController.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Errors;
 using JsonApiDotNetCore.Middleware;
@@ -107,7 +106,7 @@ public abstract class BaseJsonApiController<TResource, TId> : CoreJsonApiControl
     /// GET /articles/1 HTTP/1.1
     /// ]]></code>
     /// </summary>
-    public virtual async Task<IActionResult> GetAsync([Required] TId id, CancellationToken cancellationToken)
+    public virtual async Task<IActionResult> GetAsync(TId id, CancellationToken cancellationToken)
     {
         _traceWriter.LogMethodStart(new
         {
@@ -132,7 +131,7 @@ public abstract class BaseJsonApiController<TResource, TId> : CoreJsonApiControl
     /// GET /articles/1/revisions HTTP/1.1
     /// ]]></code>
     /// </summary>
-    public virtual async Task<IActionResult> GetSecondaryAsync([Required] TId id, [Required] string relationshipName, CancellationToken cancellationToken)
+    public virtual async Task<IActionResult> GetSecondaryAsync(TId id, string relationshipName, CancellationToken cancellationToken)
     {
         _traceWriter.LogMethodStart(new
         {
@@ -161,7 +160,7 @@ public abstract class BaseJsonApiController<TResource, TId> : CoreJsonApiControl
     /// GET /articles/1/relationships/revisions HTTP/1.1
     /// ]]></code>
     /// </summary>
-    public virtual async Task<IActionResult> GetRelationshipAsync([Required] TId id, [Required] string relationshipName, CancellationToken cancellationToken)
+    public virtual async Task<IActionResult> GetRelationshipAsync(TId id, string relationshipName, CancellationToken cancellationToken)
     {
         _traceWriter.LogMethodStart(new
         {
@@ -186,7 +185,7 @@ public abstract class BaseJsonApiController<TResource, TId> : CoreJsonApiControl
     /// POST /articles HTTP/1.1
     /// ]]></code>
     /// </summary>
-    public virtual async Task<IActionResult> PostAsync([FromBody] [Required] TResource resource, CancellationToken cancellationToken)
+    public virtual async Task<IActionResult> PostAsync(TResource resource, CancellationToken cancellationToken)
     {
         _traceWriter.LogMethodStart(new
         {
@@ -236,8 +235,8 @@ public abstract class BaseJsonApiController<TResource, TId> : CoreJsonApiControl
     /// <param name="cancellationToken">
     /// Propagates notification that request handling should be canceled.
     /// </param>
-    public virtual async Task<IActionResult> PostRelationshipAsync([Required] TId id, [Required] string relationshipName,
-        [FromBody] [Required] ISet<IIdentifiable> rightResourceIds, CancellationToken cancellationToken)
+    public virtual async Task<IActionResult> PostRelationshipAsync(TId id, string relationshipName, ISet<IIdentifiable> rightResourceIds,
+        CancellationToken cancellationToken)
     {
         _traceWriter.LogMethodStart(new
         {
@@ -265,7 +264,7 @@ public abstract class BaseJsonApiController<TResource, TId> : CoreJsonApiControl
     /// PATCH /articles/1 HTTP/1.1
     /// ]]></code>
     /// </summary>
-    public virtual async Task<IActionResult> PatchAsync([Required] TId id, [FromBody] [Required] TResource resource, CancellationToken cancellationToken)
+    public virtual async Task<IActionResult> PatchAsync(TId id, TResource resource, CancellationToken cancellationToken)
     {
         _traceWriter.LogMethodStart(new
         {
@@ -311,8 +310,7 @@ public abstract class BaseJsonApiController<TResource, TId> : CoreJsonApiControl
     /// <param name="cancellationToken">
     /// Propagates notification that request handling should be canceled.
     /// </param>
-    public virtual async Task<IActionResult> PatchRelationshipAsync([Required] TId id, [Required] string relationshipName, [FromBody] object? rightValue,
-        CancellationToken cancellationToken)
+    public virtual async Task<IActionResult> PatchRelationshipAsync(TId id, string relationshipName, object? rightValue, CancellationToken cancellationToken)
     {
         _traceWriter.LogMethodStart(new
         {
@@ -338,7 +336,7 @@ public abstract class BaseJsonApiController<TResource, TId> : CoreJsonApiControl
     /// DELETE /articles/1 HTTP/1.1
     /// ]]></code>
     /// </summary>
-    public virtual async Task<IActionResult> DeleteAsync([Required] TId id, CancellationToken cancellationToken)
+    public virtual async Task<IActionResult> DeleteAsync(TId id, CancellationToken cancellationToken)
     {
         _traceWriter.LogMethodStart(new
         {
@@ -372,8 +370,8 @@ public abstract class BaseJsonApiController<TResource, TId> : CoreJsonApiControl
     /// <param name="cancellationToken">
     /// Propagates notification that request handling should be canceled.
     /// </param>
-    public virtual async Task<IActionResult> DeleteRelationshipAsync([Required] TId id, [Required] string relationshipName,
-        [FromBody] [Required] ISet<IIdentifiable> rightResourceIds, CancellationToken cancellationToken)
+    public virtual async Task<IActionResult> DeleteRelationshipAsync(TId id, string relationshipName, ISet<IIdentifiable> rightResourceIds,
+        CancellationToken cancellationToken)
     {
         _traceWriter.LogMethodStart(new
         {

--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiOperationsController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiOperationsController.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
 using JsonApiDotNetCore.AtomicOperations;
 using JsonApiDotNetCore.Configuration;
@@ -103,8 +102,7 @@ public abstract class BaseJsonApiOperationsController : CoreJsonApiController
     /// }
     /// ]]></code>
     /// </example>
-    public virtual async Task<IActionResult> PostOperationsAsync([FromBody] [Required] IList<OperationContainer> operations,
-        CancellationToken cancellationToken)
+    public virtual async Task<IActionResult> PostOperationsAsync(IList<OperationContainer> operations, CancellationToken cancellationToken)
     {
         _traceWriter.LogMethodStart(new
         {

--- a/src/JsonApiDotNetCore/Controllers/JsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/JsonApiController.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Services;
@@ -49,7 +50,7 @@ public abstract class JsonApiController<TResource, TId> : BaseJsonApiController<
     /// <inheritdoc />
     [HttpGet("{id}")]
     [HttpHead("{id}")]
-    public override Task<IActionResult> GetAsync(TId id, CancellationToken cancellationToken)
+    public override Task<IActionResult> GetAsync([Required] TId id, CancellationToken cancellationToken)
     {
         return base.GetAsync(id, cancellationToken);
     }
@@ -57,7 +58,7 @@ public abstract class JsonApiController<TResource, TId> : BaseJsonApiController<
     /// <inheritdoc />
     [HttpGet("{id}/{relationshipName}")]
     [HttpHead("{id}/{relationshipName}")]
-    public override Task<IActionResult> GetSecondaryAsync(TId id, string relationshipName, CancellationToken cancellationToken)
+    public override Task<IActionResult> GetSecondaryAsync([Required] TId id, [Required] string relationshipName, CancellationToken cancellationToken)
     {
         return base.GetSecondaryAsync(id, relationshipName, cancellationToken);
     }
@@ -65,36 +66,37 @@ public abstract class JsonApiController<TResource, TId> : BaseJsonApiController<
     /// <inheritdoc />
     [HttpGet("{id}/relationships/{relationshipName}")]
     [HttpHead("{id}/relationships/{relationshipName}")]
-    public override Task<IActionResult> GetRelationshipAsync(TId id, string relationshipName, CancellationToken cancellationToken)
+    public override Task<IActionResult> GetRelationshipAsync([Required] TId id, [Required] string relationshipName, CancellationToken cancellationToken)
     {
         return base.GetRelationshipAsync(id, relationshipName, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpPost]
-    public override Task<IActionResult> PostAsync(TResource resource, CancellationToken cancellationToken)
+    public override Task<IActionResult> PostAsync([FromBody] [Required] TResource resource, CancellationToken cancellationToken)
     {
         return base.PostAsync(resource, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpPost("{id}/relationships/{relationshipName}")]
-    public override Task<IActionResult> PostRelationshipAsync(TId id, string relationshipName, ISet<IIdentifiable> rightResourceIds,
-        CancellationToken cancellationToken)
+    public override Task<IActionResult> PostRelationshipAsync([Required] TId id, [Required] string relationshipName,
+        [FromBody] [Required] ISet<IIdentifiable> rightResourceIds, CancellationToken cancellationToken)
     {
         return base.PostRelationshipAsync(id, relationshipName, rightResourceIds, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpPatch("{id}")]
-    public override Task<IActionResult> PatchAsync(TId id, TResource resource, CancellationToken cancellationToken)
+    public override Task<IActionResult> PatchAsync([Required] TId id, [FromBody] [Required] TResource resource, CancellationToken cancellationToken)
     {
         return base.PatchAsync(id, resource, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpPatch("{id}/relationships/{relationshipName}")]
-    public override Task<IActionResult> PatchRelationshipAsync(TId id, string relationshipName, [FromBody] object? rightValue,
+    // Parameter `[Required] object? rightValue` makes Swashbuckle generate the OpenAPI request body as required. We don't actually validate ModelState, so it doesn't hurt.
+    public override Task<IActionResult> PatchRelationshipAsync([Required] TId id, [Required] string relationshipName, [FromBody] [Required] object? rightValue,
         CancellationToken cancellationToken)
     {
         return base.PatchRelationshipAsync(id, relationshipName, rightValue, cancellationToken);
@@ -102,15 +104,15 @@ public abstract class JsonApiController<TResource, TId> : BaseJsonApiController<
 
     /// <inheritdoc />
     [HttpDelete("{id}")]
-    public override Task<IActionResult> DeleteAsync(TId id, CancellationToken cancellationToken)
+    public override Task<IActionResult> DeleteAsync([Required] TId id, CancellationToken cancellationToken)
     {
         return base.DeleteAsync(id, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpDelete("{id}/relationships/{relationshipName}")]
-    public override Task<IActionResult> DeleteRelationshipAsync(TId id, string relationshipName, ISet<IIdentifiable> rightResourceIds,
-        CancellationToken cancellationToken)
+    public override Task<IActionResult> DeleteRelationshipAsync([Required] TId id, [Required] string relationshipName,
+        [FromBody] [Required] ISet<IIdentifiable> rightResourceIds, CancellationToken cancellationToken)
     {
         return base.DeleteRelationshipAsync(id, relationshipName, rightResourceIds, cancellationToken);
     }

--- a/src/JsonApiDotNetCore/Controllers/JsonApiOperationsController.cs
+++ b/src/JsonApiDotNetCore/Controllers/JsonApiOperationsController.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using JsonApiDotNetCore.AtomicOperations;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Middleware;
@@ -17,7 +18,7 @@ public abstract class JsonApiOperationsController(
 {
     /// <inheritdoc />
     [HttpPost]
-    public override Task<IActionResult> PostOperationsAsync(IList<OperationContainer> operations, CancellationToken cancellationToken)
+    public override Task<IActionResult> PostOperationsAsync([FromBody] [Required] IList<OperationContainer> operations, CancellationToken cancellationToken)
     {
         return base.PostOperationsAsync(operations, cancellationToken);
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/IdObfuscation/ObfuscatedIdentifiableController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/IdObfuscation/ObfuscatedIdentifiableController.cs
@@ -22,21 +22,21 @@ public abstract class ObfuscatedIdentifiableController<TResource>(
     }
 
     [HttpGet("{id}")]
-    public Task<IActionResult> GetAsync(string id, CancellationToken cancellationToken)
+    public Task<IActionResult> GetAsync([Required] string id, CancellationToken cancellationToken)
     {
         int idValue = _codec.Decode(id);
         return base.GetAsync(idValue, cancellationToken);
     }
 
     [HttpGet("{id}/{relationshipName}")]
-    public Task<IActionResult> GetSecondaryAsync(string id, string relationshipName, CancellationToken cancellationToken)
+    public Task<IActionResult> GetSecondaryAsync([Required] string id, [Required] string relationshipName, CancellationToken cancellationToken)
     {
         int idValue = _codec.Decode(id);
         return base.GetSecondaryAsync(idValue, relationshipName, cancellationToken);
     }
 
     [HttpGet("{id}/relationships/{relationshipName}")]
-    public Task<IActionResult> GetRelationshipAsync(string id, string relationshipName, CancellationToken cancellationToken)
+    public Task<IActionResult> GetRelationshipAsync([Required] string id, [Required] string relationshipName, CancellationToken cancellationToken)
     {
         int idValue = _codec.Decode(id);
         return base.GetRelationshipAsync(idValue, relationshipName, cancellationToken);
@@ -49,37 +49,39 @@ public abstract class ObfuscatedIdentifiableController<TResource>(
     }
 
     [HttpPost("{id}/relationships/{relationshipName}")]
-    public Task<IActionResult> PostRelationshipAsync(string id, string relationshipName, [FromBody] [Required] ISet<IIdentifiable> rightResourceIds,
-        CancellationToken cancellationToken)
+    public Task<IActionResult> PostRelationshipAsync([Required] string id, [Required] string relationshipName,
+        [FromBody] [Required] ISet<IIdentifiable> rightResourceIds, CancellationToken cancellationToken)
     {
         int idValue = _codec.Decode(id);
         return base.PostRelationshipAsync(idValue, relationshipName, rightResourceIds, cancellationToken);
     }
 
     [HttpPatch("{id}")]
-    public Task<IActionResult> PatchAsync(string id, [FromBody] [Required] TResource resource, CancellationToken cancellationToken)
+    public Task<IActionResult> PatchAsync([Required] string id, [FromBody] [Required] TResource resource, CancellationToken cancellationToken)
     {
         int idValue = _codec.Decode(id);
         return base.PatchAsync(idValue, resource, cancellationToken);
     }
 
     [HttpPatch("{id}/relationships/{relationshipName}")]
-    public Task<IActionResult> PatchRelationshipAsync(string id, string relationshipName, [FromBody] object? rightValue, CancellationToken cancellationToken)
+    // Parameter `[Required] object? rightValue` makes Swashbuckle generate the OpenAPI request body as required. We don't actually validate ModelState, so it doesn't hurt.
+    public Task<IActionResult> PatchRelationshipAsync([Required] string id, [Required] string relationshipName, [FromBody] [Required] object? rightValue,
+        CancellationToken cancellationToken)
     {
         int idValue = _codec.Decode(id);
         return base.PatchRelationshipAsync(idValue, relationshipName, rightValue, cancellationToken);
     }
 
     [HttpDelete("{id}")]
-    public Task<IActionResult> DeleteAsync(string id, CancellationToken cancellationToken)
+    public Task<IActionResult> DeleteAsync([Required] string id, CancellationToken cancellationToken)
     {
         int idValue = _codec.Decode(id);
         return base.DeleteAsync(idValue, cancellationToken);
     }
 
     [HttpDelete("{id}/relationships/{relationshipName}")]
-    public Task<IActionResult> DeleteRelationshipAsync(string id, string relationshipName, [FromBody] [Required] ISet<IIdentifiable> rightResourceIds,
-        CancellationToken cancellationToken)
+    public Task<IActionResult> DeleteRelationshipAsync([Required] string id, [Required] string relationshipName,
+        [FromBody] [Required] ISet<IIdentifiable> rightResourceIds, CancellationToken cancellationToken)
     {
         int idValue = _codec.Decode(id);
         return base.DeleteRelationshipAsync(idValue, relationshipName, rightResourceIds, cancellationToken);


### PR DESCRIPTION
This PR moves back `[FromBody]` and `[Required]` to derived controllers, reverting most of the previous PR (#1503). It turns out that ASP.NET ModelState doesn't take attributes on base parameters into account.

As is often the case, there's more to it. The [`ParameterInfo.GetCustomAttributes`](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.parameterinfo.getcustomattributes) method has always had the bug that it doesn't look at attributes on base methods, even with `inherit: true`. To address that, without taking a breaking change, [`Attribute.GetCustomAttributes`](https://learn.microsoft.com/en-us/dotnet/api/system.attribute.getcustomattributes) was introduced, which properly takes base classes into account (but not interfaces). Aside from StackOverflow [here](https://stackoverflow.com/questions/58863025/are-attribute-getcustomattributes-and-memberinfo-getcustomattributes-interchange) and [here](https://stackoverflow.com/questions/38700721/reflection-with-generic-syntax-fails-on-a-return-parameter-of-an-overridden-meth), this isn't mentioned _anywhere_ in the official docs (a remark about it was actually _removed_). Only a comment in the [.NET runtime source code](https://github.com/dotnet/runtime/blob/release/8.0/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs#L563-L565) explains it:
```c#
// For ParameterInfo's we need to make sure that we chain through all the MethodInfo's in the inheritance chain that
// have this ParameterInfo defined. .We pick up all the CustomAttributes for the starting ParameterInfo. We need to pick up only attributes
// that are marked inherited from the remainder of the MethodInfo's in the inheritance chain.
// For MethodInfo's on an interface we do not do an inheritance walk so the default ParameterInfo attributes are returned.
// For MethodInfo's on a class we walk up the inheritance chain but do not look at the MethodInfo's on the interfaces that the
// class inherits from and return the respective ParameterInfo attributes
```

However, ASP.NET Core does _not_ use the new method (and neither does Swashbuckle). Tests succeeded in the previous PR because most input validation is handled during JSON:API deserialization, before ModelState kicks in, combined with the fact we only run ModelState validation on POST/PATCH resource endpoints. While we can work around this for Swashbuckle, we can't know what other libraries are out there, possibly using the old broken method. Therefore it seems safest to have the attributes on the derived controller class (as it was). And not having them on the base class, for maximum flexibility for users deriving and tweaking things (same for routes).

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
