### PR TITLE
Allow relaxed Content-Type for atomic operations 

### DIFF
--- a/src/JsonApiDotNetCore/Middleware/HeaderConstants.cs
+++ b/src/JsonApiDotNetCore/Middleware/HeaderConstants.cs
@@ -9,4 +9,5 @@ public static class HeaderConstants
 {
     public const string MediaType = "application/vnd.api+json";
     public const string AtomicOperationsMediaType = $"{MediaType}; ext=\"https://jsonapi.org/ext/atomic\"";
+    public const string RelaxedAtomicOperationsMediaType = $"{MediaType}; ext=atomic-operations";
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicLoggingTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicLoggingTests.cs
@@ -36,7 +36,7 @@ public sealed class AtomicLoggingTests : IClassFixture<IntegrationTestContext<Te
     }
 
     [Fact]
-    public async Task Logs_at_error_level_on_unhandled_exception()
+    public async Task Logs_unhandled_exception_at_Error_level()
     {
         // Arrange
         var loggerFactory = _testContext.Factory.Services.GetRequiredService<FakeLoggerFactory>();
@@ -88,7 +88,7 @@ public sealed class AtomicLoggingTests : IClassFixture<IntegrationTestContext<Te
     }
 
     [Fact]
-    public async Task Logs_at_info_level_on_invalid_request_body()
+    public async Task Logs_invalid_request_body_error_at_Information_level()
     {
         // Arrange
         var loggerFactory = _testContext.Factory.Services.GetRequiredService<FakeLoggerFactory>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicRequestBodyTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicRequestBodyTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FluentAssertions;
+using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.Serialization.Objects;
 using TestBuildingBlocks;
 using Xunit;
@@ -28,6 +29,9 @@ public sealed class AtomicRequestBodyTests : IClassFixture<IntegrationTestContex
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+
+        httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
+        httpResponse.Content.Headers.ContentType.ToString().Should().Be(HeaderConstants.AtomicOperationsMediaType);
 
         responseDocument.Errors.ShouldHaveCount(1);
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicTraceLoggingTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicTraceLoggingTests.cs
@@ -33,7 +33,7 @@ public sealed class AtomicTraceLoggingTests : IClassFixture<IntegrationTestConte
     }
 
     [Fact]
-    public async Task Logs_execution_flow_at_trace_level_on_operations_request()
+    public async Task Logs_execution_flow_at_Trace_level_on_operations_request()
     {
         // Arrange
         var loggerFactory = _testContext.Factory.Services.GetRequiredService<FakeLoggerFactory>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NonJsonApiControllers/NonJsonApiControllerTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NonJsonApiControllers/NonJsonApiControllerTests.cs
@@ -30,6 +30,7 @@ public sealed class NonJsonApiControllerTests : IClassFixture<IntegrationTestCon
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
         httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
         httpResponse.Content.Headers.ContentType.ToString().Should().Be("application/json; charset=utf-8");
 
@@ -58,6 +59,7 @@ public sealed class NonJsonApiControllerTests : IClassFixture<IntegrationTestCon
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
         httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
         httpResponse.Content.Headers.ContentType.ToString().Should().Be("text/plain; charset=utf-8");
 
@@ -78,6 +80,7 @@ public sealed class NonJsonApiControllerTests : IClassFixture<IntegrationTestCon
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+
         httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
         httpResponse.Content.Headers.ContentType.ToString().Should().Be("text/plain; charset=utf-8");
 
@@ -106,6 +109,7 @@ public sealed class NonJsonApiControllerTests : IClassFixture<IntegrationTestCon
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
         httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
         httpResponse.Content.Headers.ContentType.ToString().Should().Be("text/plain; charset=utf-8");
 
@@ -126,6 +130,7 @@ public sealed class NonJsonApiControllerTests : IClassFixture<IntegrationTestCon
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
         httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
         httpResponse.Content.Headers.ContentType.ToString().Should().Be("text/plain; charset=utf-8");
 
@@ -146,6 +151,7 @@ public sealed class NonJsonApiControllerTests : IClassFixture<IntegrationTestCon
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
         httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
         httpResponse.Content.Headers.ContentType.ToString().Should().Be("text/plain; charset=utf-8");
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Reflection;
 using FluentAssertions;
 using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Serialization.Objects;
 using Microsoft.EntityFrameworkCore;
@@ -475,6 +476,9 @@ public sealed class CreateResourceTests : IClassFixture<IntegrationTestContext<T
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+
+        httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
+        httpResponse.Content.Headers.ContentType.ToString().Should().Be(HeaderConstants.MediaType);
 
         responseDocument.Errors.ShouldHaveCount(1);
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Relationships/AddToToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Relationships/AddToToManyRelationshipTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FluentAssertions;
+using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.Serialization.Objects;
 using Microsoft.EntityFrameworkCore;
 using TestBuildingBlocks;
@@ -195,6 +196,9 @@ public sealed class AddToToManyRelationshipTests : IClassFixture<IntegrationTest
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+
+        httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
+        httpResponse.Content.Headers.ContentType.ToString().Should().Be(HeaderConstants.MediaType);
 
         responseDocument.Errors.ShouldHaveCount(1);
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Relationships/RemoveFromToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Relationships/RemoveFromToManyRelationshipTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using JetBrains.Annotations;
 using JsonApiDotNetCore;
 using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 using JsonApiDotNetCore.Serialization.Objects;
@@ -307,6 +308,9 @@ public sealed class RemoveFromToManyRelationshipTests : IClassFixture<Integratio
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+
+        httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
+        httpResponse.Content.Headers.ContentType.ToString().Should().Be(HeaderConstants.MediaType);
 
         responseDocument.Errors.ShouldHaveCount(1);
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Relationships/ReplaceToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Relationships/ReplaceToManyRelationshipTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FluentAssertions;
+using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.Serialization.Objects;
 using Microsoft.EntityFrameworkCore;
 using TestBuildingBlocks;
@@ -224,6 +225,9 @@ public sealed class ReplaceToManyRelationshipTests : IClassFixture<IntegrationTe
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+
+        httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
+        httpResponse.Content.Headers.ContentType.ToString().Should().Be(HeaderConstants.MediaType);
 
         responseDocument.Errors.ShouldHaveCount(1);
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Relationships/UpdateToOneRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Relationships/UpdateToOneRelationshipTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FluentAssertions;
+using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.Serialization.Objects;
 using Microsoft.EntityFrameworkCore;
 using TestBuildingBlocks;
@@ -260,6 +261,9 @@ public sealed class UpdateToOneRelationshipTests : IClassFixture<IntegrationTest
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+
+        httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
+        httpResponse.Content.Headers.ContentType.ToString().Should().Be(HeaderConstants.MediaType);
 
         responseDocument.Errors.ShouldHaveCount(1);
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateResourceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Resources/UpdateResourceTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Reflection;
 using FluentAssertions;
 using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Serialization.Objects;
 using Microsoft.EntityFrameworkCore;
@@ -662,6 +663,9 @@ public sealed class UpdateResourceTests : IClassFixture<IntegrationTestContext<T
 
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.BadRequest);
+
+        httpResponse.Content.Headers.ContentType.ShouldNotBeNull();
+        httpResponse.Content.Headers.ContentType.ToString().Should().Be(HeaderConstants.MediaType);
 
         responseDocument.Errors.ShouldHaveCount(1);
 


### PR DESCRIPTION
This PR permits using a relaxed (simpler) variant of the `atomic:operations` media type in the `Content-Type` request/response HTTP header, because OpenAPI client generators often choke on the double quotes in the official media type (producing code that doesn't compile). By default, the `Content-Type` used for responses is the same as the incoming one, although it can be overruled by sending an `Accept` HTTP header.

Official header value (existing):
`application/vnd.api+json; ext="https://jsonapi.org/ext/atomic"`
Relaxed variant (added in this PR):
`application/vnd.api+json; ext=atomic-operations`

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
