### PR TITLE
Revert "Resharper: Replace async method with Task return"

### DIFF
--- a/WarningSeverities.DotSettings
+++ b/WarningSeverities.DotSettings
@@ -166,7 +166,6 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RemoveRedundantOrStatement_002ETrue/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RemoveToList_002E1/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RemoveToList_002E2/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReplaceAsyncWithTaskReturn/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReplaceObjectPatternWithVarPattern/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReplaceSequenceEqualWithConstantPattern/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReplaceWithFirstOrDefault_002E1/@EntryIndexedValue">WARNING</s:String>

--- a/src/Examples/DapperExample/Repositories/DapperRepository.cs
+++ b/src/Examples/DapperExample/Repositories/DapperRepository.cs
@@ -161,7 +161,7 @@ public sealed class DapperRepository<TResource, TId> : IResourceRepository<TReso
     }
 
     /// <inheritdoc />
-    public Task<int> CountAsync(FilterExpression? filter, CancellationToken cancellationToken)
+    public async Task<int> CountAsync(FilterExpression? filter, CancellationToken cancellationToken)
     {
         var queryLayer = new QueryLayer(ResourceType)
         {
@@ -173,7 +173,7 @@ public sealed class DapperRepository<TResource, TId> : IResourceRepository<TReso
         CommandDefinition sqlCommand = _dapperFacade.GetSqlCommand(selectNode, cancellationToken);
         LogSqlCommand(sqlCommand);
 
-        return ExecuteQueryAsync(connection => connection.ExecuteScalarAsync<int>(sqlCommand), cancellationToken);
+        return await ExecuteQueryAsync(async connection => await connection.ExecuteScalarAsync<int>(sqlCommand), cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/JsonApiDotNetCore/AtomicOperations/OperationsProcessor.cs
+++ b/src/JsonApiDotNetCore/AtomicOperations/OperationsProcessor.cs
@@ -99,7 +99,7 @@ public class OperationsProcessor : IOperationsProcessor
         return results;
     }
 
-    protected virtual Task<OperationContainer?> ProcessOperationAsync(OperationContainer operation, CancellationToken cancellationToken)
+    protected virtual async Task<OperationContainer?> ProcessOperationAsync(OperationContainer operation, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -108,7 +108,7 @@ public class OperationsProcessor : IOperationsProcessor
         _targetedFields.CopyFrom(operation.TargetedFields);
         _request.CopyFrom(operation.Request);
 
-        return _operationProcessorAccessor.ProcessAsync(operation, cancellationToken);
+        return await _operationProcessorAccessor.ProcessAsync(operation, cancellationToken);
     }
 
     protected void TrackLocalIdsForOperation(OperationContainer operation)

--- a/src/JsonApiDotNetCore/Controllers/JsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/JsonApiController.cs
@@ -42,78 +42,78 @@ public abstract class JsonApiController<TResource, TId> : BaseJsonApiController<
     /// <inheritdoc />
     [HttpGet]
     [HttpHead]
-    public override Task<IActionResult> GetAsync(CancellationToken cancellationToken)
+    public override async Task<IActionResult> GetAsync(CancellationToken cancellationToken)
     {
-        return base.GetAsync(cancellationToken);
+        return await base.GetAsync(cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpGet("{id}")]
     [HttpHead("{id}")]
-    public override Task<IActionResult> GetAsync([Required] TId id, CancellationToken cancellationToken)
+    public override async Task<IActionResult> GetAsync([Required] TId id, CancellationToken cancellationToken)
     {
-        return base.GetAsync(id, cancellationToken);
+        return await base.GetAsync(id, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpGet("{id}/{relationshipName}")]
     [HttpHead("{id}/{relationshipName}")]
-    public override Task<IActionResult> GetSecondaryAsync([Required] TId id, [Required] string relationshipName, CancellationToken cancellationToken)
+    public override async Task<IActionResult> GetSecondaryAsync([Required] TId id, [Required] string relationshipName, CancellationToken cancellationToken)
     {
-        return base.GetSecondaryAsync(id, relationshipName, cancellationToken);
+        return await base.GetSecondaryAsync(id, relationshipName, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpGet("{id}/relationships/{relationshipName}")]
     [HttpHead("{id}/relationships/{relationshipName}")]
-    public override Task<IActionResult> GetRelationshipAsync([Required] TId id, [Required] string relationshipName, CancellationToken cancellationToken)
+    public override async Task<IActionResult> GetRelationshipAsync([Required] TId id, [Required] string relationshipName, CancellationToken cancellationToken)
     {
-        return base.GetRelationshipAsync(id, relationshipName, cancellationToken);
+        return await base.GetRelationshipAsync(id, relationshipName, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpPost]
-    public override Task<IActionResult> PostAsync([Required] TResource resource, CancellationToken cancellationToken)
+    public override async Task<IActionResult> PostAsync([Required] TResource resource, CancellationToken cancellationToken)
     {
-        return base.PostAsync(resource, cancellationToken);
+        return await base.PostAsync(resource, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpPost("{id}/relationships/{relationshipName}")]
-    public override Task<IActionResult> PostRelationshipAsync([Required] TId id, [Required] string relationshipName,
+    public override async Task<IActionResult> PostRelationshipAsync([Required] TId id, [Required] string relationshipName,
         [Required] ISet<IIdentifiable> rightResourceIds, CancellationToken cancellationToken)
     {
-        return base.PostRelationshipAsync(id, relationshipName, rightResourceIds, cancellationToken);
+        return await base.PostRelationshipAsync(id, relationshipName, rightResourceIds, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpPatch("{id}")]
-    public override Task<IActionResult> PatchAsync([Required] TId id, [Required] TResource resource, CancellationToken cancellationToken)
+    public override async Task<IActionResult> PatchAsync([Required] TId id, [Required] TResource resource, CancellationToken cancellationToken)
     {
-        return base.PatchAsync(id, resource, cancellationToken);
+        return await base.PatchAsync(id, resource, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpPatch("{id}/relationships/{relationshipName}")]
     // Parameter `[Required] object? rightValue` makes Swashbuckle generate the OpenAPI request body as required. We don't actually validate ModelState, so it doesn't hurt.
-    public override Task<IActionResult> PatchRelationshipAsync([Required] TId id, [Required] string relationshipName, [Required] object? rightValue,
+    public override async Task<IActionResult> PatchRelationshipAsync([Required] TId id, [Required] string relationshipName, [Required] object? rightValue,
         CancellationToken cancellationToken)
     {
-        return base.PatchRelationshipAsync(id, relationshipName, rightValue, cancellationToken);
+        return await base.PatchRelationshipAsync(id, relationshipName, rightValue, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpDelete("{id}")]
-    public override Task<IActionResult> DeleteAsync([Required] TId id, CancellationToken cancellationToken)
+    public override async Task<IActionResult> DeleteAsync([Required] TId id, CancellationToken cancellationToken)
     {
-        return base.DeleteAsync(id, cancellationToken);
+        return await base.DeleteAsync(id, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpDelete("{id}/relationships/{relationshipName}")]
-    public override Task<IActionResult> DeleteRelationshipAsync([Required] TId id, [Required] string relationshipName,
+    public override async Task<IActionResult> DeleteRelationshipAsync([Required] TId id, [Required] string relationshipName,
         [Required] ISet<IIdentifiable> rightResourceIds, CancellationToken cancellationToken)
     {
-        return base.DeleteRelationshipAsync(id, relationshipName, rightResourceIds, cancellationToken);
+        return await base.DeleteRelationshipAsync(id, relationshipName, rightResourceIds, cancellationToken);
     }
 }

--- a/src/JsonApiDotNetCore/Controllers/JsonApiOperationsController.cs
+++ b/src/JsonApiDotNetCore/Controllers/JsonApiOperationsController.cs
@@ -18,8 +18,8 @@ public abstract class JsonApiOperationsController(
 {
     /// <inheritdoc />
     [HttpPost]
-    public override Task<IActionResult> PostOperationsAsync([Required] IList<OperationContainer> operations, CancellationToken cancellationToken)
+    public override async Task<IActionResult> PostOperationsAsync([Required] IList<OperationContainer> operations, CancellationToken cancellationToken)
     {
-        return base.PostOperationsAsync(operations, cancellationToken);
+        return await base.PostOperationsAsync(operations, cancellationToken);
     }
 }

--- a/src/JsonApiDotNetCore/Middleware/JsonApiOutputFormatter.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiOutputFormatter.cs
@@ -16,11 +16,11 @@ public sealed class JsonApiOutputFormatter : IJsonApiOutputFormatter
     }
 
     /// <inheritdoc />
-    public Task WriteAsync(OutputFormatterWriteContext context)
+    public async Task WriteAsync(OutputFormatterWriteContext context)
     {
         ArgumentGuard.NotNull(context);
 
         var writer = context.HttpContext.RequestServices.GetRequiredService<IJsonApiWriter>();
-        return writer.WriteAsync(context.Object, context.HttpContext);
+        await writer.WriteAsync(context.Object, context.HttpContext);
     }
 }

--- a/src/JsonApiDotNetCore/Serialization/Response/JsonApiWriter.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/JsonApiWriter.cs
@@ -44,14 +44,14 @@ public sealed class JsonApiWriter : IJsonApiWriter
     }
 
     /// <inheritdoc />
-    public Task WriteAsync(object? model, HttpContext httpContext)
+    public async Task WriteAsync(object? model, HttpContext httpContext)
     {
         ArgumentGuard.NotNull(httpContext);
 
         if (model == null && !CanWriteBody((HttpStatusCode)httpContext.Response.StatusCode))
         {
             // Prevent exception from Kestrel server, caused by writing data:null json response.
-            return Task.CompletedTask;
+            return;
         }
 
         string? responseBody = GetResponseBody(model, httpContext);
@@ -59,7 +59,7 @@ public sealed class JsonApiWriter : IJsonApiWriter
         if (httpContext.Request.Method == HttpMethod.Head.Method)
         {
             httpContext.Response.GetTypedHeaders().ContentLength = responseBody == null ? 0 : Encoding.UTF8.GetByteCount(responseBody);
-            return Task.CompletedTask;
+            return;
         }
 
         _traceWriter.LogMessage(() =>
@@ -70,7 +70,7 @@ public sealed class JsonApiWriter : IJsonApiWriter
             return $"Sending {httpContext.Response.StatusCode} response for {method} request at '{url}' with body: <<{responseBody}>>";
         });
 
-        return SendResponseBodyAsync(httpContext.Response, responseBody);
+        await SendResponseBodyAsync(httpContext.Response, responseBody);
     }
 
     private static bool CanWriteBody(HttpStatusCode statusCode)

--- a/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
@@ -244,19 +244,19 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
         }
     }
 
-    protected virtual Task InitializeResourceAsync(TResource resourceForDatabase, CancellationToken cancellationToken)
+    protected virtual async Task InitializeResourceAsync(TResource resourceForDatabase, CancellationToken cancellationToken)
     {
-        return _resourceDefinitionAccessor.OnPrepareWriteAsync(resourceForDatabase, WriteOperationKind.CreateResource, cancellationToken);
+        await _resourceDefinitionAccessor.OnPrepareWriteAsync(resourceForDatabase, WriteOperationKind.CreateResource, cancellationToken);
     }
 
-    private Task AccurizeResourceTypesInHierarchyToAssignInRelationshipsAsync(TResource primaryResource, CancellationToken cancellationToken)
+    private async Task AccurizeResourceTypesInHierarchyToAssignInRelationshipsAsync(TResource primaryResource, CancellationToken cancellationToken)
     {
-        return ValidateResourcesToAssignInRelationshipsExistWithRefreshAsync(primaryResource, true, cancellationToken);
+        await ValidateResourcesToAssignInRelationshipsExistWithRefreshAsync(primaryResource, true, cancellationToken);
     }
 
-    protected Task AssertResourcesToAssignInRelationshipsExistAsync(TResource primaryResource, CancellationToken cancellationToken)
+    protected async Task AssertResourcesToAssignInRelationshipsExistAsync(TResource primaryResource, CancellationToken cancellationToken)
     {
-        return ValidateResourcesToAssignInRelationshipsExistWithRefreshAsync(primaryResource, false, cancellationToken);
+        await ValidateResourcesToAssignInRelationshipsExistWithRefreshAsync(primaryResource, false, cancellationToken);
     }
 
     private async Task ValidateResourcesToAssignInRelationshipsExistWithRefreshAsync(TResource primaryResource, bool onlyIfTypeHierarchy,

--- a/test/DapperTests/IntegrationTests/AtomicOperations/AtomicOperationsTests.cs
+++ b/test/DapperTests/IntegrationTests/AtomicOperations/AtomicOperationsTests.cs
@@ -421,7 +421,10 @@ public sealed class AtomicOperationsTests : IClassFixture<DapperTestContext>
 
         const string personLocalId = "new-person";
 
-        await _testContext.RunOnDatabaseAsync(dbContext => _testContext.ClearAllTablesAsync(dbContext));
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await _testContext.ClearAllTablesAsync(dbContext);
+        });
 
         var requestBody = new
         {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Controllers/CreateMusicTrackOperationsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Controllers/CreateMusicTrackOperationsController.cs
@@ -18,11 +18,11 @@ public sealed class CreateMusicTrackOperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
     ITargetedFields targetedFields) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields)
 {
-    public override Task<IActionResult> PostOperationsAsync(IList<OperationContainer> operations, CancellationToken cancellationToken)
+    public override async Task<IActionResult> PostOperationsAsync(IList<OperationContainer> operations, CancellationToken cancellationToken)
     {
         AssertOnlyCreatingMusicTracks(operations);
 
-        return base.PostOperationsAsync(operations, cancellationToken);
+        return await base.PostOperationsAsync(operations, cancellationToken);
     }
 
     private static void AssertOnlyCreatingMusicTracks(IEnumerable<OperationContainer> operations)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/Serialization/AtomicSerializationResourceDefinitionTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/ResourceDefinitions/Serialization/AtomicSerializationResourceDefinitionTests.cs
@@ -42,7 +42,10 @@ public sealed class AtomicSerializationResourceDefinitionTests
 
         List<RecordCompany> newCompanies = _fakers.RecordCompany.Generate(2);
 
-        await _testContext.RunOnDatabaseAsync(dbContext => dbContext.ClearTableAsync<RecordCompany>());
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<RecordCompany>();
+        });
 
         var requestBody = new
         {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Transactions/AtomicRollbackTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Transactions/AtomicRollbackTests.cs
@@ -27,7 +27,10 @@ public sealed class AtomicRollbackTests : IClassFixture<IntegrationTestContext<T
         DateTimeOffset newBornAt = _fakers.Performer.Generate().BornAt;
         string newTitle = _fakers.MusicTrack.Generate().Title;
 
-        await _testContext.RunOnDatabaseAsync(dbContext => dbContext.ClearTablesAsync<Performer, MusicTrack>());
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTablesAsync<Performer, MusicTrack>();
+        });
 
         string unknownPerformerId = Unknown.StringId.For<Performer, int>();
 
@@ -110,7 +113,10 @@ public sealed class AtomicRollbackTests : IClassFixture<IntegrationTestContext<T
         // Arrange
         string newTrackTitle = _fakers.MusicTrack.Generate().Title;
 
-        await _testContext.RunOnDatabaseAsync(dbContext => dbContext.ClearTablesAsync<Performer, MusicTrack>());
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTablesAsync<Performer, MusicTrack>();
+        });
 
         const string trackLid = "track-1";
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/ResponseMetaTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/ResponseMetaTests.cs
@@ -29,7 +29,10 @@ public sealed class ResponseMetaTests : IClassFixture<IntegrationTestContext<Tes
     public async Task Returns_top_level_meta()
     {
         // Arrange
-        await _testContext.RunOnDatabaseAsync(dbContext => dbContext.ClearTableAsync<SupportTicket>());
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<SupportTicket>();
+        });
 
         const string route = "/supportTickets";
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/TopLevelCountTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/TopLevelCountTests.cs
@@ -83,7 +83,10 @@ public sealed class TopLevelCountTests : IClassFixture<IntegrationTestContext<Te
     public async Task Renders_resource_count_for_empty_collection()
     {
         // Arrange
-        await _testContext.RunOnDatabaseAsync(dbContext => dbContext.ClearTableAsync<SupportTicket>());
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<SupportTicket>();
+        });
 
         const string route = "/supportTickets";
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/MessagingGroupDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/MessagingGroupDefinition.cs
@@ -166,8 +166,8 @@ public abstract class MessagingGroupDefinition(
 
     protected abstract Task FlushMessageAsync(OutgoingMessage message, CancellationToken cancellationToken);
 
-    protected virtual Task<DomainGroup?> GetGroupToDeleteAsync(Guid groupId, CancellationToken cancellationToken)
+    protected virtual async Task<DomainGroup?> GetGroupToDeleteAsync(Guid groupId, CancellationToken cancellationToken)
     {
-        return _groupSet.Include(group => group.Users).FirstOrDefaultAsync(group => group.Id == groupId, cancellationToken);
+        return await _groupSet.Include(group => group.Users).FirstOrDefaultAsync(group => group.Id == groupId, cancellationToken);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/MessagingUserDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/MessagingUserDefinition.cs
@@ -113,8 +113,8 @@ public abstract class MessagingUserDefinition(IResourceGraph resourceGraph, DbSe
 
     protected abstract Task FlushMessageAsync(OutgoingMessage message, CancellationToken cancellationToken);
 
-    protected virtual Task<DomainUser?> GetUserToDeleteAsync(Guid userId, CancellationToken cancellationToken)
+    protected virtual async Task<DomainUser?> GetUserToDeleteAsync(Guid userId, CancellationToken cancellationToken)
     {
-        return _userSet.Include(domainUser => domainUser.Group).FirstOrDefaultAsync(domainUser => domainUser.Id == userId, cancellationToken);
+        return await _userSet.Include(domainUser => domainUser.Group).FirstOrDefaultAsync(domainUser => domainUser.Id == userId, cancellationToken);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.Group.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.Group.cs
@@ -19,7 +19,10 @@ public sealed partial class OutboxTests
 
         string newGroupName = _fakers.DomainGroup.Generate().Name;
 
-        await _testContext.RunOnDatabaseAsync(dbContext => dbContext.ClearTableAsync<OutgoingMessage>());
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<OutgoingMessage>();
+        });
 
         var requestBody = new
         {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.User.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxTests.User.cs
@@ -20,7 +20,10 @@ public sealed partial class OutboxTests
         string newLoginName = _fakers.DomainUser.Generate().LoginName;
         string newDisplayName = _fakers.DomainUser.Generate().DisplayName!;
 
-        await _testContext.RunOnDatabaseAsync(dbContext => dbContext.ClearTableAsync<OutgoingMessage>());
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<OutgoingMessage>();
+        });
 
         var requestBody = new
         {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/SoftDeletion/SoftDeletionAwareResourceService.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/SoftDeletion/SoftDeletionAwareResourceService.cs
@@ -73,14 +73,16 @@ public class SoftDeletionAwareResourceService<TResource, TId>(
         await base.AddToToManyRelationshipAsync(leftId, relationshipName, rightResourceIds, cancellationToken);
     }
 
-    public override Task DeleteAsync(TId id, CancellationToken cancellationToken)
+    public override async Task DeleteAsync(TId id, CancellationToken cancellationToken)
     {
         if (IsSoftDeletable(typeof(TResource)))
         {
-            return SoftDeleteAsync(id, cancellationToken);
+            await SoftDeleteAsync(id, cancellationToken);
         }
-
-        return base.DeleteAsync(id, cancellationToken);
+        else
+        {
+            await base.DeleteAsync(id, cancellationToken);
+        }
     }
 
     private async Task SoftDeleteAsync(TId id, CancellationToken cancellationToken)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/EmptyGuidAsKeyTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/EmptyGuidAsKeyTests.cs
@@ -97,7 +97,10 @@ public sealed class EmptyGuidAsKeyTests : IClassFixture<IntegrationTestContext<T
         // Arrange
         string newName = _fakers.Map.Generate().Name;
 
-        await _testContext.RunOnDatabaseAsync(dbContext => dbContext.ClearTableAsync<Map>());
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Map>();
+        });
 
         var requestBody = new
         {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/ZeroAsKeyTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/ZeroAsKeyTests.cs
@@ -96,7 +96,10 @@ public sealed class ZeroAsKeyTests : IClassFixture<IntegrationTestContext<Testab
         // Arrange
         string newTitle = _fakers.Game.Generate().Title;
 
-        await _testContext.RunOnDatabaseAsync(dbContext => dbContext.ClearTableAsync<Game>());
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Game>();
+        });
 
         var requestBody = new
         {

--- a/test/TestBuildingBlocks/DbContextExtensions.cs
+++ b/test/TestBuildingBlocks/DbContextExtensions.cs
@@ -10,17 +10,17 @@ public static class DbContextExtensions
         dbContext.AddRange(entities);
     }
 
-    public static Task ClearTableAsync<TEntity>(this DbContext dbContext)
+    public static async Task ClearTableAsync<TEntity>(this DbContext dbContext)
         where TEntity : class
     {
-        return ClearTablesAsync(dbContext, typeof(TEntity));
+        await ClearTablesAsync(dbContext, typeof(TEntity));
     }
 
-    public static Task ClearTablesAsync<TEntity1, TEntity2>(this DbContext dbContext)
+    public static async Task ClearTablesAsync<TEntity1, TEntity2>(this DbContext dbContext)
         where TEntity1 : class
         where TEntity2 : class
     {
-        return ClearTablesAsync(dbContext, typeof(TEntity1), typeof(TEntity2));
+        await ClearTablesAsync(dbContext, typeof(TEntity1), typeof(TEntity2));
     }
 
     private static async Task ClearTablesAsync(this DbContext dbContext, params Type[] modelTypes)

--- a/test/TestBuildingBlocks/IntegrationTest.cs
+++ b/test/TestBuildingBlocks/IntegrationTest.cs
@@ -22,40 +22,40 @@ public abstract class IntegrationTest : IAsyncLifetime
         ThrottleSemaphore = new SemaphoreSlim(maxConcurrentTestRuns);
     }
 
-    public Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecuteHeadAsync<TResponseDocument>(string requestUrl,
+    public async Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecuteHeadAsync<TResponseDocument>(string requestUrl,
         Action<HttpRequestHeaders>? setRequestHeaders = null)
     {
-        return ExecuteRequestAsync<TResponseDocument>(HttpMethod.Head, requestUrl, null, null, setRequestHeaders);
+        return await ExecuteRequestAsync<TResponseDocument>(HttpMethod.Head, requestUrl, null, null, setRequestHeaders);
     }
 
-    public Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecuteGetAsync<TResponseDocument>(string requestUrl,
+    public async Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecuteGetAsync<TResponseDocument>(string requestUrl,
         Action<HttpRequestHeaders>? setRequestHeaders = null)
     {
-        return ExecuteRequestAsync<TResponseDocument>(HttpMethod.Get, requestUrl, null, null, setRequestHeaders);
+        return await ExecuteRequestAsync<TResponseDocument>(HttpMethod.Get, requestUrl, null, null, setRequestHeaders);
     }
 
-    public Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecutePostAsync<TResponseDocument>(string requestUrl,
+    public async Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecutePostAsync<TResponseDocument>(string requestUrl,
         object requestBody, string contentType = HeaderConstants.MediaType, Action<HttpRequestHeaders>? setRequestHeaders = null)
     {
-        return ExecuteRequestAsync<TResponseDocument>(HttpMethod.Post, requestUrl, requestBody, contentType, setRequestHeaders);
+        return await ExecuteRequestAsync<TResponseDocument>(HttpMethod.Post, requestUrl, requestBody, contentType, setRequestHeaders);
     }
 
-    public Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecutePostAtomicAsync<TResponseDocument>(string requestUrl,
+    public async Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecutePostAtomicAsync<TResponseDocument>(string requestUrl,
         object requestBody, string contentType = HeaderConstants.AtomicOperationsMediaType, Action<HttpRequestHeaders>? setRequestHeaders = null)
     {
-        return ExecuteRequestAsync<TResponseDocument>(HttpMethod.Post, requestUrl, requestBody, contentType, setRequestHeaders);
+        return await ExecuteRequestAsync<TResponseDocument>(HttpMethod.Post, requestUrl, requestBody, contentType, setRequestHeaders);
     }
 
-    public Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecutePatchAsync<TResponseDocument>(string requestUrl,
+    public async Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecutePatchAsync<TResponseDocument>(string requestUrl,
         object requestBody, string contentType = HeaderConstants.MediaType, Action<HttpRequestHeaders>? setRequestHeaders = null)
     {
-        return ExecuteRequestAsync<TResponseDocument>(HttpMethod.Patch, requestUrl, requestBody, contentType, setRequestHeaders);
+        return await ExecuteRequestAsync<TResponseDocument>(HttpMethod.Patch, requestUrl, requestBody, contentType, setRequestHeaders);
     }
 
-    public Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecuteDeleteAsync<TResponseDocument>(string requestUrl,
+    public async Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecuteDeleteAsync<TResponseDocument>(string requestUrl,
         object? requestBody = null, string contentType = HeaderConstants.MediaType, Action<HttpRequestHeaders>? setRequestHeaders = null)
     {
-        return ExecuteRequestAsync<TResponseDocument>(HttpMethod.Delete, requestUrl, requestBody, contentType, setRequestHeaders);
+        return await ExecuteRequestAsync<TResponseDocument>(HttpMethod.Delete, requestUrl, requestBody, contentType, setRequestHeaders);
     }
 
     private async Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecuteRequestAsync<TResponseDocument>(HttpMethod method,
@@ -116,9 +116,9 @@ public abstract class IntegrationTest : IAsyncLifetime
         }
     }
 
-    public Task InitializeAsync()
+    public async Task InitializeAsync()
     {
-        return ThrottleSemaphore.WaitAsync();
+        await ThrottleSemaphore.WaitAsync();
     }
 
     public virtual Task DisposeAsync()

--- a/test/TestBuildingBlocks/QueryableExtensions.cs
+++ b/test/TestBuildingBlocks/QueryableExtensions.cs
@@ -11,10 +11,10 @@ public static class QueryableExtensions
         return resources.FirstAsync(resource => Equals(resource.Id, id), cancellationToken);
     }
 
-    public static Task<TResource?> FirstWithIdOrDefaultAsync<TResource, TId>(this IQueryable<TResource> resources, TId id,
+    public static async Task<TResource?> FirstWithIdOrDefaultAsync<TResource, TId>(this IQueryable<TResource> resources, TId id,
         CancellationToken cancellationToken = default)
         where TResource : IIdentifiable<TId>
     {
-        return resources.FirstOrDefaultAsync(resource => Equals(resource.Id, id), cancellationToken);
+        return await resources.FirstOrDefaultAsync(resource => Equals(resource.Id, id), cancellationToken);
     }
 }


### PR DESCRIPTION
Reverting this Resharper rule because it makes stack traces harder to understand, while the gain it provides is theoretical. Resharper turned off this suggestion in the default ruleset in a later version.

This reverts commit 3e1b27b6c4723b08e827904e9ffdd30f8fb71383.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
