### PR TITLE
Remove installing PowerShell in cibuild, this is no longer needed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,36 +48,6 @@ jobs:
         dotnet-version: |
           6.0.x
           8.0.x
-    - name: Setup PowerShell (Ubuntu)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        dotnet tool install --global PowerShell
-    - name: Find latest PowerShell version (Windows)
-      if: matrix.os == 'windows-latest'
-      shell: pwsh
-      run: |
-        $packageName = "powershell"
-        $outputText = dotnet tool search $packageName --take 1
-        $outputLine = ("" + $outputText)
-        $indexOfVersionLine = $outputLine.IndexOf($packageName)
-        $latestVersion = $outputLine.substring($indexOfVersionLine + $packageName.length).trim().split(" ")[0].trim()
-
-        Write-Output "Found PowerShell version: $latestVersion"
-        Write-Output "POWERSHELL_LATEST_VERSION=$latestVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-    - name: Setup PowerShell (Windows)
-      if: matrix.os == 'windows-latest'
-      shell: cmd
-      run: |
-        set DOWNLOAD_LINK=https://github.com/PowerShell/PowerShell/releases/download/v%POWERSHELL_LATEST_VERSION%/PowerShell-%POWERSHELL_LATEST_VERSION%-win-x64.msi
-        set OUTPUT_PATH=%RUNNER_TEMP%\PowerShell-%POWERSHELL_LATEST_VERSION%-win-x64.msi
-        echo Downloading from: %DOWNLOAD_LINK% to: %OUTPUT_PATH%
-        curl --location --output %OUTPUT_PATH% %DOWNLOAD_LINK%
-        msiexec.exe /package %OUTPUT_PATH% /quiet USE_MU=1 ENABLE_MU=1 ADD_PATH=1 DISABLE_TELEMETRY=1
-    - name: Setup PowerShell (macOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        brew install --cask powershell
     - name: Show installed versions
       shell: pwsh
       run: |


### PR DESCRIPTION
All GitHub Actions runners now come preinstalled with a PowerShell version that is high enough to generate our documentation.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
