### PR TITLE
Filter operations based on GenerateControllerEndpoints usage

### DIFF
--- a/docs/usage/writing/bulk-batch-operations.md
+++ b/docs/usage/writing/bulk-batch-operations.md
@@ -19,12 +19,23 @@ public sealed class OperationsController : JsonApiOperationsController
 {
     public OperationsController(IJsonApiOptions options, IResourceGraph resourceGraph,
         ILoggerFactory loggerFactory, IOperationsProcessor processor,
-        IJsonApiRequest request, ITargetedFields targetedFields)
-        : base(options, resourceGraph, loggerFactory, processor, request, targetedFields)
+        IJsonApiRequest request, ITargetedFields targetedFields,
+        IAtomicOperationFilter operationFilter)
+        : base(options, resourceGraph, loggerFactory, processor, request, targetedFields,
+        operationFilter)
     {
     }
 }
 ```
+
+> [!IMPORTANT]  
+> Since v5.6.0, the set of exposed operations is based on
+> [`GenerateControllerEndpoints` usage](~/usage/extensibility/controllers.md#resource-access-control).
+> Earlier versions always exposed all operations for all resource types.
+> If you're using [explicit controllers](~/usage/extensibility/controllers.md#explicit-controllers),
+> register and implement your own
+> [`IAtomicOperationFilter`](~/api/JsonApiDotNetCore.AtomicOperations.IAtomicOperationFilter.yml)
+> to indicate which operations to expose.
 
 You'll need to send the next Content-Type in a POST request for operations:
 

--- a/src/Examples/DapperExample/Controllers/OperationsController.cs
+++ b/src/Examples/DapperExample/Controllers/OperationsController.cs
@@ -8,4 +8,5 @@ namespace DapperExample.Controllers;
 
 public sealed class OperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields);
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor,
+    request, targetedFields, operationFilter);

--- a/src/Examples/JsonApiDotNetCoreExample/Controllers/OperationsController.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Controllers/OperationsController.cs
@@ -8,4 +8,5 @@ namespace JsonApiDotNetCoreExample.Controllers;
 
 public sealed class OperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields);
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor,
+    request, targetedFields, operationFilter);

--- a/src/JsonApiDotNetCore/AtomicOperations/DefaultOperationFilter.cs
+++ b/src/JsonApiDotNetCore/AtomicOperations/DefaultOperationFilter.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Middleware;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace JsonApiDotNetCore.AtomicOperations;
+
+/// <inheritdoc />
+internal sealed class DefaultOperationFilter : IAtomicOperationFilter
+{
+    /// <inheritdoc />
+    public bool IsEnabled(ResourceType resourceType, WriteOperationKind writeOperation)
+    {
+        var resourceAttribute = resourceType.ClrType.GetCustomAttribute<ResourceAttribute>();
+        return resourceAttribute != null && Contains(resourceAttribute.GenerateControllerEndpoints, writeOperation);
+    }
+
+    private static bool Contains(JsonApiEndpoints endpoints, WriteOperationKind writeOperation)
+    {
+        return writeOperation switch
+        {
+            WriteOperationKind.CreateResource => endpoints.HasFlag(JsonApiEndpoints.Post),
+            WriteOperationKind.UpdateResource => endpoints.HasFlag(JsonApiEndpoints.Patch),
+            WriteOperationKind.DeleteResource => endpoints.HasFlag(JsonApiEndpoints.Delete),
+            WriteOperationKind.SetRelationship => endpoints.HasFlag(JsonApiEndpoints.PatchRelationship),
+            WriteOperationKind.AddToRelationship => endpoints.HasFlag(JsonApiEndpoints.PostRelationship),
+            WriteOperationKind.RemoveFromRelationship => endpoints.HasFlag(JsonApiEndpoints.DeleteRelationship),
+            _ => false
+        };
+    }
+}

--- a/src/JsonApiDotNetCore/AtomicOperations/IAtomicOperationFilter.cs
+++ b/src/JsonApiDotNetCore/AtomicOperations/IAtomicOperationFilter.cs
@@ -1,0 +1,42 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Middleware;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace JsonApiDotNetCore.AtomicOperations;
+
+/// <summary>
+/// Determines whether an operation in an atomic:operations request can be used.
+/// </summary>
+/// <remarks>
+/// The default implementation relies on the usage of <see cref="ResourceAttribute.GenerateControllerEndpoints" />. If you're using explicit
+/// (non-generated) controllers, register your own implementation to indicate which operations are accessible.
+/// </remarks>
+[PublicAPI]
+public interface IAtomicOperationFilter
+{
+    /// <summary>
+    /// An <see cref="IAtomicOperationFilter" /> that always returns <c>true</c>. Provided for convenience, to revert to the original behavior from before
+    /// filtering was introduced.
+    /// </summary>
+    public static IAtomicOperationFilter AlwaysEnabled { get; } = new AlwaysEnabledOperationFilter();
+
+    /// <summary>
+    /// Determines whether the specified operation can be used in an atomic:operations request.
+    /// </summary>
+    /// <param name="resourceType">
+    /// The targeted primary resource type of the operation.
+    /// </param>
+    /// <param name="writeOperation">
+    /// The operation kind.
+    /// </param>
+    bool IsEnabled(ResourceType resourceType, WriteOperationKind writeOperation);
+
+    private sealed class AlwaysEnabledOperationFilter : IAtomicOperationFilter
+    {
+        public bool IsEnabled(ResourceType resourceType, WriteOperationKind writeOperation)
+        {
+            return true;
+        }
+    }
+}

--- a/src/JsonApiDotNetCore/Configuration/JsonApiApplicationBuilder.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiApplicationBuilder.cs
@@ -300,5 +300,6 @@ internal sealed class JsonApiApplicationBuilder : IJsonApiApplicationBuilder
         _services.TryAddScoped<IOperationsProcessor, OperationsProcessor>();
         _services.TryAddScoped<IOperationProcessorAccessor, OperationProcessorAccessor>();
         _services.TryAddScoped<ILocalIdTracker, LocalIdTracker>();
+        _services.TryAddSingleton<IAtomicOperationFilter, DefaultOperationFilter>();
     }
 }

--- a/src/JsonApiDotNetCore/Controllers/JsonApiOperationsController.cs
+++ b/src/JsonApiDotNetCore/Controllers/JsonApiOperationsController.cs
@@ -14,7 +14,8 @@ namespace JsonApiDotNetCore.Controllers;
 /// </summary>
 public abstract class JsonApiOperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields) : BaseJsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields)
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter) : BaseJsonApiOperationsController(options, resourceGraph, loggerFactory, processor,
+    request, targetedFields, operationFilter)
 {
     /// <inheritdoc />
     [HttpPost]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Controllers/AtomicCustomConstrainedOperationsControllerTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Controllers/AtomicCustomConstrainedOperationsControllerTests.cs
@@ -6,13 +6,13 @@ using Xunit;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Controllers;
 
-public sealed class AtomicConstrainedOperationsControllerTests
+public sealed class AtomicCustomConstrainedOperationsControllerTests
     : IClassFixture<IntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
 {
     private readonly IntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
     private readonly OperationsFakers _fakers = new();
 
-    public AtomicConstrainedOperationsControllerTests(IntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
+    public AtomicCustomConstrainedOperationsControllerTests(IntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
     {
         _testContext = testContext;
 
@@ -102,14 +102,14 @@ public sealed class AtomicConstrainedOperationsControllerTests
 
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
-        error.Title.Should().Be("Unsupported combination of operation code and resource type at this endpoint.");
-        error.Detail.Should().Be("This endpoint can only be used to create resources of type 'musicTracks'.");
+        error.Title.Should().Be("The requested operation is not accessible.");
+        error.Detail.Should().Be("The 'add' resource operation is not accessible for resource type 'performers'.");
         error.Source.ShouldNotBeNull();
         error.Source.Pointer.Should().Be("/atomic:operations[0]");
     }
 
     [Fact]
-    public async Task Cannot_update_resources_for_matching_resource_type()
+    public async Task Cannot_update_resource_for_matching_resource_type()
     {
         // Arrange
         MusicTrack existingTrack = _fakers.MusicTrack.Generate();
@@ -151,8 +151,8 @@ public sealed class AtomicConstrainedOperationsControllerTests
 
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
-        error.Title.Should().Be("Unsupported combination of operation code and resource type at this endpoint.");
-        error.Detail.Should().Be("This endpoint can only be used to create resources of type 'musicTracks'.");
+        error.Title.Should().Be("The requested operation is not accessible.");
+        error.Detail.Should().Be("The 'update' resource operation is not accessible for resource type 'musicTracks'.");
         error.Source.ShouldNotBeNull();
         error.Source.Pointer.Should().Be("/atomic:operations[0]");
     }
@@ -207,8 +207,8 @@ public sealed class AtomicConstrainedOperationsControllerTests
 
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
-        error.Title.Should().Be("Unsupported combination of operation code and resource type at this endpoint.");
-        error.Detail.Should().Be("This endpoint can only be used to create resources of type 'musicTracks'.");
+        error.Title.Should().Be("The requested operation is not accessible.");
+        error.Detail.Should().Be("The 'add' relationship operation is not accessible for relationship 'performers' on resource type 'musicTracks'.");
         error.Source.ShouldNotBeNull();
         error.Source.Pointer.Should().Be("/atomic:operations[0]");
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Controllers/AtomicDefaultConstrainedOperationsControllerTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Controllers/AtomicDefaultConstrainedOperationsControllerTests.cs
@@ -1,0 +1,173 @@
+using System.Net;
+using FluentAssertions;
+using JsonApiDotNetCore.Serialization.Objects;
+using TestBuildingBlocks;
+using Xunit;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Controllers;
+
+public sealed class AtomicDefaultConstrainedOperationsControllerTests
+    : IClassFixture<IntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext>>
+{
+    private readonly IntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> _testContext;
+    private readonly OperationsFakers _fakers = new();
+
+    public AtomicDefaultConstrainedOperationsControllerTests(IntegrationTestContext<TestableStartup<OperationsDbContext>, OperationsDbContext> testContext)
+    {
+        _testContext = testContext;
+
+        testContext.UseController<OperationsController>();
+    }
+
+    [Fact]
+    public async Task Cannot_delete_resource_for_disabled_resource_endpoint()
+    {
+        // Arrange
+        TextLanguage existingLanguage = _fakers.TextLanguage.Generate();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            dbContext.AddInRange(existingLanguage);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var requestBody = new
+        {
+            atomic__operations = new[]
+            {
+                new
+                {
+                    op = "remove",
+                    @ref = new
+                    {
+                        type = "textLanguages",
+                        id = existingLanguage.StringId
+                    }
+                }
+            }
+        };
+
+        const string route = "/operations";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAtomicAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        error.Title.Should().Be("The requested operation is not accessible.");
+        error.Detail.Should().Be("The 'remove' resource operation is not accessible for resource type 'textLanguages'.");
+        error.Source.ShouldNotBeNull();
+        error.Source.Pointer.Should().Be("/atomic:operations[0]");
+    }
+
+    [Fact]
+    public async Task Cannot_change_ToMany_relationship_for_disabled_resource_endpoints()
+    {
+        // Arrange
+        TextLanguage existingLanguage = _fakers.TextLanguage.Generate();
+        Lyric existingLyric = _fakers.Lyric.Generate();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            dbContext.AddInRange(existingLanguage, existingLyric);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var requestBody = new
+        {
+            atomic__operations = new[]
+            {
+                new
+                {
+                    op = "update",
+                    @ref = new
+                    {
+                        type = "textLanguages",
+                        id = existingLanguage.StringId,
+                        relationship = "lyrics"
+                    },
+                    data = new[]
+                    {
+                        new
+                        {
+                            type = "lyrics",
+                            id = existingLyric.StringId
+                        }
+                    }
+                },
+                new
+                {
+                    op = "add",
+                    @ref = new
+                    {
+                        type = "textLanguages",
+                        id = existingLanguage.StringId,
+                        relationship = "lyrics"
+                    },
+                    data = new[]
+                    {
+                        new
+                        {
+                            type = "lyrics",
+                            id = existingLyric.StringId
+                        }
+                    }
+                },
+                new
+                {
+                    op = "remove",
+                    @ref = new
+                    {
+                        type = "textLanguages",
+                        id = existingLanguage.StringId,
+                        relationship = "lyrics"
+                    },
+                    data = new[]
+                    {
+                        new
+                        {
+                            type = "lyrics",
+                            id = existingLyric.StringId
+                        }
+                    }
+                }
+            }
+        };
+
+        const string route = "/operations";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAtomicAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+
+        responseDocument.Errors.ShouldHaveCount(3);
+
+        ErrorObject error1 = responseDocument.Errors[0];
+        error1.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        error1.Title.Should().Be("The requested operation is not accessible.");
+        error1.Detail.Should().Be("The 'update' relationship operation is not accessible for relationship 'lyrics' on resource type 'textLanguages'.");
+        error1.Source.ShouldNotBeNull();
+        error1.Source.Pointer.Should().Be("/atomic:operations[0]");
+
+        ErrorObject error2 = responseDocument.Errors[1];
+        error2.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        error2.Title.Should().Be("The requested operation is not accessible.");
+        error2.Detail.Should().Be("The 'add' relationship operation is not accessible for relationship 'lyrics' on resource type 'textLanguages'.");
+        error2.Source.ShouldNotBeNull();
+        error2.Source.Pointer.Should().Be("/atomic:operations[1]");
+
+        ErrorObject error3 = responseDocument.Errors[2];
+        error3.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        error3.Title.Should().Be("The requested operation is not accessible.");
+        error3.Detail.Should().Be("The 'remove' relationship operation is not accessible for relationship 'lyrics' on resource type 'textLanguages'.");
+        error3.Source.ShouldNotBeNull();
+        error3.Source.Pointer.Should().Be("/atomic:operations[2]");
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/OperationsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/OperationsController.cs
@@ -9,4 +9,5 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations;
 
 public sealed class OperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields);
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor,
+    request, targetedFields, operationFilter);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/TextLanguage.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/TextLanguage.cs
@@ -1,11 +1,13 @@
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Controllers;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations")]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations",
+    GenerateControllerEndpoints = JsonApiEndpoints.Post | JsonApiEndpoints.Patch)]
 public sealed class TextLanguage : Identifiable<Guid>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/OperationsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/OperationsController.cs
@@ -12,7 +12,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
 
 public sealed class OperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields)
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor,
+    request, targetedFields, operationFilter)
 {
     public override async Task<IActionResult> PostOperationsAsync(IList<OperationContainer> operations, CancellationToken cancellationToken)
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/OperationsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/OperationsController.cs
@@ -9,4 +9,5 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ContentNegotiation;
 
 public sealed class OperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields);
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor,
+    request, targetedFields, operationFilter);


### PR DESCRIPTION
This PR adds `IAtomicOperationFilter`, which is used to constrain the exposed atomic:operations. The default implementation filters based on the usage of `GenerateControllerEndpoints` (which defaults to `All`, in which case all operations are exposed).

See the related issue for notes on this breaking change.

Fixes #1560.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [x] Documentation updated
