### PR TITLE
Fix whitespace in query string parameters within pagination links

### DIFF
--- a/src/JsonApiDotNetCore/Serialization/Response/LinkBuilder.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/LinkBuilder.cs
@@ -214,7 +214,7 @@ public class LinkBuilder : ILinkBuilder
         };
 
         UriComponents components = _options.UseRelativeLinks ? UriComponents.PathAndQuery : UriComponents.AbsoluteUri;
-        return builder.Uri.GetComponents(components, UriFormat.SafeUnescaped);
+        return builder.Uri.GetComponents(components, UriFormat.UriEscaped);
     }
 
     private string GetQueryStringInPaginationLink(int pageOffset, string? pageSizeValue)

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Filtering/FilterOperatorTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Filtering/FilterOperatorTests.cs
@@ -85,6 +85,10 @@ public sealed class FilterOperatorTests : IClassFixture<IntegrationTestContext<T
 
         responseDocument.Data.ManyValue.ShouldHaveCount(1);
         responseDocument.Data.ManyValue[0].Attributes.ShouldContainKey("someString").With(value => value.Should().Be(resource.SomeString));
+
+        responseDocument.Links.ShouldNotBeNull();
+        responseDocument.Links.Self.Should().Be("http://localhost/filterableResources?filter=equals(someString,'This%2c+that+%26+more+%2b+some')");
+        responseDocument.Links.First.Should().Be("http://localhost/filterableResources?filter=equals(someString,%27This,%20that%20%26%20more%20%2B%20some%27)");
     }
 
     [Fact]


### PR DESCRIPTION
Fix whitespace in query string parameters within pagination links. See conversation at https://github.com/dotnet/runtime/issues/100792.

Fixes #1525.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
