### PR TITLE
Fixed: Produce error on invalid ID in request body

### DIFF
--- a/src/Examples/DapperExample/Repositories/ResultSetMapper.cs
+++ b/src/Examples/DapperExample/Repositories/ResultSetMapper.cs
@@ -18,9 +18,6 @@ internal sealed class ResultSetMapper<TResource, TId>
     // Note we don't do full bidirectional relationship fix-up; this just avoids duplicate instances.
     private readonly Dictionary<Type, Dictionary<object, object>> _resourceByTypeCache = [];
 
-    // Optimization to avoid unneeded calls to expensive Activator.CreateInstance() method, which is needed multiple times per row.
-    private readonly Dictionary<Type, object?> _defaultValueByTypeCache = [];
-
     // Used to determine where in the tree of included relationships a join object belongs to.
     private readonly Dictionary<IncludeElementExpression, int> _includeElementToJoinObjectArrayIndexLookup = new(ReferenceEqualityComparer.Instance);
 
@@ -114,20 +111,8 @@ internal sealed class ResultSetMapper<TResource, TId>
 
     private bool HasDefaultValue(object value)
     {
-        object? defaultValue = GetDefaultValueCached(value.GetType());
+        object? defaultValue = RuntimeTypeConverter.GetDefaultValue(value.GetType());
         return Equals(defaultValue, value);
-    }
-
-    private object? GetDefaultValueCached(Type type)
-    {
-        if (_defaultValueByTypeCache.TryGetValue(type, out object? defaultValue))
-        {
-            return defaultValue;
-        }
-
-        defaultValue = RuntimeTypeConverter.GetDefaultValue(type);
-        _defaultValueByTypeCache[type] = defaultValue;
-        return defaultValue;
     }
 
     private void RecursiveSetRelationships(object leftResource, IEnumerable<IncludeElementExpression> includeElements, object?[] joinObjects)

--- a/src/JsonApiDotNetCore.Annotations/Resources/RuntimeTypeConverter.cs
+++ b/src/JsonApiDotNetCore.Annotations/Resources/RuntimeTypeConverter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using JetBrains.Annotations;
 
@@ -12,6 +13,8 @@ namespace JsonApiDotNetCore.Resources;
 public static class RuntimeTypeConverter
 {
     private const string ParseQueryStringsUsingCurrentCultureSwitchName = "JsonApiDotNetCore.ParseQueryStringsUsingCurrentCulture";
+
+    private static readonly ConcurrentDictionary<Type, object?> DefaultTypeCache = new();
 
     /// <summary>
     /// Converts the specified value to the specified type.
@@ -137,6 +140,8 @@ public static class RuntimeTypeConverter
     /// </summary>
     public static bool CanContainNull(Type type)
     {
+        ArgumentGuard.NotNull(type);
+
         return !type.IsValueType || Nullable.GetUnderlyingType(type) != null;
     }
 
@@ -148,6 +153,8 @@ public static class RuntimeTypeConverter
     /// </returns>
     public static object? GetDefaultValue(Type type)
     {
-        return type.IsValueType ? Activator.CreateInstance(type) : null;
+        ArgumentGuard.NotNull(type);
+
+        return type.IsValueType ? DefaultTypeCache.GetOrAdd(type, Activator.CreateInstance) : null;
     }
 }

--- a/src/JsonApiDotNetCore/Controllers/JsonApiController.cs
+++ b/src/JsonApiDotNetCore/Controllers/JsonApiController.cs
@@ -51,7 +51,7 @@ public abstract class JsonApiController<TResource, TId> : BaseJsonApiController<
     /// <inheritdoc />
     [HttpGet("{id}")]
     [HttpHead("{id}")]
-    public override async Task<IActionResult> GetAsync([Required] [DisallowNull] TId id, CancellationToken cancellationToken)
+    public override async Task<IActionResult> GetAsync([Required(AllowEmptyStrings = true)] [DisallowNull] TId id, CancellationToken cancellationToken)
     {
         return await base.GetAsync(id, cancellationToken);
     }
@@ -59,7 +59,7 @@ public abstract class JsonApiController<TResource, TId> : BaseJsonApiController<
     /// <inheritdoc />
     [HttpGet("{id}/{relationshipName}")]
     [HttpHead("{id}/{relationshipName}")]
-    public override async Task<IActionResult> GetSecondaryAsync([Required] [DisallowNull] TId id, [Required] string relationshipName,
+    public override async Task<IActionResult> GetSecondaryAsync([Required(AllowEmptyStrings = true)] [DisallowNull] TId id, [Required] string relationshipName,
         CancellationToken cancellationToken)
     {
         return await base.GetSecondaryAsync(id, relationshipName, cancellationToken);
@@ -68,8 +68,8 @@ public abstract class JsonApiController<TResource, TId> : BaseJsonApiController<
     /// <inheritdoc />
     [HttpGet("{id}/relationships/{relationshipName}")]
     [HttpHead("{id}/relationships/{relationshipName}")]
-    public override async Task<IActionResult> GetRelationshipAsync([Required] [DisallowNull] TId id, [Required] string relationshipName,
-        CancellationToken cancellationToken)
+    public override async Task<IActionResult> GetRelationshipAsync([Required(AllowEmptyStrings = true)] [DisallowNull] TId id,
+        [Required] string relationshipName, CancellationToken cancellationToken)
     {
         return await base.GetRelationshipAsync(id, relationshipName, cancellationToken);
     }
@@ -83,39 +83,41 @@ public abstract class JsonApiController<TResource, TId> : BaseJsonApiController<
 
     /// <inheritdoc />
     [HttpPost("{id}/relationships/{relationshipName}")]
-    public override async Task<IActionResult> PostRelationshipAsync([Required] [DisallowNull] TId id, [Required] string relationshipName,
-        [Required] ISet<IIdentifiable> rightResourceIds, CancellationToken cancellationToken)
+    public override async Task<IActionResult> PostRelationshipAsync([Required(AllowEmptyStrings = true)] [DisallowNull] TId id,
+        [Required] string relationshipName, [Required] ISet<IIdentifiable> rightResourceIds, CancellationToken cancellationToken)
     {
         return await base.PostRelationshipAsync(id, relationshipName, rightResourceIds, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpPatch("{id}")]
-    public override async Task<IActionResult> PatchAsync([Required] [DisallowNull] TId id, [Required] TResource resource, CancellationToken cancellationToken)
+    public override async Task<IActionResult> PatchAsync([Required(AllowEmptyStrings = true)] [DisallowNull] TId id, [Required] TResource resource,
+        CancellationToken cancellationToken)
     {
         return await base.PatchAsync(id, resource, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpPatch("{id}/relationships/{relationshipName}")]
+    // `AllowEmptyStrings = true` in `[Required]` prevents the model binder from producing a validation error on whitespace when TId is string.
     // Parameter `[Required] object? rightValue` makes Swashbuckle generate the OpenAPI request body as required. We don't actually validate ModelState, so it doesn't hurt.
-    public override async Task<IActionResult> PatchRelationshipAsync([Required] [DisallowNull] TId id, [Required] string relationshipName,
-        [Required] object? rightValue, CancellationToken cancellationToken)
+    public override async Task<IActionResult> PatchRelationshipAsync([Required(AllowEmptyStrings = true)] [DisallowNull] TId id,
+        [Required] string relationshipName, [Required] object? rightValue, CancellationToken cancellationToken)
     {
         return await base.PatchRelationshipAsync(id, relationshipName, rightValue, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpDelete("{id}")]
-    public override async Task<IActionResult> DeleteAsync([Required] [DisallowNull] TId id, CancellationToken cancellationToken)
+    public override async Task<IActionResult> DeleteAsync([Required(AllowEmptyStrings = true)] [DisallowNull] TId id, CancellationToken cancellationToken)
     {
         return await base.DeleteAsync(id, cancellationToken);
     }
 
     /// <inheritdoc />
     [HttpDelete("{id}/relationships/{relationshipName}")]
-    public override async Task<IActionResult> DeleteRelationshipAsync([Required] [DisallowNull] TId id, [Required] string relationshipName,
-        [Required] ISet<IIdentifiable> rightResourceIds, CancellationToken cancellationToken)
+    public override async Task<IActionResult> DeleteRelationshipAsync([Required(AllowEmptyStrings = true)] [DisallowNull] TId id,
+        [Required] string relationshipName, [Required] ISet<IIdentifiable> rightResourceIds, CancellationToken cancellationToken)
     {
         return await base.DeleteRelationshipAsync(id, relationshipName, rightResourceIds, cancellationToken);
     }

--- a/src/JsonApiDotNetCore/Resources/IdentifiableExtensions.cs
+++ b/src/JsonApiDotNetCore/Resources/IdentifiableExtensions.cs
@@ -18,17 +18,12 @@ internal static class IdentifiableExtensions
         }
 
         object? propertyValue = property.GetValue(identifiable);
+        object? defaultValue = RuntimeTypeConverter.GetDefaultValue(property.PropertyType);
 
-        // PERF: We want to throw when 'Id' is unassigned without doing an expensive reflection call, unless this is likely the case.
-        if (identifiable.StringId == null)
+        if (Equals(propertyValue, defaultValue))
         {
-            object? defaultValue = RuntimeTypeConverter.GetDefaultValue(property.PropertyType);
-
-            if (Equals(propertyValue, defaultValue))
-            {
-                throw new InvalidOperationException($"Property '{identifiable.GetClrType().Name}.{IdPropertyName}' should " +
-                    $"have been assigned at this point, but it contains its default {property.PropertyType.Name} value '{propertyValue}'.");
-            }
+            throw new InvalidOperationException($"Property '{identifiable.GetClrType().Name}.{IdPropertyName}' should " +
+                $"have been assigned at this point, but it contains its default {property.PropertyType.Name} value '{propertyValue}'.");
         }
 
         return propertyValue!;

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Creating/AssignIdToTextLanguageDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Creating/AssignIdToTextLanguageDefinition.cs
@@ -1,0 +1,20 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Middleware;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Creating;
+
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+public sealed class AssignIdToTextLanguageDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter, OperationsDbContext dbContext)
+    : ImplicitlyChangingTextLanguageDefinition(resourceGraph, hitCounter, dbContext)
+{
+    public override Task OnWritingAsync(TextLanguage resource, WriteOperationKind writeOperation, CancellationToken cancellationToken)
+    {
+        if (writeOperation == WriteOperationKind.CreateResource && resource.Id == Guid.Empty)
+        {
+            resource.Id = Guid.NewGuid();
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/AssignIdToRgbColorDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/AssignIdToRgbColorDefinition.cs
@@ -1,0 +1,29 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Middleware;
+using JsonApiDotNetCore.Resources;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.ReadWrite.Creating;
+
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+internal sealed class AssignIdToRgbColorDefinition(IResourceGraph resourceGraph) : JsonApiResourceDefinition<RgbColor, string?>(resourceGraph)
+{
+    internal const string DefaultId = "0x000000";
+    internal const string DefaultName = "Black";
+
+    public override Task OnWritingAsync(RgbColor resource, WriteOperationKind writeOperation, CancellationToken cancellationToken)
+    {
+        if (writeOperation == WriteOperationKind.CreateResource && resource.Id == null)
+        {
+            SetDefaultColor(resource);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static void SetDefaultColor(RgbColor resource)
+    {
+        resource.Id = DefaultId;
+        resource.DisplayName = DefaultName;
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithClientGeneratedIdTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithClientGeneratedIdTests.cs
@@ -21,6 +21,7 @@ public sealed class CreateResourceWithClientGeneratedIdTests : IClassFixture<Int
 
         testContext.UseController<WorkItemGroupsController>();
         testContext.UseController<RgbColorsController>();
+        testContext.UseController<UserAccountsController>();
 
         testContext.ConfigureServices(services =>
         {
@@ -334,6 +335,231 @@ public sealed class CreateResourceWithClientGeneratedIdTests : IClassFixture<Int
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
         error.Title.Should().Be("Failed to deserialize request body: The 'id' element is required.");
+        error.Detail.Should().BeNull();
+        error.Source.ShouldNotBeNull();
+        error.Source.Pointer.Should().Be("/data");
+        error.Meta.ShouldContainKey("requestBody").With(value => value.ShouldNotBeNull().ToString().ShouldNotBeEmpty());
+    }
+
+    [Theory]
+    [InlineData(ClientIdGenerationMode.Allowed)]
+    [InlineData(ClientIdGenerationMode.Required)]
+    public async Task Cannot_create_resource_with_client_generated_zero_guid_ID(ClientIdGenerationMode mode)
+    {
+        // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.ClientIdGeneration = mode;
+
+        WorkItemGroup newGroup = _fakers.WorkItemGroup.Generate();
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "workItemGroups",
+                id = Guid.Empty.ToString(),
+                attributes = new
+                {
+                    name = newGroup.Name
+                }
+            }
+        };
+
+        const string route = "/workItemGroups";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        error.Title.Should().Be("Failed to deserialize request body: The 'id' element is invalid.");
+        error.Detail.Should().BeNull();
+        error.Source.ShouldNotBeNull();
+        error.Source.Pointer.Should().Be("/data");
+        error.Meta.ShouldContainKey("requestBody").With(value => value.ShouldNotBeNull().ToString().ShouldNotBeEmpty());
+    }
+
+    [Theory]
+    [InlineData(ClientIdGenerationMode.Allowed)]
+    [InlineData(ClientIdGenerationMode.Required)]
+    public async Task Cannot_create_resource_with_client_generated_empty_guid_ID(ClientIdGenerationMode mode)
+    {
+        // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.ClientIdGeneration = mode;
+
+        WorkItemGroup newGroup = _fakers.WorkItemGroup.Generate();
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "workItemGroups",
+                id = string.Empty,
+                attributes = new
+                {
+                    name = newGroup.Name
+                }
+            }
+        };
+
+        const string route = "/workItemGroups";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        error.Title.Should().Be("Failed to deserialize request body: The 'id' element is invalid.");
+        error.Detail.Should().BeNull();
+        error.Source.ShouldNotBeNull();
+        error.Source.Pointer.Should().Be("/data");
+        error.Meta.ShouldContainKey("requestBody").With(value => value.ShouldNotBeNull().ToString().ShouldNotBeEmpty());
+    }
+
+    [Theory]
+    [InlineData(ClientIdGenerationMode.Allowed)]
+    [InlineData(ClientIdGenerationMode.Required)]
+    public async Task Can_create_resource_with_client_generated_empty_string_ID(ClientIdGenerationMode mode)
+    {
+        // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.ClientIdGeneration = mode;
+
+        RgbColor newColor = _fakers.RgbColor.Generate();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<RgbColor>();
+        });
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "rgbColors",
+                id = string.Empty,
+                attributes = new
+                {
+                    displayName = newColor.DisplayName
+                }
+            }
+        };
+
+        const string route = "/rgbColors?fields[rgbColors]=id";
+
+        // Act
+        (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePostAsync<string>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        responseDocument.Should().BeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            RgbColor colorInDatabase = await dbContext.RgbColors.FirstWithIdAsync((string?)string.Empty);
+
+            colorInDatabase.DisplayName.Should().Be(newColor.DisplayName);
+        });
+
+        PropertyInfo? property = typeof(RgbColor).GetProperty(nameof(Identifiable<object>.Id));
+        property.ShouldNotBeNull();
+        property.PropertyType.Should().Be(typeof(string));
+    }
+
+    [Theory]
+    [InlineData(ClientIdGenerationMode.Allowed)]
+    [InlineData(ClientIdGenerationMode.Required)]
+    public async Task Cannot_create_resource_with_client_generated_zero_long_ID(ClientIdGenerationMode mode)
+    {
+        // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.ClientIdGeneration = mode;
+
+        UserAccount newAccount = _fakers.UserAccount.Generate();
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "userAccounts",
+                id = "0",
+                attributes = new
+                {
+                    firstName = newAccount.FirstName,
+                    lastName = newAccount.LastName
+                }
+            }
+        };
+
+        const string route = "/userAccounts";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        error.Title.Should().Be("Failed to deserialize request body: The 'id' element is invalid.");
+        error.Detail.Should().BeNull();
+        error.Source.ShouldNotBeNull();
+        error.Source.Pointer.Should().Be("/data");
+        error.Meta.ShouldContainKey("requestBody").With(value => value.ShouldNotBeNull().ToString().ShouldNotBeEmpty());
+    }
+
+    [Theory]
+    [InlineData(ClientIdGenerationMode.Allowed)]
+    [InlineData(ClientIdGenerationMode.Required)]
+    public async Task Cannot_create_resource_with_client_generated_empty_long_ID(ClientIdGenerationMode mode)
+    {
+        // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.ClientIdGeneration = mode;
+
+        UserAccount newAccount = _fakers.UserAccount.Generate();
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "userAccounts",
+                id = string.Empty,
+                attributes = new
+                {
+                    firstName = newAccount.FirstName,
+                    lastName = newAccount.LastName
+                }
+            }
+        };
+
+        const string route = "/userAccounts";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.UnprocessableEntity);
+
+        responseDocument.Errors.ShouldHaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        error.Title.Should().Be("Failed to deserialize request body: The 'id' element is invalid.");
         error.Detail.Should().BeNull();
         error.Source.ShouldNotBeNull();
         error.Source.Pointer.Should().Be("/data");

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithClientGeneratedIdTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithClientGeneratedIdTests.cs
@@ -22,16 +22,22 @@ public sealed class CreateResourceWithClientGeneratedIdTests : IClassFixture<Int
         testContext.UseController<WorkItemGroupsController>();
         testContext.UseController<RgbColorsController>();
 
-        testContext.ConfigureServices(services => services.AddResourceDefinition<ImplicitlyChangingWorkItemGroupDefinition>());
-
-        var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
-        options.ClientIdGeneration = ClientIdGenerationMode.Required;
+        testContext.ConfigureServices(services =>
+        {
+            services.AddResourceDefinition<ImplicitlyChangingWorkItemGroupDefinition>();
+            services.AddResourceDefinition<AssignIdToRgbColorDefinition>();
+        });
     }
 
-    [Fact]
-    public async Task Can_create_resource_with_client_generated_guid_ID_having_side_effects()
+    [Theory]
+    [InlineData(ClientIdGenerationMode.Allowed)]
+    [InlineData(ClientIdGenerationMode.Required)]
+    public async Task Can_create_resource_with_client_generated_guid_ID_having_side_effects(ClientIdGenerationMode mode)
     {
         // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.ClientIdGeneration = mode;
+
         WorkItemGroup newGroup = _fakers.WorkItemGroup.Generate();
         newGroup.Id = Guid.NewGuid();
 
@@ -76,10 +82,15 @@ public sealed class CreateResourceWithClientGeneratedIdTests : IClassFixture<Int
         property.PropertyType.Should().Be(typeof(Guid));
     }
 
-    [Fact]
-    public async Task Can_create_resource_with_client_generated_guid_ID_having_side_effects_with_fieldset()
+    [Theory]
+    [InlineData(ClientIdGenerationMode.Allowed)]
+    [InlineData(ClientIdGenerationMode.Required)]
+    public async Task Can_create_resource_with_client_generated_guid_ID_having_side_effects_with_fieldset(ClientIdGenerationMode mode)
     {
         // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.ClientIdGeneration = mode;
+
         WorkItemGroup newGroup = _fakers.WorkItemGroup.Generate();
         newGroup.Id = Guid.NewGuid();
 
@@ -125,11 +136,21 @@ public sealed class CreateResourceWithClientGeneratedIdTests : IClassFixture<Int
         property.PropertyType.Should().Be(typeof(Guid));
     }
 
-    [Fact]
-    public async Task Can_create_resource_with_client_generated_string_ID_having_no_side_effects()
+    [Theory]
+    [InlineData(ClientIdGenerationMode.Allowed)]
+    [InlineData(ClientIdGenerationMode.Required)]
+    public async Task Can_create_resource_with_client_generated_string_ID_having_no_side_effects(ClientIdGenerationMode mode)
     {
         // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.ClientIdGeneration = mode;
+
         RgbColor newColor = _fakers.RgbColor.Generate();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<RgbColor>();
+        });
 
         var requestBody = new
         {
@@ -166,11 +187,21 @@ public sealed class CreateResourceWithClientGeneratedIdTests : IClassFixture<Int
         property.PropertyType.Should().Be(typeof(string));
     }
 
-    [Fact]
-    public async Task Can_create_resource_with_client_generated_string_ID_having_no_side_effects_with_fieldset()
+    [Theory]
+    [InlineData(ClientIdGenerationMode.Allowed)]
+    [InlineData(ClientIdGenerationMode.Required)]
+    public async Task Can_create_resource_with_client_generated_string_ID_having_no_side_effects_with_fieldset(ClientIdGenerationMode mode)
     {
         // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.ClientIdGeneration = mode;
+
         RgbColor newColor = _fakers.RgbColor.Generate();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<RgbColor>();
+        });
 
         var requestBody = new
         {
@@ -207,11 +238,76 @@ public sealed class CreateResourceWithClientGeneratedIdTests : IClassFixture<Int
         property.PropertyType.Should().Be(typeof(string));
     }
 
-    [Fact]
-    public async Task Cannot_create_resource_for_missing_client_generated_ID()
+    [Theory]
+    [InlineData(ClientIdGenerationMode.Allowed)]
+    public async Task Can_create_resource_for_missing_client_generated_ID_having_side_effects(ClientIdGenerationMode mode)
     {
         // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.ClientIdGeneration = mode;
+
         string newDisplayName = _fakers.RgbColor.Generate().DisplayName;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<RgbColor>();
+        });
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "rgbColors",
+                attributes = new
+                {
+                    displayName = newDisplayName
+                }
+            }
+        };
+
+        const string route = "/rgbColors";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Created);
+
+        const string defaultId = AssignIdToRgbColorDefinition.DefaultId;
+        const string defaultName = AssignIdToRgbColorDefinition.DefaultName;
+
+        responseDocument.Data.SingleValue.ShouldNotBeNull();
+        responseDocument.Data.SingleValue.Type.Should().Be("rgbColors");
+        responseDocument.Data.SingleValue.Id.Should().Be(defaultId);
+        responseDocument.Data.SingleValue.Attributes.ShouldContainKey("displayName").With(value => value.Should().Be(defaultName));
+        responseDocument.Data.SingleValue.Relationships.ShouldNotBeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            RgbColor colorInDatabase = await dbContext.RgbColors.FirstWithIdAsync((string?)defaultId);
+
+            colorInDatabase.DisplayName.Should().Be(defaultName);
+        });
+
+        PropertyInfo? property = typeof(RgbColor).GetProperty(nameof(Identifiable<object>.Id));
+        property.ShouldNotBeNull();
+        property.PropertyType.Should().Be(typeof(string));
+    }
+
+    [Theory]
+    [InlineData(ClientIdGenerationMode.Required)]
+    public async Task Cannot_create_resource_for_missing_client_generated_ID(ClientIdGenerationMode mode)
+    {
+        // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.ClientIdGeneration = mode;
+
+        string newDisplayName = _fakers.RgbColor.Generate().DisplayName;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<RgbColor>();
+        });
 
         var requestBody = new
         {
@@ -244,17 +340,23 @@ public sealed class CreateResourceWithClientGeneratedIdTests : IClassFixture<Int
         error.Meta.ShouldContainKey("requestBody").With(value => value.ShouldNotBeNull().ToString().ShouldNotBeEmpty());
     }
 
-    [Fact]
-    public async Task Cannot_create_resource_for_existing_client_generated_ID()
+    [Theory]
+    [InlineData(ClientIdGenerationMode.Allowed)]
+    [InlineData(ClientIdGenerationMode.Required)]
+    public async Task Cannot_create_resource_for_existing_client_generated_ID(ClientIdGenerationMode mode)
     {
         // Arrange
+        var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.ClientIdGeneration = mode;
+
         RgbColor existingColor = _fakers.RgbColor.Generate();
 
-        RgbColor colorToCreate = _fakers.RgbColor.Generate();
-        colorToCreate.Id = existingColor.Id;
+        RgbColor newColor = _fakers.RgbColor.Generate();
+        newColor.Id = existingColor.Id;
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
+            await dbContext.ClearTableAsync<RgbColor>();
             dbContext.RgbColors.Add(existingColor);
             await dbContext.SaveChangesAsync();
         });
@@ -264,10 +366,10 @@ public sealed class CreateResourceWithClientGeneratedIdTests : IClassFixture<Int
             data = new
             {
                 type = "rgbColors",
-                id = colorToCreate.StringId,
+                id = newColor.StringId,
                 attributes = new
                 {
-                    displayName = colorToCreate.DisplayName
+                    displayName = newColor.DisplayName
                 }
             }
         };

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/CreateResourceWithToManyRelationshipTests.cs
@@ -232,7 +232,7 @@ public sealed class CreateResourceWithToManyRelationshipTests : IClassFixture<In
     {
         // Arrange
         List<WorkTag> existingTags = _fakers.WorkTag.Generate(3);
-        WorkItem workItemToCreate = _fakers.WorkItem.Generate();
+        WorkItem newWorkItem = _fakers.WorkItem.Generate();
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
@@ -247,8 +247,8 @@ public sealed class CreateResourceWithToManyRelationshipTests : IClassFixture<In
                 type = "workItems",
                 attributes = new
                 {
-                    description = workItemToCreate.Description,
-                    priority = workItemToCreate.Priority
+                    description = newWorkItem.Description,
+                    priority = newWorkItem.Priority
                 },
                 relationships = new
                 {
@@ -287,7 +287,7 @@ public sealed class CreateResourceWithToManyRelationshipTests : IClassFixture<In
 
         responseDocument.Data.SingleValue.ShouldNotBeNull();
         responseDocument.Data.SingleValue.Attributes.ShouldHaveCount(1);
-        responseDocument.Data.SingleValue.Attributes.ShouldContainKey("priority").With(value => value.Should().Be(workItemToCreate.Priority));
+        responseDocument.Data.SingleValue.Attributes.ShouldContainKey("priority").With(value => value.Should().Be(newWorkItem.Priority));
         responseDocument.Data.SingleValue.Relationships.ShouldHaveCount(1);
 
         responseDocument.Data.SingleValue.Relationships.ShouldContainKey("tags").With(value =>

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/RgbColor.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/RgbColor.cs
@@ -6,8 +6,13 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ReadWrite;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
 [Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.ReadWrite")]
-public sealed class RgbColor : Identifiable<string>
+public sealed class RgbColor : Identifiable<string?>
 {
+#if NET6_0
+    // Workaround for bug in .NET 6, see https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/1153.
+    public override string? Id { get; set; }
+#endif
+
     [Attr]
     public string DisplayName { get; set; } = null!;
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/EmptyGuidAsKeyTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/EmptyGuidAsKeyTests.cs
@@ -572,9 +572,9 @@ public sealed class EmptyGuidAsKeyTests : IClassFixture<IntegrationTestContext<T
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            Map? gameInDatabase = await dbContext.Maps.FirstWithIdOrDefaultAsync(existingMap.Id);
+            Map? mapInDatabase = await dbContext.Maps.FirstWithIdOrDefaultAsync(existingMap.Id);
 
-            gameInDatabase.Should().BeNull();
+            mapInDatabase.Should().BeNull();
         });
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/Game.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/Game.cs
@@ -17,6 +17,9 @@ public sealed class Game : Identifiable<int?>
     [Attr]
     public Guid SessionToken => Guid.NewGuid();
 
+    [HasOne]
+    public Player? Host { get; set; }
+
     [HasMany]
     public ICollection<Player> ActivePlayers { get; set; } = new List<Player>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/Player.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/Player.cs
@@ -1,11 +1,12 @@
 using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys")]
+[Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys", ClientIdGeneration = ClientIdGenerationMode.Allowed)]
 public sealed class Player : Identifiable<string?>
 {
     [Attr]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/Player.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/Player.cs
@@ -6,7 +6,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
 [Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys")]
-public sealed class Player : Identifiable<string>
+public sealed class Player : Identifiable<string?>
 {
     [Attr]
     public string EmailAddress { get; set; } = null!;

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/WhiteSpaceAsKeyTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/WhiteSpaceAsKeyTests.cs
@@ -1,0 +1,656 @@
+using System.Net;
+using System.Reflection;
+using FluentAssertions;
+using JsonApiDotNetCore;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Serialization.Objects;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TestBuildingBlocks;
+using Xunit;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys;
+
+public sealed class WhiteSpaceAsKeyTests : IClassFixture<IntegrationTestContext<TestableStartup<ZeroKeyDbContext>, ZeroKeyDbContext>>
+{
+    // An empty string id makes no sense: get-by-id, update and delete resource are impossible, and rendered links are unusable.
+    private const string SingleSpace = " ";
+
+    private readonly IntegrationTestContext<TestableStartup<ZeroKeyDbContext>, ZeroKeyDbContext> _testContext;
+    private readonly ZeroKeyFakers _fakers = new();
+
+    public WhiteSpaceAsKeyTests(IntegrationTestContext<TestableStartup<ZeroKeyDbContext>, ZeroKeyDbContext> testContext)
+    {
+        _testContext = testContext;
+
+        testContext.UseController<PlayersController>();
+        testContext.UseController<GamesController>();
+        testContext.UseController<MapsController>();
+
+        testContext.PostConfigureServices(services =>
+        {
+            ServiceDescriptor serviceDescriptor = services.Single(descriptor => descriptor.ServiceType == typeof(IModelMetadataProvider));
+            services.Remove(serviceDescriptor);
+            Type existingProviderType = serviceDescriptor.ImplementationType!;
+
+            services.AddSingleton<IModelMetadataProvider>(serviceProvider =>
+            {
+                var existingProvider = (ModelMetadataProvider)ActivatorUtilities.CreateInstance(serviceProvider, existingProviderType);
+                return new PreserveWhitespaceModelMetadataProvider(existingProvider);
+            });
+        });
+
+        var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.UseRelativeLinks = true;
+    }
+
+    [Fact]
+    public async Task Can_filter_by_space_ID_on_primary_resources()
+    {
+        // Arrange
+        List<Player> players = _fakers.Player.Generate(2);
+        players[0].Id = SingleSpace;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Player>();
+            dbContext.Players.AddRange(players);
+            await dbContext.SaveChangesAsync();
+        });
+
+        const string route = "/players?filter=equals(id,' ')";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        responseDocument.Data.ManyValue.ShouldHaveCount(1);
+        responseDocument.Data.ManyValue[0].Id.Should().Be(SingleSpace);
+
+        responseDocument.Data.ManyValue[0].With(resource =>
+        {
+            resource.Links.ShouldNotBeNull();
+            resource.Links.Self.Should().Be("/players/%20");
+        });
+    }
+
+    [Fact]
+    public async Task Can_get_primary_resource_by_space_ID_with_include()
+    {
+        // Arrange
+        Player player = _fakers.Player.Generate();
+        player.Id = SingleSpace;
+        player.ActiveGame = _fakers.Game.Generate();
+        player.ActiveGame.Id = 0;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTablesAsync<Player, Game>();
+            dbContext.Players.Add(player);
+            await dbContext.SaveChangesAsync();
+        });
+
+        const string route = "/players/%20?include=activeGame";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        responseDocument.Data.SingleValue.ShouldNotBeNull();
+        responseDocument.Data.SingleValue.Id.Should().Be(SingleSpace);
+        responseDocument.Data.SingleValue.Links.ShouldNotBeNull();
+        responseDocument.Data.SingleValue.Links.Self.Should().Be("/players/%20");
+
+        responseDocument.Included.ShouldHaveCount(1);
+        responseDocument.Included[0].Id.Should().Be("0");
+    }
+
+    [Fact]
+    public async Task Can_create_resource_with_space_ID()
+    {
+        // Arrange
+        string newEmailAddress = _fakers.Player.Generate().EmailAddress;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Player>();
+        });
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "players",
+                id = SingleSpace,
+                attributes = new
+                {
+                    emailAddress = newEmailAddress
+                }
+            }
+        };
+
+        const string route = "/players";
+
+        // Act
+        (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePostAsync<string>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        httpResponse.Headers.Location.Should().Be("/players/%20");
+
+        responseDocument.Should().BeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            Player playerInDatabase = await dbContext.Players.FirstWithIdAsync((string?)SingleSpace);
+
+            playerInDatabase.ShouldNotBeNull();
+            playerInDatabase.EmailAddress.Should().Be(newEmailAddress);
+        });
+    }
+
+    [Fact]
+    public async Task Can_update_resource_with_space_ID()
+    {
+        // Arrange
+        Player existingPlayer = _fakers.Player.Generate();
+        existingPlayer.Id = SingleSpace;
+
+        string newEmailAddress = _fakers.Player.Generate().EmailAddress;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Player>();
+            dbContext.Players.Add(existingPlayer);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "players",
+                id = SingleSpace,
+                attributes = new
+                {
+                    emailAddress = newEmailAddress
+                }
+            }
+        };
+
+        const string route = "/players/%20";
+
+        // Act
+        (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePatchAsync<string>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        responseDocument.Should().BeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            Player playerInDatabase = await dbContext.Players.FirstWithIdAsync((string?)SingleSpace);
+
+            playerInDatabase.ShouldNotBeNull();
+            playerInDatabase.EmailAddress.Should().Be(newEmailAddress);
+        });
+    }
+
+    [Fact]
+    public async Task Can_clear_ToOne_relationship_with_space_ID()
+    {
+        // Arrange
+        Game existingGame = _fakers.Game.Generate();
+        existingGame.Host = _fakers.Player.Generate();
+        existingGame.Host.Id = string.Empty;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Player>();
+            dbContext.Games.Add(existingGame);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var requestBody = new
+        {
+            data = (object?)null
+        };
+
+        string route = $"/games/{existingGame.StringId}/relationships/host";
+
+        // Act
+        (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePatchAsync<string>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        responseDocument.Should().BeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            Game gameInDatabase = await dbContext.Games.Include(game => game.Host).FirstWithIdAsync(existingGame.Id);
+
+            gameInDatabase.ShouldNotBeNull();
+            gameInDatabase.Host.Should().BeNull();
+        });
+    }
+
+    [Fact]
+    public async Task Can_assign_ToOne_relationship_with_space_ID()
+    {
+        // Arrange
+        Game existingGame = _fakers.Game.Generate();
+
+        Player existingPlayer = _fakers.Player.Generate();
+        existingPlayer.Id = SingleSpace;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Player>();
+            dbContext.AddInRange(existingGame, existingPlayer);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "players",
+                id = SingleSpace
+            }
+        };
+
+        string route = $"/games/{existingGame.StringId}/relationships/host";
+
+        // Act
+        (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePatchAsync<string>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        responseDocument.Should().BeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            Game gameInDatabase = await dbContext.Games.Include(game => game.Host).FirstWithIdAsync(existingGame.Id);
+
+            gameInDatabase.ShouldNotBeNull();
+            gameInDatabase.Host.ShouldNotBeNull();
+            gameInDatabase.Host.Id.Should().Be(SingleSpace);
+        });
+    }
+
+    [Fact]
+    public async Task Can_replace_ToOne_relationship_with_space_ID()
+    {
+        // Arrange
+        Game existingGame = _fakers.Game.Generate();
+        existingGame.Host = _fakers.Player.Generate();
+
+        Player existingPlayer = _fakers.Player.Generate();
+        existingPlayer.Id = SingleSpace;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Player>();
+            dbContext.AddInRange(existingGame, existingPlayer);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "players",
+                id = SingleSpace
+            }
+        };
+
+        string route = $"/games/{existingGame.StringId}/relationships/host";
+
+        // Act
+        (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePatchAsync<string>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        responseDocument.Should().BeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            Game gameInDatabase = await dbContext.Games.Include(game => game.Host).FirstWithIdAsync(existingGame.Id);
+
+            gameInDatabase.ShouldNotBeNull();
+            gameInDatabase.Host.ShouldNotBeNull();
+            gameInDatabase.Host.Id.Should().Be(SingleSpace);
+        });
+    }
+
+    [Fact]
+    public async Task Can_clear_ToMany_relationship_with_space_ID()
+    {
+        // Arrange
+        Game existingGame = _fakers.Game.Generate();
+        existingGame.ActivePlayers = _fakers.Player.Generate(2);
+        existingGame.ActivePlayers.ElementAt(0).Id = SingleSpace;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Player>();
+            dbContext.Games.Add(existingGame);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var requestBody = new
+        {
+            data = Array.Empty<object>()
+        };
+
+        string route = $"/games/{existingGame.StringId}/relationships/activePlayers";
+
+        // Act
+        (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePatchAsync<string>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        responseDocument.Should().BeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            Game gameInDatabase = await dbContext.Games.Include(game => game.ActivePlayers).FirstWithIdAsync(existingGame.Id);
+
+            gameInDatabase.ShouldNotBeNull();
+            gameInDatabase.ActivePlayers.Should().BeEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task Can_assign_ToMany_relationship_with_space_ID()
+    {
+        // Arrange
+        Game existingGame = _fakers.Game.Generate();
+
+        Player existingPlayer = _fakers.Player.Generate();
+        existingPlayer.Id = SingleSpace;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Player>();
+            dbContext.AddInRange(existingGame, existingPlayer);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var requestBody = new
+        {
+            data = new[]
+            {
+                new
+                {
+                    type = "players",
+                    id = SingleSpace
+                }
+            }
+        };
+
+        string route = $"/games/{existingGame.StringId}/relationships/activePlayers";
+
+        // Act
+        (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePatchAsync<string>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        responseDocument.Should().BeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            Game gameInDatabase = await dbContext.Games.Include(game => game.ActivePlayers).FirstWithIdAsync(existingGame.Id);
+
+            gameInDatabase.ShouldNotBeNull();
+            gameInDatabase.ActivePlayers.ShouldHaveCount(1);
+            gameInDatabase.ActivePlayers.ElementAt(0).Id.Should().Be(SingleSpace);
+        });
+    }
+
+    [Fact]
+    public async Task Can_replace_ToMany_relationship_with_space_ID()
+    {
+        // Arrange
+        Game existingGame = _fakers.Game.Generate();
+        existingGame.ActivePlayers = _fakers.Player.Generate(2);
+
+        Player existingPlayer = _fakers.Player.Generate();
+        existingPlayer.Id = SingleSpace;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Player>();
+            dbContext.AddInRange(existingGame, existingPlayer);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var requestBody = new
+        {
+            data = new[]
+            {
+                new
+                {
+                    type = "players",
+                    id = SingleSpace
+                }
+            }
+        };
+
+        string route = $"/games/{existingGame.StringId}/relationships/activePlayers";
+
+        // Act
+        (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePatchAsync<string>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        responseDocument.Should().BeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            Game gameInDatabase = await dbContext.Games.Include(game => game.ActivePlayers).FirstWithIdAsync(existingGame.Id);
+
+            gameInDatabase.ShouldNotBeNull();
+            gameInDatabase.ActivePlayers.ShouldHaveCount(1);
+            gameInDatabase.ActivePlayers.ElementAt(0).Id.Should().Be(SingleSpace);
+        });
+    }
+
+    [Fact]
+    public async Task Can_add_to_ToMany_relationship_with_space_ID()
+    {
+        // Arrange
+        Game existingGame = _fakers.Game.Generate();
+        existingGame.ActivePlayers = _fakers.Player.Generate(1);
+
+        Player existingPlayer = _fakers.Player.Generate();
+        existingPlayer.Id = SingleSpace;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Player>();
+            dbContext.AddInRange(existingGame, existingPlayer);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var requestBody = new
+        {
+            data = new[]
+            {
+                new
+                {
+                    type = "players",
+                    id = SingleSpace
+                }
+            }
+        };
+
+        string route = $"/games/{existingGame.StringId}/relationships/activePlayers";
+
+        // Act
+        (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePostAsync<string>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        responseDocument.Should().BeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            Game gameInDatabase = await dbContext.Games.Include(game => game.ActivePlayers).FirstWithIdAsync(existingGame.Id);
+
+            gameInDatabase.ShouldNotBeNull();
+            gameInDatabase.ActivePlayers.ShouldHaveCount(2);
+            gameInDatabase.ActivePlayers.Should().ContainSingle(player => player.Id == SingleSpace);
+        });
+    }
+
+    [Fact]
+    public async Task Can_remove_from_ToMany_relationship_with_space_ID()
+    {
+        // Arrange
+        Game existingGame = _fakers.Game.Generate();
+        existingGame.ActivePlayers = _fakers.Player.Generate(2);
+        existingGame.ActivePlayers.ElementAt(0).Id = SingleSpace;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Player>();
+            dbContext.Games.Add(existingGame);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var requestBody = new
+        {
+            data = new[]
+            {
+                new
+                {
+                    type = "players",
+                    id = SingleSpace
+                }
+            }
+        };
+
+        string route = $"/games/{existingGame.StringId}/relationships/activePlayers";
+
+        // Act
+        (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecuteDeleteAsync<string>(route, requestBody);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        responseDocument.Should().BeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            Game gameInDatabase = await dbContext.Games.Include(game => game.ActivePlayers).FirstWithIdAsync(existingGame.Id);
+
+            gameInDatabase.ShouldNotBeNull();
+            gameInDatabase.ActivePlayers.ShouldHaveCount(1);
+            gameInDatabase.ActivePlayers.Should().ContainSingle(player => player.Id != SingleSpace);
+        });
+    }
+
+    [Fact]
+    public async Task Can_delete_resource_with_space_ID()
+    {
+        // Arrange
+        Player existingPlayer = _fakers.Player.Generate();
+        existingPlayer.Id = SingleSpace;
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Player>();
+            dbContext.Players.Add(existingPlayer);
+            await dbContext.SaveChangesAsync();
+        });
+
+        const string route = "/players/%20";
+
+        // Act
+        (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecuteDeleteAsync<string>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NoContent);
+
+        responseDocument.Should().BeEmpty();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            Player? playerInDatabase = await dbContext.Players.FirstWithIdOrDefaultAsync((string?)existingPlayer.Id);
+
+            playerInDatabase.Should().BeNull();
+        });
+    }
+
+    private sealed class PreserveWhitespaceModelMetadataProvider : ModelMetadataProvider
+    {
+        private readonly ModelMetadataProvider _innerProvider;
+
+        public PreserveWhitespaceModelMetadataProvider(ModelMetadataProvider innerProvider)
+        {
+            ArgumentGuard.NotNull(innerProvider);
+
+            _innerProvider = innerProvider;
+        }
+
+        public override ModelMetadata GetMetadataForType(Type modelType)
+        {
+            var metadata = (DefaultModelMetadata)_innerProvider.GetMetadataForType(modelType);
+
+            TurnOffConvertEmptyStringToNull(metadata);
+
+            return metadata;
+        }
+
+        public override IEnumerable<ModelMetadata> GetMetadataForProperties(Type modelType)
+        {
+            return _innerProvider.GetMetadataForProperties(modelType);
+        }
+
+        public override ModelMetadata GetMetadataForParameter(ParameterInfo parameter)
+        {
+            var metadata = (DefaultModelMetadata)_innerProvider.GetMetadataForParameter(parameter);
+
+            TurnOffConvertEmptyStringToNull(metadata);
+
+            return metadata;
+        }
+
+        public override ModelMetadata GetMetadataForParameter(ParameterInfo parameter, Type modelType)
+        {
+            return _innerProvider.GetMetadataForParameter(parameter, modelType);
+        }
+
+        public override ModelMetadata GetMetadataForProperty(PropertyInfo propertyInfo, Type modelType)
+        {
+            return _innerProvider.GetMetadataForProperty(propertyInfo, modelType);
+        }
+
+        public override ModelMetadata GetMetadataForConstructor(ConstructorInfo constructor, Type modelType)
+        {
+            return _innerProvider.GetMetadataForConstructor(constructor, modelType);
+        }
+
+        private static void TurnOffConvertEmptyStringToNull(DefaultModelMetadata metadata)
+        {
+            // https://github.com/dotnet/aspnetcore/issues/29948#issuecomment-2058747809
+            metadata.DisplayMetadata.ConvertEmptyStringToNull = false;
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the bug where an empty string or whitespace for `id` is incorrectly accepted in a request body when `TId` is not `string`.
The behavior of `RuntimeTypeConverter` remains unchanged (due to potential impact). The check is implemented in the deserialization of incoming request bodies.

Test coverage for the three modes of `ClientIdGenerationMode` has improved. Tests for all endpoints using `string` as `TId` were added. These use a single space, because an empty string results in a broken experience: you can't get-by-id, delete, or update such a resource, and rendered links are unusable.

Additionally, this PR makes a type's default value lookup 20% faster and reduces allocations by 90% (see commit message for details).

Fixes #1485.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
