### PR TITLE
Fixed: Do not allow the use of 'lid' when client-generated IDs are required

### DIFF
--- a/src/JsonApiDotNetCore/Serialization/Request/Adapters/AtomicOperationObjectAdapter.cs
+++ b/src/JsonApiDotNetCore/Serialization/Request/Adapters/AtomicOperationObjectAdapter.cs
@@ -125,7 +125,9 @@ public sealed class AtomicOperationObjectAdapter : IAtomicOperationObjectAdapter
         return new ResourceIdentityRequirements
         {
             EvaluateIdConstraint = resourceType =>
-                ResourceIdentityRequirements.DoEvaluateIdConstraint(resourceType, state.Request.WriteOperation, _options.ClientIdGeneration)
+                ResourceIdentityRequirements.DoEvaluateIdConstraint(resourceType, state.Request.WriteOperation, _options.ClientIdGeneration),
+            EvaluateAllowLid = resourceType =>
+                ResourceIdentityRequirements.DoEvaluateAllowLid(resourceType, state.Request.WriteOperation, _options.ClientIdGeneration)
         };
     }
 
@@ -135,6 +137,7 @@ public sealed class AtomicOperationObjectAdapter : IAtomicOperationObjectAdapter
         {
             ResourceType = refResult.ResourceType,
             EvaluateIdConstraint = refRequirements.EvaluateIdConstraint,
+            EvaluateAllowLid = refRequirements.EvaluateAllowLid,
             IdValue = refResult.Resource.StringId,
             LidValue = refResult.Resource.LocalId,
             RelationshipName = refResult.Relationship?.PublicName

--- a/src/JsonApiDotNetCore/Serialization/Request/Adapters/RelationshipDataAdapter.cs
+++ b/src/JsonApiDotNetCore/Serialization/Request/Adapters/RelationshipDataAdapter.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 using JsonApiDotNetCore.Serialization.Objects;
@@ -71,6 +72,7 @@ public sealed class RelationshipDataAdapter : BaseAdapter, IRelationshipDataAdap
         {
             ResourceType = relationship.RightType,
             EvaluateIdConstraint = _ => JsonElementConstraint.Required,
+            EvaluateAllowLid = _ => state.Request.Kind == EndpointKind.AtomicOperations,
             RelationshipName = relationship.PublicName
         };
 

--- a/src/JsonApiDotNetCore/Serialization/Request/Adapters/ResourceIdentityRequirements.cs
+++ b/src/JsonApiDotNetCore/Serialization/Request/Adapters/ResourceIdentityRequirements.cs
@@ -22,6 +22,11 @@ public sealed class ResourceIdentityRequirements
     public Func<ResourceType, JsonElementConstraint?>? EvaluateIdConstraint { get; init; }
 
     /// <summary>
+    /// When not null, provides a callback to indicate whether the "lid" element can be used instead of the "id" element. Defaults to <c>false</c>.
+    /// </summary>
+    public Func<ResourceType, bool>? EvaluateAllowLid { get; init; }
+
+    /// <summary>
     /// When not null, indicates what the value of the "id" element must be.
     /// </summary>
     public string? IdValue { get; init; }
@@ -49,5 +54,16 @@ public sealed class ResourceIdentityRequirements
                 _ => null
             }
             : JsonElementConstraint.Required;
+    }
+
+    internal static bool DoEvaluateAllowLid(ResourceType resourceType, WriteOperationKind? writeOperation, ClientIdGenerationMode globalClientIdGeneration)
+    {
+        if (writeOperation == null)
+        {
+            return false;
+        }
+
+        ClientIdGenerationMode clientIdGeneration = resourceType.ClientIdGeneration ?? globalClientIdGeneration;
+        return !(writeOperation == WriteOperationKind.CreateResource && clientIdGeneration == ClientIdGenerationMode.Required);
     }
 }


### PR DESCRIPTION
Fixes #1574.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
