### PR TITLE
Fixed: return empty object instead of data:null in operation results

### DIFF
--- a/src/JsonApiDotNetCore/Serialization/JsonConverters/WriteOnlyDocumentConverter.cs
+++ b/src/JsonApiDotNetCore/Serialization/JsonConverters/WriteOnlyDocumentConverter.cs
@@ -61,7 +61,28 @@ public sealed class WriteOnlyDocumentConverter : JsonObjectConverter<Document>
         if (!value.Results.IsNullOrEmpty())
         {
             writer.WritePropertyName(AtomicResultsText);
-            WriteSubTree(writer, value.Results, options);
+            writer.WriteStartArray();
+
+            foreach (AtomicResultObject result in value.Results)
+            {
+                writer.WriteStartObject();
+
+                if (result.Data.IsAssigned)
+                {
+                    writer.WritePropertyName(DataText);
+                    WriteSubTree(writer, result.Data, options);
+                }
+
+                if (!result.Meta.IsNullOrEmpty())
+                {
+                    writer.WritePropertyName(MetaText);
+                    WriteSubTree(writer, result.Meta, options);
+                }
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
         }
 
         if (!value.Errors.IsNullOrEmpty())

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicSerializationTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicSerializationTests.cs
@@ -101,9 +101,7 @@ public sealed class AtomicSerializationTests : IClassFixture<IntegrationTestCont
                 "self": "http://localhost/operations"
               },
               "atomic:results": [
-                {
-                  "data": null
-                },
+                {},
                 {
                   "data": {
                     "type": "textLanguages",


### PR DESCRIPTION
According to the spec at https://jsonapi.org/ext/atomic/:

> An empty result object (`{}`) is acceptable for operations that are not required to return `data`.

This PR changes the response to align with the spec by returning an empty object instead of `{ "data": null }`.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
