### PR TITLE
OpenAPI: Add type hints on 'id' parameters and properties

### DIFF
--- a/src/Examples/JsonApiDotNetCoreExample/GeneratedSwagger/JsonApiDotNetCoreExample.json
+++ b/src/Examples/JsonApiDotNetCoreExample/GeneratedSwagger/JsonApiDotNetCoreExample.json
@@ -368,7 +368,9 @@
             "description": "The identifier of the person to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -461,7 +463,9 @@
             "description": "The identifier of the person to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -540,7 +544,9 @@
             "description": "The identifier of the person to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -641,7 +647,9 @@
             "description": "The identifier of the person to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -676,7 +684,9 @@
             "description": "The identifier of the person whose related todoItems to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -769,7 +779,9 @@
             "description": "The identifier of the person whose related todoItems to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -850,7 +862,9 @@
             "description": "The identifier of the person whose related todoItem identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -943,7 +957,9 @@
             "description": "The identifier of the person whose related todoItem identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1022,7 +1038,9 @@
             "description": "The identifier of the person to add todoItems to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -1090,7 +1108,9 @@
             "description": "The identifier of the person whose assignedTodoItems relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -1158,7 +1178,9 @@
             "description": "The identifier of the person to remove todoItems from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -1228,7 +1250,9 @@
             "description": "The identifier of the person whose related todoItems to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1321,7 +1345,9 @@
             "description": "The identifier of the person whose related todoItems to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1402,7 +1428,9 @@
             "description": "The identifier of the person whose related todoItem identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1495,7 +1523,9 @@
             "description": "The identifier of the person whose related todoItem identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1574,7 +1604,9 @@
             "description": "The identifier of the person to add todoItems to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -1642,7 +1674,9 @@
             "description": "The identifier of the person whose ownedTodoItems relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -1710,7 +1744,9 @@
             "description": "The identifier of the person to remove todoItems from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2035,7 +2071,9 @@
             "description": "The identifier of the tag to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2128,7 +2166,9 @@
             "description": "The identifier of the tag to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2207,7 +2247,9 @@
             "description": "The identifier of the tag to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2308,7 +2350,9 @@
             "description": "The identifier of the tag to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2343,7 +2387,9 @@
             "description": "The identifier of the tag whose related todoItems to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2436,7 +2482,9 @@
             "description": "The identifier of the tag whose related todoItems to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2517,7 +2565,9 @@
             "description": "The identifier of the tag whose related todoItem identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2610,7 +2660,9 @@
             "description": "The identifier of the tag whose related todoItem identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2689,7 +2741,9 @@
             "description": "The identifier of the tag to add todoItems to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2757,7 +2811,9 @@
             "description": "The identifier of the tag whose todoItems relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2825,7 +2881,9 @@
             "description": "The identifier of the tag to remove todoItems from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3150,7 +3208,9 @@
             "description": "The identifier of the todoItem to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3243,7 +3303,9 @@
             "description": "The identifier of the todoItem to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3322,7 +3384,9 @@
             "description": "The identifier of the todoItem to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3423,7 +3487,9 @@
             "description": "The identifier of the todoItem to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3458,7 +3524,9 @@
             "description": "The identifier of the todoItem whose related person to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3551,7 +3619,9 @@
             "description": "The identifier of the todoItem whose related person to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3632,7 +3702,9 @@
             "description": "The identifier of the todoItem whose related person identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3725,7 +3797,9 @@
             "description": "The identifier of the todoItem whose related person identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3804,7 +3878,9 @@
             "description": "The identifier of the todoItem whose assignee relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3874,7 +3950,9 @@
             "description": "The identifier of the todoItem whose related person to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3967,7 +4045,9 @@
             "description": "The identifier of the todoItem whose related person to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4048,7 +4128,9 @@
             "description": "The identifier of the todoItem whose related person identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4141,7 +4223,9 @@
             "description": "The identifier of the todoItem whose related person identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4220,7 +4304,9 @@
             "description": "The identifier of the todoItem whose owner relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -4290,7 +4376,9 @@
             "description": "The identifier of the todoItem whose related tags to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4383,7 +4471,9 @@
             "description": "The identifier of the todoItem whose related tags to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4464,7 +4554,9 @@
             "description": "The identifier of the todoItem whose related tag identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4557,7 +4649,9 @@
             "description": "The identifier of the todoItem whose related tag identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4636,7 +4730,9 @@
             "description": "The identifier of the todoItem to add tags to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -4704,7 +4800,9 @@
             "description": "The identifier of the todoItem whose tags relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -4772,7 +4870,9 @@
             "description": "The identifier of the todoItem to remove tags from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -5439,7 +5539,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -5477,7 +5578,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -5515,7 +5617,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -5947,7 +6050,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -6036,7 +6140,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -6087,7 +6192,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -6112,7 +6218,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -6164,7 +6271,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -6731,7 +6839,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -6812,7 +6921,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -6837,7 +6947,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -6915,7 +7026,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -7079,7 +7191,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -7181,7 +7294,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -7262,7 +7376,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -7287,7 +7402,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -7308,7 +7424,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -7426,7 +7543,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,

--- a/src/JsonApiDotNetCore.OpenApi/SchemaGenerators/Components/ResourceIdSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi/SchemaGenerators/Components/ResourceIdSchemaGenerator.cs
@@ -1,0 +1,41 @@
+using JsonApiDotNetCore.Configuration;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace JsonApiDotNetCore.OpenApi.SchemaGenerators.Components;
+
+internal sealed class ResourceIdSchemaGenerator
+{
+    private readonly SchemaGenerator _defaultSchemaGenerator;
+
+    public ResourceIdSchemaGenerator(SchemaGenerator defaultSchemaGenerator)
+    {
+        ArgumentGuard.NotNull(defaultSchemaGenerator);
+
+        _defaultSchemaGenerator = defaultSchemaGenerator;
+    }
+
+    public OpenApiSchema GenerateSchema(ResourceType resourceType, SchemaRepository schemaRepository)
+    {
+        return GenerateSchema(resourceType.IdentityClrType, schemaRepository);
+    }
+
+    public OpenApiSchema GenerateSchema(Type resourceIdClrType, SchemaRepository schemaRepository)
+    {
+        ArgumentGuard.NotNull(resourceIdClrType);
+        ArgumentGuard.NotNull(schemaRepository);
+
+        OpenApiSchema idSchema = _defaultSchemaGenerator.GenerateSchema(resourceIdClrType, schemaRepository);
+        idSchema.Type = "string";
+
+        if (resourceIdClrType != typeof(string))
+        {
+            // When using string IDs, it's discouraged (but possible) to use an empty string as primary key value, because
+            // some things won't work: get-by-id, update and delete resource are impossible, and rendered links are unusable.
+            // For other ID types, provide the length constraint as a fallback in case the type hint isn't recognized.
+            idSchema.MinLength = 1;
+        }
+
+        return idSchema;
+    }
+}

--- a/src/JsonApiDotNetCore.OpenApi/SchemaGenerators/JsonApiSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi/SchemaGenerators/JsonApiSchemaGenerator.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using JsonApiDotNetCore.Controllers;
 using JsonApiDotNetCore.OpenApi.SchemaGenerators.Bodies;
+using JsonApiDotNetCore.OpenApi.SchemaGenerators.Components;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -9,17 +10,15 @@ namespace JsonApiDotNetCore.OpenApi.SchemaGenerators;
 
 internal sealed class JsonApiSchemaGenerator : ISchemaGenerator
 {
-    private static readonly OpenApiSchema IdTypeSchema = new()
-    {
-        Type = "string"
-    };
-
+    private readonly ResourceIdSchemaGenerator _resourceIdSchemaGenerator;
     private readonly ICollection<BodySchemaGenerator> _bodySchemaGenerators;
 
-    public JsonApiSchemaGenerator(IEnumerable<BodySchemaGenerator> bodySchemaGenerators)
+    public JsonApiSchemaGenerator(ResourceIdSchemaGenerator resourceIdSchemaGenerator, IEnumerable<BodySchemaGenerator> bodySchemaGenerators)
     {
+        ArgumentGuard.NotNull(resourceIdSchemaGenerator);
         ArgumentGuard.NotNull(bodySchemaGenerators);
 
+        _resourceIdSchemaGenerator = resourceIdSchemaGenerator;
         _bodySchemaGenerators = bodySchemaGenerators.ToArray();
     }
 
@@ -31,7 +30,7 @@ internal sealed class JsonApiSchemaGenerator : ISchemaGenerator
 
         if (parameterInfo is { Name: "id" } && IsJsonApiParameter(parameterInfo))
         {
-            return IdTypeSchema;
+            return _resourceIdSchemaGenerator.GenerateSchema(modelType, schemaRepository);
         }
 
         BodySchemaGenerator schemaGenerator = GetBodySchemaGenerator(modelType);

--- a/src/JsonApiDotNetCore.OpenApi/ServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore.OpenApi/ServiceCollectionExtensions.cs
@@ -95,6 +95,7 @@ public static class ServiceCollectionExtensions
 
         services.TryAddSingleton<AtomicOperationCodeSchemaGenerator>();
         services.TryAddSingleton<ResourceTypeSchemaGenerator>();
+        services.TryAddSingleton<ResourceIdSchemaGenerator>();
         services.TryAddSingleton<MetaSchemaGenerator>();
         services.TryAddSingleton<ResourceIdentifierSchemaGenerator>();
         services.TryAddSingleton<RelationshipIdentifierSchemaGenerator>();

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicCreateResourceTests.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicCreateResourceTests.cs
@@ -121,7 +121,7 @@ public sealed class AtomicCreateResourceTests : IClassFixture<IntegrationTestCon
                                 Data = new CourseIdentifierInRequest
                                 {
                                     Type = CourseResourceType.Courses,
-                                    Id = existingCourse.StringId!
+                                    Id = existingCourse.Id
                                 }
                             },
                             Student = new ToOneStudentInRequest
@@ -183,7 +183,7 @@ public sealed class AtomicCreateResourceTests : IClassFixture<IntegrationTestCon
                     Data = new DataInCreateCourseRequest
                     {
                         Type = CourseResourceType.Courses,
-                        Id = newCourse.StringId!,
+                        Id = newCourse.Id,
                         Attributes = new AttributesInCreateCourseRequest
                         {
                             Subject = newCourse.Subject

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicLocalIdTests.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicLocalIdTests.cs
@@ -72,7 +72,7 @@ public sealed class AtomicLocalIdTests : IClassFixture<IntegrationTestContext<Op
                     Data = new DataInCreateCourseRequest
                     {
                         Type = CourseResourceType.Courses,
-                        Id = newCourse.StringId!,
+                        Id = newCourse.Id,
                         Attributes = new AttributesInCreateCourseRequest
                         {
                             Subject = newCourse.Subject,
@@ -94,7 +94,7 @@ public sealed class AtomicLocalIdTests : IClassFixture<IntegrationTestContext<Op
                         new CourseIdentifierInRequest
                         {
                             Type = CourseResourceType.Courses,
-                            Id = newCourse.StringId!
+                            Id = newCourse.Id
                         }
                     ]
                 },
@@ -130,7 +130,7 @@ public sealed class AtomicLocalIdTests : IClassFixture<IntegrationTestContext<Op
                                 Data = new CourseIdentifierInRequest
                                 {
                                     Type = CourseResourceType.Courses,
-                                    Id = newCourse.StringId!
+                                    Id = newCourse.Id
                                 }
                             },
                             Student = new ToOneStudentInRequest

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicRelationshipTests.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicRelationshipTests.cs
@@ -123,12 +123,12 @@ public sealed class AtomicRelationshipTests : IClassFixture<IntegrationTestConte
                         new CourseIdentifierInRequest
                         {
                             Type = CourseResourceType.Courses,
-                            Id = existingCourses.ElementAt(0).StringId!
+                            Id = existingCourses.ElementAt(0).Id
                         },
                         new CourseIdentifierInRequest
                         {
                             Type = CourseResourceType.Courses,
-                            Id = existingCourses.ElementAt(1).StringId!
+                            Id = existingCourses.ElementAt(1).Id
                         }
                     ]
                 }
@@ -187,12 +187,12 @@ public sealed class AtomicRelationshipTests : IClassFixture<IntegrationTestConte
                         new CourseIdentifierInRequest
                         {
                             Type = CourseResourceType.Courses,
-                            Id = existingCourses.ElementAt(0).StringId!
+                            Id = existingCourses.ElementAt(0).Id
                         },
                         new CourseIdentifierInRequest
                         {
                             Type = CourseResourceType.Courses,
-                            Id = existingCourses.ElementAt(1).StringId!
+                            Id = existingCourses.ElementAt(1).Id
                         }
                     ]
                 }
@@ -250,12 +250,12 @@ public sealed class AtomicRelationshipTests : IClassFixture<IntegrationTestConte
                         new CourseIdentifierInRequest
                         {
                             Type = CourseResourceType.Courses,
-                            Id = existingTeacher.Teaches.ElementAt(0).StringId!
+                            Id = existingTeacher.Teaches.ElementAt(0).Id
                         },
                         new CourseIdentifierInRequest
                         {
                             Type = CourseResourceType.Courses,
-                            Id = existingTeacher.Teaches.ElementAt(2).StringId!
+                            Id = existingTeacher.Teaches.ElementAt(2).Id
                         }
                     ]
                 }

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicUpdateResourceTests.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicUpdateResourceTests.cs
@@ -203,7 +203,7 @@ public sealed class AtomicUpdateResourceTests : IClassFixture<IntegrationTestCon
                                 Data = new CourseIdentifierInRequest
                                 {
                                     Type = CourseResourceType.Courses,
-                                    Id = existingCourse.StringId!
+                                    Id = existingCourse.Id
                                 }
                             },
                             Student = new ToOneStudentInRequest

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Courses/CoursesRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Courses/CoursesRequestBuilder.cs
@@ -19,7 +19,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Courses
         /// <summary>Gets an item from the OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.courses.item collection</summary>
         /// <param name="position">The identifier of the course to retrieve.</param>
         /// <returns>A <see cref="OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Courses.Item.CoursesItemRequestBuilder"/></returns>
-        public OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Courses.Item.CoursesItemRequestBuilder this[string position]
+        public OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Courses.Item.CoursesItemRequestBuilder this[Guid position]
         {
             get
             {

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/CourseDataInResponse.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/CourseDataInResponse.cs
@@ -27,21 +27,11 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         }
 #endif
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The links property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -109,7 +99,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
             return new Dictionary<string, Action<IParseNode>>(base.GetFieldDeserializers())
             {
                 { "attributes", n => { Attributes = n.GetObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseAttributesInResponse>(OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseAttributesInResponse.CreateFromDiscriminatorValue); } },
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "links", n => { Links = n.GetObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.ResourceLinks>(OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.ResourceLinks.CreateFromDiscriminatorValue); } },
                 { "meta", n => { Meta = n.GetObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.Meta>(OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.Meta.CreateFromDiscriminatorValue); } },
                 { "relationships", n => { Relationships = n.GetObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseRelationshipsInResponse>(OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseRelationshipsInResponse.CreateFromDiscriminatorValue); } },
@@ -124,7 +114,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             base.Serialize(writer);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseAttributesInResponse>("attributes", Attributes);
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.ResourceLinks>("links", Links);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.Meta>("meta", Meta);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseRelationshipsInResponse>("relationships", Relationships);

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/CourseEnrollmentsRelationshipIdentifier.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/CourseEnrollmentsRelationshipIdentifier.cs
@@ -14,21 +14,11 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The lid property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -82,7 +72,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         {
             return new Dictionary<string, Action<IParseNode>>
             {
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "lid", n => { Lid = n.GetStringValue(); } },
                 { "relationship", n => { Relationship = n.GetEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseEnrollmentsRelationshipName>(); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType>(); } },
@@ -95,7 +85,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         public virtual void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteStringValue("lid", Lid);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseEnrollmentsRelationshipName>("relationship", Relationship);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType>("type", Type);

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/CourseIdentifierInRequest.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/CourseIdentifierInRequest.cs
@@ -14,21 +14,11 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The lid property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -76,7 +66,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         {
             return new Dictionary<string, Action<IParseNode>>
             {
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "lid", n => { Lid = n.GetStringValue(); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType>(); } },
             };
@@ -88,7 +78,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         public virtual void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteStringValue("lid", Lid);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType>("type", Type);
         }

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/CourseIdentifierInResponse.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/CourseIdentifierInResponse.cs
@@ -14,21 +14,11 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The type property</summary>
         public OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType? Type
         {
@@ -60,7 +50,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         {
             return new Dictionary<string, Action<IParseNode>>
             {
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType>(); } },
             };
         }
@@ -71,7 +61,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         public virtual void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType>("type", Type);
         }
     }

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/CourseTaughtByRelationshipIdentifier.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/CourseTaughtByRelationshipIdentifier.cs
@@ -14,21 +14,11 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The lid property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -82,7 +72,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         {
             return new Dictionary<string, Action<IParseNode>>
             {
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "lid", n => { Lid = n.GetStringValue(); } },
                 { "relationship", n => { Relationship = n.GetEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseTaughtByRelationshipName>(); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType>(); } },
@@ -95,7 +85,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         public virtual void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteStringValue("lid", Lid);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseTaughtByRelationshipName>("relationship", Relationship);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType>("type", Type);

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/DataInCreateCourseRequest.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/DataInCreateCourseRequest.cs
@@ -30,21 +30,11 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The relationships property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -93,7 +83,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
             return new Dictionary<string, Action<IParseNode>>
             {
                 { "attributes", n => { Attributes = n.GetObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.AttributesInCreateCourseRequest>(OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.AttributesInCreateCourseRequest.CreateFromDiscriminatorValue); } },
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "relationships", n => { Relationships = n.GetObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.RelationshipsInCreateCourseRequest>(OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.RelationshipsInCreateCourseRequest.CreateFromDiscriminatorValue); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType>(); } },
             };
@@ -106,7 +96,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.AttributesInCreateCourseRequest>("attributes", Attributes);
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.RelationshipsInCreateCourseRequest>("relationships", Relationships);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType>("type", Type);
         }

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/DataInUpdateCourseRequest.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Models/DataInUpdateCourseRequest.cs
@@ -30,21 +30,11 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The lid property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -109,7 +99,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
             return new Dictionary<string, Action<IParseNode>>
             {
                 { "attributes", n => { Attributes = n.GetObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.AttributesInUpdateCourseRequest>(OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.AttributesInUpdateCourseRequest.CreateFromDiscriminatorValue); } },
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "lid", n => { Lid = n.GetStringValue(); } },
                 { "relationships", n => { Relationships = n.GetObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.RelationshipsInUpdateCourseRequest>(OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.RelationshipsInUpdateCourseRequest.CreateFromDiscriminatorValue); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType>(); } },
@@ -123,7 +113,7 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.AttributesInUpdateCourseRequest>("attributes", Attributes);
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteStringValue("lid", Lid);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.RelationshipsInUpdateCourseRequest>("relationships", Relationships);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Models.CourseResourceType>("type", Type);

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/ClientIdGenerationModesTests.cs
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/ClientIdGenerationModesTests.cs
@@ -82,7 +82,7 @@ public sealed class ClientIdGenerationModesTests
             Data = new DataInCreatePlayerRequest
             {
                 Type = PlayerResourceType.Players,
-                Id = newPlayer.StringId,
+                Id = newPlayer.Id,
                 Attributes = new AttributesInCreatePlayerRequest
                 {
                     UserName = newPlayer.UserName
@@ -132,13 +132,12 @@ public sealed class ClientIdGenerationModesTests
         // Assert
         document.ShouldNotBeNull();
         document.Data.ShouldNotBeNull();
-        document.Data.Id.ShouldNotBeNullOrEmpty();
-
-        Guid newGameId = Guid.Parse(document.Data.Id);
+        document.Data.Id.ShouldNotBeNull();
+        document.Data.Id.Value.Should().NotBe(Guid.Empty);
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            Game gameInDatabase = await dbContext.Games.FirstWithIdAsync(newGameId);
+            Game gameInDatabase = await dbContext.Games.FirstWithIdAsync(document.Data.Id.Value);
 
             gameInDatabase.Title.Should().Be(newGame.Title);
             gameInDatabase.PurchasePrice.Should().Be(newGame.PurchasePrice);
@@ -160,7 +159,7 @@ public sealed class ClientIdGenerationModesTests
             Data = new DataInCreateGameRequest
             {
                 Type = GameResourceType.Games,
-                Id = newGame.StringId,
+                Id = newGame.Id,
                 Attributes = new AttributesInCreateGameRequest
                 {
                     Title = newGame.Title,
@@ -204,7 +203,7 @@ public sealed class ClientIdGenerationModesTests
             Data = new DataInCreateGameRequest
             {
                 Type = GameResourceType.Games,
-                Id = existingGame.StringId,
+                Id = existingGame.Id,
                 Attributes = new AttributesInCreateGameRequest
                 {
                     Title = existingGame.Title,

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/DataInCreateGameRequest.cs
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/DataInCreateGameRequest.cs
@@ -30,21 +30,11 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The type property</summary>
         public OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.GameResourceType? Type
         {
@@ -77,7 +67,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
             return new Dictionary<string, Action<IParseNode>>
             {
                 { "attributes", n => { Attributes = n.GetObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.AttributesInCreateGameRequest>(OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.AttributesInCreateGameRequest.CreateFromDiscriminatorValue); } },
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.GameResourceType>(); } },
             };
         }
@@ -89,7 +79,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.AttributesInCreateGameRequest>("attributes", Attributes);
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.GameResourceType>("type", Type);
         }
     }

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/DataInCreatePlayerRequest.cs
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/DataInCreatePlayerRequest.cs
@@ -30,21 +30,11 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The relationships property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -93,7 +83,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
             return new Dictionary<string, Action<IParseNode>>
             {
                 { "attributes", n => { Attributes = n.GetObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.AttributesInCreatePlayerRequest>(OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.AttributesInCreatePlayerRequest.CreateFromDiscriminatorValue); } },
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "relationships", n => { Relationships = n.GetObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.RelationshipsInCreatePlayerRequest>(OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.RelationshipsInCreatePlayerRequest.CreateFromDiscriminatorValue); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerResourceType>(); } },
             };
@@ -106,7 +96,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.AttributesInCreatePlayerRequest>("attributes", Attributes);
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.RelationshipsInCreatePlayerRequest>("relationships", Relationships);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerResourceType>("type", Type);
         }

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/GameDataInResponse.cs
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/GameDataInResponse.cs
@@ -27,21 +27,11 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         }
 #endif
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The links property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -93,7 +83,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
             return new Dictionary<string, Action<IParseNode>>(base.GetFieldDeserializers())
             {
                 { "attributes", n => { Attributes = n.GetObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.GameAttributesInResponse>(OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.GameAttributesInResponse.CreateFromDiscriminatorValue); } },
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "links", n => { Links = n.GetObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.ResourceLinks>(OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.ResourceLinks.CreateFromDiscriminatorValue); } },
                 { "meta", n => { Meta = n.GetObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.Meta>(OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.Meta.CreateFromDiscriminatorValue); } },
             };
@@ -107,7 +97,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             base.Serialize(writer);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.GameAttributesInResponse>("attributes", Attributes);
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.ResourceLinks>("links", Links);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.Meta>("meta", Meta);
         }

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/GameIdentifierInRequest.cs
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/GameIdentifierInRequest.cs
@@ -14,21 +14,11 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The type property</summary>
         public OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.GameResourceType? Type
         {
@@ -60,7 +50,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         {
             return new Dictionary<string, Action<IParseNode>>
             {
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.GameResourceType>(); } },
             };
         }
@@ -71,7 +61,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         public virtual void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.GameResourceType>("type", Type);
         }
     }

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/GameIdentifierInResponse.cs
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/GameIdentifierInResponse.cs
@@ -14,21 +14,11 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The type property</summary>
         public OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.GameResourceType? Type
         {
@@ -60,7 +50,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         {
             return new Dictionary<string, Action<IParseNode>>
             {
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.GameResourceType>(); } },
             };
         }
@@ -71,7 +61,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         public virtual void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.GameResourceType>("type", Type);
         }
     }

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/PlayerDataInResponse.cs
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/PlayerDataInResponse.cs
@@ -27,21 +27,11 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         }
 #endif
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The links property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -109,7 +99,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
             return new Dictionary<string, Action<IParseNode>>(base.GetFieldDeserializers())
             {
                 { "attributes", n => { Attributes = n.GetObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerAttributesInResponse>(OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerAttributesInResponse.CreateFromDiscriminatorValue); } },
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "links", n => { Links = n.GetObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.ResourceLinks>(OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.ResourceLinks.CreateFromDiscriminatorValue); } },
                 { "meta", n => { Meta = n.GetObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.Meta>(OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.Meta.CreateFromDiscriminatorValue); } },
                 { "relationships", n => { Relationships = n.GetObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerRelationshipsInResponse>(OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerRelationshipsInResponse.CreateFromDiscriminatorValue); } },
@@ -124,7 +114,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             base.Serialize(writer);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerAttributesInResponse>("attributes", Attributes);
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.ResourceLinks>("links", Links);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.Meta>("meta", Meta);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerRelationshipsInResponse>("relationships", Relationships);

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/PlayerIdentifierInRequest.cs
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/PlayerIdentifierInRequest.cs
@@ -14,21 +14,11 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The type property</summary>
         public OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerResourceType? Type
         {
@@ -60,7 +50,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         {
             return new Dictionary<string, Action<IParseNode>>
             {
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerResourceType>(); } },
             };
         }
@@ -71,7 +61,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         public virtual void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerResourceType>("type", Type);
         }
     }

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/PlayerIdentifierInResponse.cs
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Models/PlayerIdentifierInResponse.cs
@@ -14,21 +14,11 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The type property</summary>
         public OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerResourceType? Type
         {
@@ -60,7 +50,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         {
             return new Dictionary<string, Action<IParseNode>>
             {
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerResourceType>(); } },
             };
         }
@@ -71,7 +61,7 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models
         public virtual void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Models.PlayerResourceType>("type", Type);
         }
     }

--- a/test/OpenApiKiotaEndToEndTests/Headers/ETagTests.cs
+++ b/test/OpenApiKiotaEndToEndTests/Headers/ETagTests.cs
@@ -94,7 +94,7 @@ public sealed class ETagTests : IClassFixture<IntegrationTestContext<OpenApiStar
     public async Task Returns_no_ETag_for_failed_GET_request()
     {
         // Arrange
-        string unknownCountryId = Unknown.StringId.For<Country, Guid>();
+        Guid unknownCountryId = Unknown.TypedId.Guid;
 
         using HttpClientRequestAdapter requestAdapter = _requestAdapterFactory.CreateAdapter(_testContext.Factory);
         var apiClient = new HeadersClient(requestAdapter);

--- a/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Countries/CountriesRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Countries/CountriesRequestBuilder.cs
@@ -19,7 +19,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries
         /// <summary>Gets an item from the OpenApiKiotaEndToEndTests.Headers.GeneratedCode.countries.item collection</summary>
         /// <param name="position">The identifier of the country to retrieve.</param>
         /// <returns>A <see cref="OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries.Item.CountriesItemRequestBuilder"/></returns>
-        public OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries.Item.CountriesItemRequestBuilder this[string position]
+        public OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries.Item.CountriesItemRequestBuilder this[Guid position]
         {
             get
             {

--- a/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Models/CountryDataInResponse.cs
+++ b/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Models/CountryDataInResponse.cs
@@ -27,21 +27,11 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
         }
 #endif
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The links property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -109,7 +99,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
             return new Dictionary<string, Action<IParseNode>>(base.GetFieldDeserializers())
             {
                 { "attributes", n => { Attributes = n.GetObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.CountryAttributesInResponse>(OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.CountryAttributesInResponse.CreateFromDiscriminatorValue); } },
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "links", n => { Links = n.GetObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.ResourceLinks>(OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.ResourceLinks.CreateFromDiscriminatorValue); } },
                 { "meta", n => { Meta = n.GetObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.Meta>(OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.Meta.CreateFromDiscriminatorValue); } },
                 { "relationships", n => { Relationships = n.GetObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.CountryRelationshipsInResponse>(OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.CountryRelationshipsInResponse.CreateFromDiscriminatorValue); } },
@@ -124,7 +114,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             base.Serialize(writer);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.CountryAttributesInResponse>("attributes", Attributes);
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.ResourceLinks>("links", Links);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.Meta>("meta", Meta);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.CountryRelationshipsInResponse>("relationships", Relationships);

--- a/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Models/DataInUpdateCountryRequest.cs
+++ b/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Models/DataInUpdateCountryRequest.cs
@@ -30,21 +30,11 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The relationships property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -93,7 +83,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
             return new Dictionary<string, Action<IParseNode>>
             {
                 { "attributes", n => { Attributes = n.GetObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.AttributesInUpdateCountryRequest>(OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.AttributesInUpdateCountryRequest.CreateFromDiscriminatorValue); } },
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "relationships", n => { Relationships = n.GetObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.RelationshipsInUpdateCountryRequest>(OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.RelationshipsInUpdateCountryRequest.CreateFromDiscriminatorValue); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.CountryResourceType>(); } },
             };
@@ -106,7 +96,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.AttributesInUpdateCountryRequest>("attributes", Attributes);
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.RelationshipsInUpdateCountryRequest>("relationships", Relationships);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.CountryResourceType>("type", Type);
         }

--- a/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Models/LanguageDataInResponse.cs
+++ b/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Models/LanguageDataInResponse.cs
@@ -27,21 +27,11 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
         }
 #endif
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The links property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -93,7 +83,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
             return new Dictionary<string, Action<IParseNode>>(base.GetFieldDeserializers())
             {
                 { "attributes", n => { Attributes = n.GetObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.LanguageAttributesInResponse>(OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.LanguageAttributesInResponse.CreateFromDiscriminatorValue); } },
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "links", n => { Links = n.GetObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.ResourceLinks>(OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.ResourceLinks.CreateFromDiscriminatorValue); } },
                 { "meta", n => { Meta = n.GetObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.Meta>(OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.Meta.CreateFromDiscriminatorValue); } },
             };
@@ -107,7 +97,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             base.Serialize(writer);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.LanguageAttributesInResponse>("attributes", Attributes);
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.ResourceLinks>("links", Links);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.Meta>("meta", Meta);
         }

--- a/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Models/LanguageIdentifierInRequest.cs
+++ b/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Models/LanguageIdentifierInRequest.cs
@@ -14,21 +14,11 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The type property</summary>
         public OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.LanguageResourceType? Type
         {
@@ -60,7 +50,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
         {
             return new Dictionary<string, Action<IParseNode>>
             {
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.LanguageResourceType>(); } },
             };
         }
@@ -71,7 +61,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
         public virtual void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.LanguageResourceType>("type", Type);
         }
     }

--- a/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Models/LanguageIdentifierInResponse.cs
+++ b/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Models/LanguageIdentifierInResponse.cs
@@ -14,21 +14,11 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The type property</summary>
         public OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.LanguageResourceType? Type
         {
@@ -60,7 +50,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
         {
             return new Dictionary<string, Action<IParseNode>>
             {
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.LanguageResourceType>(); } },
             };
         }
@@ -71,7 +61,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models
         public virtual void Serialize(ISerializationWriter writer)
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Models.LanguageResourceType>("type", Type);
         }
     }

--- a/test/OpenApiKiotaEndToEndTests/Headers/HeaderTests.cs
+++ b/test/OpenApiKiotaEndToEndTests/Headers/HeaderTests.cs
@@ -117,7 +117,7 @@ public sealed class HeaderTests : IClassFixture<IntegrationTestContext<OpenApiSt
         };
 
         // Act
-        await apiClient.Countries[existingCountry.StringId].HeadAsync(configuration => configuration.Options.Add(headerInspector));
+        await apiClient.Countries[existingCountry.Id].HeadAsync(configuration => configuration.Options.Add(headerInspector));
 
         // Assert
         string[] contentLengthHeaderValues = headerInspector.ResponseHeaders.Should().ContainKey(HeaderNames.ContentLength).WhoseValue.ToArray();
@@ -147,7 +147,7 @@ public sealed class HeaderTests : IClassFixture<IntegrationTestContext<OpenApiSt
         };
 
         // Act
-        await apiClient.Countries[existingCountry.StringId].Languages.HeadAsync(configuration => configuration.Options.Add(headerInspector));
+        await apiClient.Countries[existingCountry.Id].Languages.HeadAsync(configuration => configuration.Options.Add(headerInspector));
 
         // Assert
         string[] contentLengthHeaderValues = headerInspector.ResponseHeaders.Should().ContainKey(HeaderNames.ContentLength).WhoseValue.ToArray();
@@ -177,7 +177,7 @@ public sealed class HeaderTests : IClassFixture<IntegrationTestContext<OpenApiSt
         };
 
         // Act
-        await apiClient.Countries[existingCountry.StringId].Relationships.Languages.HeadAsync(configuration => configuration.Options.Add(headerInspector));
+        await apiClient.Countries[existingCountry.Id].Relationships.Languages.HeadAsync(configuration => configuration.Options.Add(headerInspector));
 
         // Assert
         string[] contentLengthHeaderValues = headerInspector.ResponseHeaders.Should().ContainKey(HeaderNames.ContentLength).WhoseValue.ToArray();

--- a/test/OpenApiKiotaEndToEndTests/ModelStateValidation/GeneratedCode/Models/DataInUpdateSocialMediaAccountRequest.cs
+++ b/test/OpenApiKiotaEndToEndTests/ModelStateValidation/GeneratedCode/Models/DataInUpdateSocialMediaAccountRequest.cs
@@ -30,21 +30,11 @@ namespace OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models
         /// <summary>Stores model information.</summary>
         public IBackingStore BackingStore { get; private set; }
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The type property</summary>
         public OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.SocialMediaAccountResourceType? Type
         {
@@ -77,7 +67,7 @@ namespace OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models
             return new Dictionary<string, Action<IParseNode>>
             {
                 { "attributes", n => { Attributes = n.GetObjectValue<OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.AttributesInUpdateSocialMediaAccountRequest>(OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.AttributesInUpdateSocialMediaAccountRequest.CreateFromDiscriminatorValue); } },
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "type", n => { Type = n.GetEnumValue<OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.SocialMediaAccountResourceType>(); } },
             };
         }
@@ -89,7 +79,7 @@ namespace OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models
         {
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.AttributesInUpdateSocialMediaAccountRequest>("attributes", Attributes);
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteEnumValue<OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.SocialMediaAccountResourceType>("type", Type);
         }
     }

--- a/test/OpenApiKiotaEndToEndTests/ModelStateValidation/GeneratedCode/Models/SocialMediaAccountDataInResponse.cs
+++ b/test/OpenApiKiotaEndToEndTests/ModelStateValidation/GeneratedCode/Models/SocialMediaAccountDataInResponse.cs
@@ -27,21 +27,11 @@ namespace OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models
         }
 #endif
         /// <summary>The id property</summary>
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
-#nullable enable
-        public string? Id
+        public Guid? Id
         {
-            get { return BackingStore?.Get<string?>("id"); }
+            get { return BackingStore?.Get<Guid?>("id"); }
             set { BackingStore?.Set("id", value); }
         }
-#nullable restore
-#else
-        public string Id
-        {
-            get { return BackingStore?.Get<string>("id"); }
-            set { BackingStore?.Set("id", value); }
-        }
-#endif
         /// <summary>The links property</summary>
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 #nullable enable
@@ -93,7 +83,7 @@ namespace OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models
             return new Dictionary<string, Action<IParseNode>>(base.GetFieldDeserializers())
             {
                 { "attributes", n => { Attributes = n.GetObjectValue<OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.SocialMediaAccountAttributesInResponse>(OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.SocialMediaAccountAttributesInResponse.CreateFromDiscriminatorValue); } },
-                { "id", n => { Id = n.GetStringValue(); } },
+                { "id", n => { Id = n.GetGuidValue(); } },
                 { "links", n => { Links = n.GetObjectValue<OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.ResourceLinks>(OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.ResourceLinks.CreateFromDiscriminatorValue); } },
                 { "meta", n => { Meta = n.GetObjectValue<OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.Meta>(OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.Meta.CreateFromDiscriminatorValue); } },
             };
@@ -107,7 +97,7 @@ namespace OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models
             _ = writer ?? throw new ArgumentNullException(nameof(writer));
             base.Serialize(writer);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.SocialMediaAccountAttributesInResponse>("attributes", Attributes);
-            writer.WriteStringValue("id", Id);
+            writer.WriteGuidValue("id", Id);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.ResourceLinks>("links", Links);
             writer.WriteObjectValue<OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.Models.Meta>("meta", Meta);
         }

--- a/test/OpenApiKiotaEndToEndTests/ModelStateValidation/GeneratedCode/SocialMediaAccounts/SocialMediaAccountsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ModelStateValidation/GeneratedCode/SocialMediaAccounts/SocialMediaAccountsRequestBuilder.cs
@@ -19,7 +19,7 @@ namespace OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.SocialMed
         /// <summary>Gets an item from the OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.socialMediaAccounts.item collection</summary>
         /// <param name="position">The identifier of the socialMediaAccount to update.</param>
         /// <returns>A <see cref="OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.SocialMediaAccounts.Item.SocialMediaAccountsItemRequestBuilder"/></returns>
-        public OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.SocialMediaAccounts.Item.SocialMediaAccountsItemRequestBuilder this[string position]
+        public OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.SocialMediaAccounts.Item.SocialMediaAccountsItemRequestBuilder this[Guid position]
         {
             get
             {

--- a/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicCreateResourceTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicCreateResourceTests.cs
@@ -115,7 +115,7 @@ public sealed class AtomicCreateResourceTests : IClassFixture<IntegrationTestCon
                             {
                                 Data = new CourseIdentifierInRequest
                                 {
-                                    Id = existingCourse.StringId!
+                                    Id = existingCourse.Id
                                 }
                             },
                             Student = new ToOneStudentInRequest
@@ -174,7 +174,7 @@ public sealed class AtomicCreateResourceTests : IClassFixture<IntegrationTestCon
                 {
                     Data = new DataInCreateCourseRequest
                     {
-                        Id = newCourse.StringId!,
+                        Id = newCourse.Id,
                         Attributes = new AttributesInCreateCourseRequest
                         {
                             Subject = newCourse.Subject

--- a/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicLocalIdTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicLocalIdTests.cs
@@ -66,7 +66,7 @@ public sealed class AtomicLocalIdTests : IClassFixture<IntegrationTestContext<Op
                 {
                     Data = new DataInCreateCourseRequest
                     {
-                        Id = newCourse.StringId!,
+                        Id = newCourse.Id,
                         Attributes = new AttributesInCreateCourseRequest
                         {
                             Subject = newCourse.Subject,
@@ -84,7 +84,7 @@ public sealed class AtomicLocalIdTests : IClassFixture<IntegrationTestContext<Op
                     [
                         new CourseIdentifierInRequest
                         {
-                            Id = newCourse.StringId!
+                            Id = newCourse.Id
                         }
                     ]
                 },
@@ -115,7 +115,7 @@ public sealed class AtomicLocalIdTests : IClassFixture<IntegrationTestContext<Op
                             {
                                 Data = new CourseIdentifierInRequest
                                 {
-                                    Id = newCourse.StringId!
+                                    Id = newCourse.Id
                                 }
                             },
                             Student = new ToOneStudentInRequest

--- a/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicRelationshipTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicRelationshipTests.cs
@@ -114,11 +114,11 @@ public sealed class AtomicRelationshipTests : IClassFixture<IntegrationTestConte
                     [
                         new CourseIdentifierInRequest
                         {
-                            Id = existingCourses.ElementAt(0).StringId!
+                            Id = existingCourses.ElementAt(0).Id
                         },
                         new CourseIdentifierInRequest
                         {
-                            Id = existingCourses.ElementAt(1).StringId!
+                            Id = existingCourses.ElementAt(1).Id
                         }
                     ]
                 }
@@ -173,11 +173,11 @@ public sealed class AtomicRelationshipTests : IClassFixture<IntegrationTestConte
                     [
                         new CourseIdentifierInRequest
                         {
-                            Id = existingCourses.ElementAt(0).StringId!
+                            Id = existingCourses.ElementAt(0).Id
                         },
                         new CourseIdentifierInRequest
                         {
-                            Id = existingCourses.ElementAt(1).StringId!
+                            Id = existingCourses.ElementAt(1).Id
                         }
                     ]
                 }
@@ -231,11 +231,11 @@ public sealed class AtomicRelationshipTests : IClassFixture<IntegrationTestConte
                     [
                         new CourseIdentifierInRequest
                         {
-                            Id = existingTeacher.Teaches.ElementAt(0).StringId!
+                            Id = existingTeacher.Teaches.ElementAt(0).Id
                         },
                         new CourseIdentifierInRequest
                         {
-                            Id = existingTeacher.Teaches.ElementAt(2).StringId!
+                            Id = existingTeacher.Teaches.ElementAt(2).Id
                         }
                     ]
                 }

--- a/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicUpdateResourceTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicUpdateResourceTests.cs
@@ -193,7 +193,7 @@ public sealed class AtomicUpdateResourceTests : IClassFixture<IntegrationTestCon
                             {
                                 Data = new CourseIdentifierInRequest
                                 {
-                                    Id = existingCourse.StringId!
+                                    Id = existingCourse.Id
                                 }
                             },
                             Student = new ToOneStudentInRequest

--- a/test/OpenApiNSwagEndToEndTests/Headers/ETagTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/Headers/ETagTests.cs
@@ -86,7 +86,7 @@ public sealed class ETagTests : IClassFixture<IntegrationTestContext<OpenApiStar
     public async Task Returns_no_ETag_for_failed_GET_request()
     {
         // Arrange
-        string unknownCountryId = Unknown.StringId.For<Country, Guid>();
+        Guid unknownCountryId = Unknown.TypedId.Guid;
 
         using HttpClient httpClient = _testContext.Factory.CreateDefaultClient(_logHttpMessageHandler);
         var apiClient = new HeadersClient(httpClient);

--- a/test/OpenApiNSwagEndToEndTests/Headers/HeaderTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/Headers/HeaderTests.cs
@@ -103,7 +103,7 @@ public sealed class HeaderTests : IClassFixture<IntegrationTestContext<OpenApiSt
         var apiClient = new HeadersClient(httpClient);
 
         // Act
-        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryAsync(existingCountry.StringId!, null, null));
+        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryAsync(existingCountry.Id, null, null));
 
         // Assert
         response.StatusCode.Should().Be((int)HttpStatusCode.OK);
@@ -130,7 +130,7 @@ public sealed class HeaderTests : IClassFixture<IntegrationTestContext<OpenApiSt
         var apiClient = new HeadersClient(httpClient);
 
         // Act
-        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryLanguagesAsync(existingCountry.StringId!, null, null));
+        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryLanguagesAsync(existingCountry.Id, null, null));
 
         // Assert
         response.StatusCode.Should().Be((int)HttpStatusCode.OK);
@@ -158,7 +158,7 @@ public sealed class HeaderTests : IClassFixture<IntegrationTestContext<OpenApiSt
 
         // Act
         ApiResponse response =
-            await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryLanguagesRelationshipAsync(existingCountry.StringId!, null, null));
+            await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryLanguagesRelationshipAsync(existingCountry.Id, null, null));
 
         // Assert
         response.StatusCode.Should().Be((int)HttpStatusCode.OK);

--- a/test/OpenApiNSwagEndToEndTests/OpenApiNSwagEndToEndTests.csproj
+++ b/test/OpenApiNSwagEndToEndTests/OpenApiNSwagEndToEndTests.csproj
@@ -28,14 +28,14 @@
       <ClassName>ClientIdGenerationModesClient</ClassName>
       <OutputPath>ClientIdGenerationModesClient.cs</OutputPath>
       <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true</Options>
+      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true /GenerateOptionalPropertiesAsNullable:true /GenerateOptionalParameters:true</Options>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\ModelStateValidation\GeneratedSwagger\$(TargetFramework)\swagger.g.json">
       <Namespace>OpenApiNSwagEndToEndTests.ModelStateValidation.GeneratedCode</Namespace>
       <ClassName>ModelStateValidationClient</ClassName>
       <OutputPath>ModelStateValidationClient.cs</OutputPath>
       <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true /GenerateOptionalParameters:true</Options>
+      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true /GenerateOptionalPropertiesAsNullable:true /GenerateOptionalParameters:true</Options>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\Headers\GeneratedSwagger\swagger.g.json">
       <Namespace>OpenApiNSwagEndToEndTests.Headers.GeneratedCode</Namespace>

--- a/test/OpenApiTests/AtomicOperations/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/AtomicOperations/GeneratedSwagger/swagger.g.json
@@ -269,7 +269,9 @@
             "description": "The identifier of the course to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -362,7 +364,9 @@
             "description": "The identifier of the course to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -441,7 +445,9 @@
             "description": "The identifier of the course to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -542,7 +548,9 @@
             "description": "The identifier of the course to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -577,7 +585,9 @@
             "description": "The identifier of the course whose related enrollments to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -670,7 +680,9 @@
             "description": "The identifier of the course whose related enrollments to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -751,7 +763,9 @@
             "description": "The identifier of the course whose related enrollment identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -844,7 +858,9 @@
             "description": "The identifier of the course whose related enrollment identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -923,7 +939,9 @@
             "description": "The identifier of the course to add enrollments to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -991,7 +1009,9 @@
             "description": "The identifier of the course whose enrollments relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1061,7 +1081,9 @@
             "description": "The identifier of the course whose related teachers to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1154,7 +1176,9 @@
             "description": "The identifier of the course whose related teachers to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1235,7 +1259,9 @@
             "description": "The identifier of the course whose related teacher identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1328,7 +1354,9 @@
             "description": "The identifier of the course whose related teacher identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -1407,7 +1435,9 @@
             "description": "The identifier of the course to add teachers to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1475,7 +1505,9 @@
             "description": "The identifier of the course whose taughtBy relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1800,7 +1832,9 @@
             "description": "The identifier of the enrollment to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1893,7 +1927,9 @@
             "description": "The identifier of the enrollment to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1972,7 +2008,9 @@
             "description": "The identifier of the enrollment to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2073,7 +2111,9 @@
             "description": "The identifier of the enrollment to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2108,7 +2148,9 @@
             "description": "The identifier of the enrollment whose related course to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2201,7 +2243,9 @@
             "description": "The identifier of the enrollment whose related course to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2282,7 +2326,9 @@
             "description": "The identifier of the enrollment whose related course identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2375,7 +2421,9 @@
             "description": "The identifier of the enrollment whose related course identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2454,7 +2502,9 @@
             "description": "The identifier of the enrollment whose course relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2524,7 +2574,9 @@
             "description": "The identifier of the enrollment whose related student to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2617,7 +2669,9 @@
             "description": "The identifier of the enrollment whose related student to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2698,7 +2752,9 @@
             "description": "The identifier of the enrollment whose related student identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2791,7 +2847,9 @@
             "description": "The identifier of the enrollment whose related student identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2870,7 +2928,9 @@
             "description": "The identifier of the enrollment whose student relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3284,7 +3344,9 @@
             "description": "The identifier of the student to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3377,7 +3439,9 @@
             "description": "The identifier of the student to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3456,7 +3520,9 @@
             "description": "The identifier of the student to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3559,7 +3625,9 @@
             "description": "The identifier of the student whose related enrollments to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3652,7 +3720,9 @@
             "description": "The identifier of the student whose related enrollments to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3733,7 +3803,9 @@
             "description": "The identifier of the student whose related enrollment identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3826,7 +3898,9 @@
             "description": "The identifier of the student whose related enrollment identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3905,7 +3979,9 @@
             "description": "The identifier of the student to add enrollments to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3973,7 +4049,9 @@
             "description": "The identifier of the student whose enrollments relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -4041,7 +4119,9 @@
             "description": "The identifier of the student to remove enrollments from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -4111,7 +4191,9 @@
             "description": "The identifier of the student whose related teacher to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4204,7 +4286,9 @@
             "description": "The identifier of the student whose related teacher to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4285,7 +4369,9 @@
             "description": "The identifier of the student whose related teacher identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4378,7 +4464,9 @@
             "description": "The identifier of the student whose related teacher identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4457,7 +4545,9 @@
             "description": "The identifier of the student whose mentor relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -4782,7 +4872,9 @@
             "description": "The identifier of the teacher to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4875,7 +4967,9 @@
             "description": "The identifier of the teacher to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -4954,7 +5048,9 @@
             "description": "The identifier of the teacher to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -5055,7 +5151,9 @@
             "description": "The identifier of the teacher to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -5090,7 +5188,9 @@
             "description": "The identifier of the teacher whose related students to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -5183,7 +5283,9 @@
             "description": "The identifier of the teacher whose related students to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -5264,7 +5366,9 @@
             "description": "The identifier of the teacher whose related student identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -5357,7 +5461,9 @@
             "description": "The identifier of the teacher whose related student identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -5436,7 +5542,9 @@
             "description": "The identifier of the teacher to add students to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -5504,7 +5612,9 @@
             "description": "The identifier of the teacher whose mentors relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -5572,7 +5682,9 @@
             "description": "The identifier of the teacher to remove students from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -5642,7 +5754,9 @@
             "description": "The identifier of the teacher whose related courses to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -5735,7 +5849,9 @@
             "description": "The identifier of the teacher whose related courses to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -5816,7 +5932,9 @@
             "description": "The identifier of the teacher whose related course identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -5909,7 +6027,9 @@
             "description": "The identifier of the teacher whose related course identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -5988,7 +6108,9 @@
             "description": "The identifier of the teacher to add courses to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -6056,7 +6178,9 @@
             "description": "The identifier of the teacher whose teaches relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -6124,7 +6248,9 @@
             "description": "The identifier of the teacher to remove courses from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -6638,7 +6764,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "uuid"
               },
               "attributes": {
                 "allOf": [
@@ -6690,7 +6817,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           },
           "lid": {
             "minLength": 1,
@@ -6765,7 +6893,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           },
           "lid": {
             "minLength": 1,
@@ -6790,7 +6919,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -6964,7 +7094,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           },
           "lid": {
             "minLength": 1,
@@ -7195,7 +7326,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           },
           "attributes": {
             "allOf": [
@@ -7354,7 +7486,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           },
           "lid": {
             "minLength": 1,
@@ -7392,7 +7525,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -7430,7 +7564,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -7468,7 +7603,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -7665,7 +7801,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -7701,7 +7838,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -7789,7 +7927,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -7814,7 +7953,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -7906,7 +8046,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -8737,7 +8878,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -8789,7 +8931,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -8864,7 +9007,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -8889,7 +9033,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -8948,7 +9093,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -9155,7 +9301,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -9243,7 +9390,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -9268,7 +9416,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -9289,7 +9438,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,
@@ -9399,7 +9549,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "lid": {
             "minLength": 1,

--- a/test/OpenApiTests/AtomicOperations/OperationsTests.cs
+++ b/test/OpenApiTests/AtomicOperations/OperationsTests.cs
@@ -370,7 +370,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "uuid"
                     },
                     "attributes": {
                       "allOf": [
@@ -491,7 +492,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "uuid"
                     },
                     "lid": {
                       "minLength": 1,
@@ -696,7 +698,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "uuid"
                     },
                     "lid": {
                       "minLength": 1,
@@ -724,7 +727,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "uuid"
                     },
                     "lid": {
                       "minLength": 1,
@@ -934,7 +938,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "int64"
                     },
                     "lid": {
                       "minLength": 1,
@@ -1188,7 +1193,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "int64"
                     },
                     "lid": {
                       "minLength": 1,
@@ -1216,7 +1222,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "int64"
                     },
                     "lid": {
                       "minLength": 1,
@@ -1261,7 +1268,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "int64"
                     },
                     "lid": {
                       "minLength": 1,
@@ -1471,7 +1479,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "int64"
                     },
                     "lid": {
                       "minLength": 1,
@@ -1714,7 +1723,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "int64"
                     },
                     "lid": {
                       "minLength": 1,
@@ -1742,7 +1752,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "int64"
                     },
                     "lid": {
                       "minLength": 1,
@@ -1955,7 +1966,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "int64"
                     },
                     "lid": {
                       "minLength": 1,
@@ -2117,7 +2129,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "int64"
                     },
                     "lid": {
                       "minLength": 1,
@@ -2145,7 +2158,8 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                     },
                     "id": {
                       "minLength": 1,
-                      "type": "string"
+                      "type": "string",
+                      "format": "int64"
                     },
                     "lid": {
                       "minLength": 1,

--- a/test/OpenApiTests/ClientIdGenerationModes/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ClientIdGenerationModes/GeneratedSwagger/swagger.g.json
@@ -438,7 +438,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           },
           "attributes": {
             "allOf": [
@@ -496,7 +497,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           },
           "attributes": {
             "allOf": [
@@ -685,7 +687,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "uuid"
               },
               "attributes": {
                 "allOf": [
@@ -730,7 +733,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -751,7 +755,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -828,7 +833,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "uuid"
               },
               "attributes": {
                 "allOf": [
@@ -886,7 +892,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -938,7 +945,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -959,7 +967,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -1037,7 +1046,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -1058,7 +1068,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false

--- a/test/OpenApiTests/Headers/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/Headers/GeneratedSwagger/swagger.g.json
@@ -279,7 +279,9 @@
             "description": "The identifier of the country to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -372,7 +374,9 @@
             "description": "The identifier of the country to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -451,7 +455,9 @@
             "description": "The identifier of the country to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -552,7 +558,9 @@
             "description": "The identifier of the country to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -587,7 +595,9 @@
             "description": "The identifier of the country whose related languages to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -680,7 +690,9 @@
             "description": "The identifier of the country whose related languages to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -761,7 +773,9 @@
             "description": "The identifier of the country whose related language identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -854,7 +868,9 @@
             "description": "The identifier of the country whose related language identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -933,7 +949,9 @@
             "description": "The identifier of the country to add languages to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1001,7 +1019,9 @@
             "description": "The identifier of the country whose languages relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1069,7 +1089,9 @@
             "description": "The identifier of the country to remove languages from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1219,7 +1241,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "uuid"
               },
               "attributes": {
                 "allOf": [
@@ -1395,7 +1418,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           },
           "attributes": {
             "allOf": [
@@ -1597,7 +1621,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "uuid"
               },
               "attributes": {
                 "allOf": [
@@ -1672,7 +1697,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false
@@ -1693,7 +1719,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           }
         },
         "additionalProperties": false

--- a/test/OpenApiTests/LegacyOpenApi/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/LegacyOpenApi/GeneratedSwagger/swagger.g.json
@@ -5975,7 +5975,6 @@
             "type": "object",
             "properties": {
               "id": {
-                "minLength": 1,
                 "type": "string"
               },
               "attributes": {
@@ -6440,7 +6439,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           },
           "attributes": {
@@ -6475,7 +6473,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           },
           "attributes": {
@@ -6510,7 +6507,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           },
           "attributes": {
@@ -6545,7 +6541,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           },
           "attributes": {
@@ -6767,7 +6762,6 @@
             "type": "object",
             "properties": {
               "id": {
-                "minLength": 1,
                 "type": "string"
               },
               "attributes": {
@@ -6856,7 +6850,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           }
         },
@@ -6877,7 +6870,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           }
         },
@@ -7129,7 +7121,6 @@
             "type": "object",
             "properties": {
               "id": {
-                "minLength": 1,
                 "type": "string"
               },
               "attributes": {
@@ -7218,7 +7209,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           }
         },
@@ -7239,7 +7229,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           }
         },
@@ -7565,7 +7554,6 @@
             "type": "object",
             "properties": {
               "id": {
-                "minLength": 1,
                 "type": "string"
               },
               "attributes": {
@@ -7647,7 +7635,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           }
         },
@@ -7668,7 +7655,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           }
         },

--- a/test/OpenApiTests/LegacyOpenApi/expected-swagger.json
+++ b/test/OpenApiTests/LegacyOpenApi/expected-swagger.json
@@ -5975,7 +5975,6 @@
             "type": "object",
             "properties": {
               "id": {
-                "minLength": 1,
                 "type": "string"
               },
               "attributes": {
@@ -6440,7 +6439,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           },
           "attributes": {
@@ -6475,7 +6473,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           },
           "attributes": {
@@ -6510,7 +6507,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           },
           "attributes": {
@@ -6545,7 +6541,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           },
           "attributes": {
@@ -6767,7 +6762,6 @@
             "type": "object",
             "properties": {
               "id": {
-                "minLength": 1,
                 "type": "string"
               },
               "attributes": {
@@ -6856,7 +6850,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           }
         },
@@ -6877,7 +6870,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           }
         },
@@ -7129,7 +7121,6 @@
             "type": "object",
             "properties": {
               "id": {
-                "minLength": 1,
                 "type": "string"
               },
               "attributes": {
@@ -7218,7 +7209,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           }
         },
@@ -7239,7 +7229,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           }
         },
@@ -7565,7 +7554,6 @@
             "type": "object",
             "properties": {
               "id": {
-                "minLength": 1,
                 "type": "string"
               },
               "attributes": {
@@ -7647,7 +7635,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           }
         },
@@ -7668,7 +7655,6 @@
             ]
           },
           "id": {
-            "minLength": 1,
             "type": "string"
           }
         },

--- a/test/OpenApiTests/Links/Enabled/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/Links/Enabled/GeneratedSwagger/swagger.g.json
@@ -279,7 +279,9 @@
             "description": "The identifier of the accommodation to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -372,7 +374,9 @@
             "description": "The identifier of the accommodation to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -451,7 +455,9 @@
             "description": "The identifier of the accommodation to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -552,7 +558,9 @@
             "description": "The identifier of the accommodation to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -842,7 +850,9 @@
             "description": "The identifier of the excursion to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -935,7 +945,9 @@
             "description": "The identifier of the excursion to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1014,7 +1026,9 @@
             "description": "The identifier of the excursion to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1115,7 +1129,9 @@
             "description": "The identifier of the excursion to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -1405,7 +1421,9 @@
             "description": "The identifier of the transport to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1498,7 +1516,9 @@
             "description": "The identifier of the transport to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1577,7 +1597,9 @@
             "description": "The identifier of the transport to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1678,7 +1700,9 @@
             "description": "The identifier of the transport to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -1968,7 +1992,9 @@
             "description": "The identifier of the vacation to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2061,7 +2087,9 @@
             "description": "The identifier of the vacation to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2140,7 +2168,9 @@
             "description": "The identifier of the vacation to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2241,7 +2271,9 @@
             "description": "The identifier of the vacation to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2276,7 +2308,9 @@
             "description": "The identifier of the vacation whose related accommodation to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2369,7 +2403,9 @@
             "description": "The identifier of the vacation whose related accommodation to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2450,7 +2486,9 @@
             "description": "The identifier of the vacation whose related accommodation identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2543,7 +2581,9 @@
             "description": "The identifier of the vacation whose related accommodation identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2622,7 +2662,9 @@
             "description": "The identifier of the vacation whose accommodation relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2692,7 +2734,9 @@
             "description": "The identifier of the vacation whose related excursions to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2785,7 +2829,9 @@
             "description": "The identifier of the vacation whose related excursions to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2866,7 +2912,9 @@
             "description": "The identifier of the vacation whose related excursion identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2959,7 +3007,9 @@
             "description": "The identifier of the vacation whose related excursion identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3038,7 +3088,9 @@
             "description": "The identifier of the vacation to add excursions to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3106,7 +3158,9 @@
             "description": "The identifier of the vacation whose excursions relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3174,7 +3228,9 @@
             "description": "The identifier of the vacation to remove excursions from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3244,7 +3300,9 @@
             "description": "The identifier of the vacation whose related transport to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3337,7 +3395,9 @@
             "description": "The identifier of the vacation whose related transport to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3418,7 +3478,9 @@
             "description": "The identifier of the vacation whose related transport identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3511,7 +3573,9 @@
             "description": "The identifier of the vacation whose related transport identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3590,7 +3654,9 @@
             "description": "The identifier of the vacation whose transport relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3707,7 +3773,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -3752,7 +3819,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -3773,7 +3841,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -4213,7 +4282,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "attributes": {
             "allOf": [
@@ -4241,7 +4311,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "attributes": {
             "allOf": [
@@ -4269,7 +4340,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "attributes": {
             "allOf": [
@@ -4297,7 +4369,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "attributes": {
             "allOf": [
@@ -4500,7 +4573,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -4575,7 +4649,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -4596,7 +4671,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -5072,7 +5148,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -5117,7 +5194,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -5138,7 +5216,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -5324,7 +5403,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [

--- a/test/OpenApiTests/ModelStateValidation/GeneratedSwagger/net6.0/swagger.g.json
+++ b/test/OpenApiTests/ModelStateValidation/GeneratedSwagger/net6.0/swagger.g.json
@@ -138,7 +138,9 @@
             "description": "The identifier of the socialMediaAccount to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -500,7 +502,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           },
           "attributes": {
             "allOf": [
@@ -770,7 +773,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "uuid"
               },
               "attributes": {
                 "allOf": [

--- a/test/OpenApiTests/ModelStateValidation/GeneratedSwagger/net8.0/swagger.g.json
+++ b/test/OpenApiTests/ModelStateValidation/GeneratedSwagger/net8.0/swagger.g.json
@@ -138,7 +138,9 @@
             "description": "The identifier of the socialMediaAccount to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "uuid"
             }
           },
           {
@@ -518,7 +520,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "uuid"
           },
           "attributes": {
             "allOf": [
@@ -797,7 +800,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "uuid"
               },
               "attributes": {
                 "allOf": [

--- a/test/OpenApiTests/NamingConventions/CamelCase/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/NamingConventions/CamelCase/GeneratedSwagger/swagger.g.json
@@ -368,7 +368,9 @@
             "description": "The identifier of the staffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -461,7 +463,9 @@
             "description": "The identifier of the staffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -540,7 +544,9 @@
             "description": "The identifier of the staffMember to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -641,7 +647,9 @@
             "description": "The identifier of the staffMember to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -931,7 +939,9 @@
             "description": "The identifier of the supermarket to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1024,7 +1034,9 @@
             "description": "The identifier of the supermarket to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1103,7 +1115,9 @@
             "description": "The identifier of the supermarket to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1204,7 +1218,9 @@
             "description": "The identifier of the supermarket to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1239,7 +1255,9 @@
             "description": "The identifier of the supermarket whose related staffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1332,7 +1350,9 @@
             "description": "The identifier of the supermarket whose related staffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1413,7 +1433,9 @@
             "description": "The identifier of the supermarket whose related staffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1506,7 +1528,9 @@
             "description": "The identifier of the supermarket whose related staffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1585,7 +1609,9 @@
             "description": "The identifier of the supermarket whose backupStoreManager relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1655,7 +1681,9 @@
             "description": "The identifier of the supermarket whose related staffMembers to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1748,7 +1776,9 @@
             "description": "The identifier of the supermarket whose related staffMembers to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1829,7 +1859,9 @@
             "description": "The identifier of the supermarket whose related staffMember identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1922,7 +1954,9 @@
             "description": "The identifier of the supermarket whose related staffMember identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2001,7 +2035,9 @@
             "description": "The identifier of the supermarket to add staffMembers to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2069,7 +2105,9 @@
             "description": "The identifier of the supermarket whose cashiers relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2137,7 +2175,9 @@
             "description": "The identifier of the supermarket to remove staffMembers from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2207,7 +2247,9 @@
             "description": "The identifier of the supermarket whose related staffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2300,7 +2342,9 @@
             "description": "The identifier of the supermarket whose related staffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2381,7 +2425,9 @@
             "description": "The identifier of the supermarket whose related staffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2474,7 +2520,9 @@
             "description": "The identifier of the supermarket whose related staffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2553,7 +2601,9 @@
             "description": "The identifier of the supermarket whose storeManager relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2967,7 +3017,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -2998,7 +3049,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -3708,7 +3760,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "attributes": {
                 "allOf": [
@@ -3789,7 +3842,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -3814,7 +3868,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -3984,7 +4039,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -4023,7 +4079,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -4102,7 +4159,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "attributes": {
                 "allOf": [
@@ -4153,7 +4211,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -4256,7 +4315,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,

--- a/test/OpenApiTests/NamingConventions/KebabCase/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/NamingConventions/KebabCase/GeneratedSwagger/swagger.g.json
@@ -368,7 +368,9 @@
             "description": "The identifier of the staff-member to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -461,7 +463,9 @@
             "description": "The identifier of the staff-member to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -540,7 +544,9 @@
             "description": "The identifier of the staff-member to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -641,7 +647,9 @@
             "description": "The identifier of the staff-member to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -931,7 +939,9 @@
             "description": "The identifier of the supermarket to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1024,7 +1034,9 @@
             "description": "The identifier of the supermarket to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1103,7 +1115,9 @@
             "description": "The identifier of the supermarket to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1204,7 +1218,9 @@
             "description": "The identifier of the supermarket to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1239,7 +1255,9 @@
             "description": "The identifier of the supermarket whose related staff-member to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1332,7 +1350,9 @@
             "description": "The identifier of the supermarket whose related staff-member to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1413,7 +1433,9 @@
             "description": "The identifier of the supermarket whose related staff-member identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1506,7 +1528,9 @@
             "description": "The identifier of the supermarket whose related staff-member identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1585,7 +1609,9 @@
             "description": "The identifier of the supermarket whose backup-store-manager relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1655,7 +1681,9 @@
             "description": "The identifier of the supermarket whose related staff-members to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1748,7 +1776,9 @@
             "description": "The identifier of the supermarket whose related staff-members to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1829,7 +1859,9 @@
             "description": "The identifier of the supermarket whose related staff-member identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1922,7 +1954,9 @@
             "description": "The identifier of the supermarket whose related staff-member identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2001,7 +2035,9 @@
             "description": "The identifier of the supermarket to add staff-members to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2069,7 +2105,9 @@
             "description": "The identifier of the supermarket whose cashiers relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2137,7 +2175,9 @@
             "description": "The identifier of the supermarket to remove staff-members from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2207,7 +2247,9 @@
             "description": "The identifier of the supermarket whose related staff-member to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2300,7 +2342,9 @@
             "description": "The identifier of the supermarket whose related staff-member to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2381,7 +2425,9 @@
             "description": "The identifier of the supermarket whose related staff-member identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2474,7 +2520,9 @@
             "description": "The identifier of the supermarket whose related staff-member identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2553,7 +2601,9 @@
             "description": "The identifier of the supermarket whose store-manager relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2967,7 +3017,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -2998,7 +3049,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -3708,7 +3760,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "attributes": {
                 "allOf": [
@@ -3789,7 +3842,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -3814,7 +3868,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -3984,7 +4039,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -4023,7 +4079,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -4102,7 +4159,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "attributes": {
                 "allOf": [
@@ -4153,7 +4211,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -4256,7 +4315,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,

--- a/test/OpenApiTests/NamingConventions/PascalCase/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/NamingConventions/PascalCase/GeneratedSwagger/swagger.g.json
@@ -368,7 +368,9 @@
             "description": "The identifier of the StaffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -461,7 +463,9 @@
             "description": "The identifier of the StaffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -540,7 +544,9 @@
             "description": "The identifier of the StaffMember to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -641,7 +647,9 @@
             "description": "The identifier of the StaffMember to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -931,7 +939,9 @@
             "description": "The identifier of the Supermarket to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1024,7 +1034,9 @@
             "description": "The identifier of the Supermarket to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1103,7 +1115,9 @@
             "description": "The identifier of the Supermarket to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1204,7 +1218,9 @@
             "description": "The identifier of the Supermarket to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1239,7 +1255,9 @@
             "description": "The identifier of the Supermarket whose related StaffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1332,7 +1350,9 @@
             "description": "The identifier of the Supermarket whose related StaffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1413,7 +1433,9 @@
             "description": "The identifier of the Supermarket whose related StaffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1506,7 +1528,9 @@
             "description": "The identifier of the Supermarket whose related StaffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1585,7 +1609,9 @@
             "description": "The identifier of the Supermarket whose BackupStoreManager relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1655,7 +1681,9 @@
             "description": "The identifier of the Supermarket whose related StaffMembers to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1748,7 +1776,9 @@
             "description": "The identifier of the Supermarket whose related StaffMembers to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1829,7 +1859,9 @@
             "description": "The identifier of the Supermarket whose related StaffMember identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1922,7 +1954,9 @@
             "description": "The identifier of the Supermarket whose related StaffMember identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2001,7 +2035,9 @@
             "description": "The identifier of the Supermarket to add StaffMembers to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2069,7 +2105,9 @@
             "description": "The identifier of the Supermarket whose Cashiers relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2137,7 +2175,9 @@
             "description": "The identifier of the Supermarket to remove StaffMembers from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2207,7 +2247,9 @@
             "description": "The identifier of the Supermarket whose related StaffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2300,7 +2342,9 @@
             "description": "The identifier of the Supermarket whose related StaffMember to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2381,7 +2425,9 @@
             "description": "The identifier of the Supermarket whose related StaffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2474,7 +2520,9 @@
             "description": "The identifier of the Supermarket whose related StaffMember identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2553,7 +2601,9 @@
             "description": "The identifier of the Supermarket whose StoreManager relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2967,7 +3017,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -2998,7 +3049,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -3708,7 +3760,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "attributes": {
                 "allOf": [
@@ -3789,7 +3842,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -3814,7 +3868,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -3984,7 +4039,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -4023,7 +4079,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -4102,7 +4159,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "attributes": {
                 "allOf": [
@@ -4153,7 +4211,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,
@@ -4256,7 +4315,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "lid": {
             "minLength": 1,

--- a/test/OpenApiTests/QueryStrings/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/QueryStrings/GeneratedSwagger/swagger.g.json
@@ -279,7 +279,9 @@
             "description": "The identifier of the nameValuePair to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -372,7 +374,9 @@
             "description": "The identifier of the nameValuePair to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -451,7 +455,9 @@
             "description": "The identifier of the nameValuePair to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -552,7 +558,9 @@
             "description": "The identifier of the nameValuePair to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -587,7 +595,9 @@
             "description": "The identifier of the nameValuePair whose related node to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -680,7 +690,9 @@
             "description": "The identifier of the nameValuePair whose related node to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -761,7 +773,9 @@
             "description": "The identifier of the nameValuePair whose related node identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -854,7 +868,9 @@
             "description": "The identifier of the nameValuePair whose related node identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -933,7 +949,9 @@
             "description": "The identifier of the nameValuePair whose owner relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -1258,7 +1276,9 @@
             "description": "The identifier of the node to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1351,7 +1371,9 @@
             "description": "The identifier of the node to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1430,7 +1452,9 @@
             "description": "The identifier of the node to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1531,7 +1555,9 @@
             "description": "The identifier of the node to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -1566,7 +1592,9 @@
             "description": "The identifier of the node whose related nodes to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1659,7 +1687,9 @@
             "description": "The identifier of the node whose related nodes to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1740,7 +1770,9 @@
             "description": "The identifier of the node whose related node identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1833,7 +1865,9 @@
             "description": "The identifier of the node whose related node identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1912,7 +1946,9 @@
             "description": "The identifier of the node to add nodes to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -1980,7 +2016,9 @@
             "description": "The identifier of the node whose children relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2048,7 +2086,9 @@
             "description": "The identifier of the node to remove nodes from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2118,7 +2158,9 @@
             "description": "The identifier of the node whose related node to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2211,7 +2253,9 @@
             "description": "The identifier of the node whose related node to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2292,7 +2336,9 @@
             "description": "The identifier of the node whose related node identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2385,7 +2431,9 @@
             "description": "The identifier of the node whose related node identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2464,7 +2512,9 @@
             "description": "The identifier of the node whose parent relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2534,7 +2584,9 @@
             "description": "The identifier of the node whose related nameValuePairs to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2627,7 +2679,9 @@
             "description": "The identifier of the node whose related nameValuePairs to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2708,7 +2762,9 @@
             "description": "The identifier of the node whose related nameValuePair identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2801,7 +2857,9 @@
             "description": "The identifier of the node whose related nameValuePair identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2880,7 +2938,9 @@
             "description": "The identifier of the node to add nameValuePairs to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2948,7 +3008,9 @@
             "description": "The identifier of the node whose values relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3016,7 +3078,9 @@
             "description": "The identifier of the node to remove nameValuePairs from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3262,7 +3326,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "attributes": {
             "allOf": [
@@ -3297,7 +3362,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "attributes": {
             "allOf": [
@@ -3506,7 +3572,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -3588,7 +3655,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -3609,7 +3677,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -3733,7 +3802,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -3815,7 +3885,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -3836,7 +3907,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/GeneratedSwagger/swagger.g.json
@@ -279,7 +279,9 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -372,7 +374,9 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -451,7 +455,9 @@
             "description": "The identifier of the resource to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -552,7 +558,9 @@
             "description": "The identifier of the resource to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -587,7 +595,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -680,7 +690,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -761,7 +773,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -854,7 +868,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -933,7 +949,9 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1001,7 +1019,9 @@
             "description": "The identifier of the resource whose requiredToMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1069,7 +1089,9 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1139,7 +1161,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1232,7 +1256,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1313,7 +1339,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1406,7 +1434,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1485,7 +1515,9 @@
             "description": "The identifier of the resource whose requiredToOne relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1555,7 +1587,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1648,7 +1682,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1729,7 +1765,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1822,7 +1860,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1901,7 +1941,9 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1969,7 +2011,9 @@
             "description": "The identifier of the resource whose toMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2037,7 +2081,9 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2107,7 +2153,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2200,7 +2248,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2281,7 +2331,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2374,7 +2426,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2453,7 +2507,9 @@
             "description": "The identifier of the resource whose toOne relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2666,7 +2722,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "attributes": {
             "allOf": [
@@ -2734,7 +2791,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "links": {
                 "allOf": [
@@ -2802,7 +2860,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -2823,7 +2882,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -3268,7 +3328,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "attributes": {
                 "allOf": [

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/GeneratedSwagger/swagger.g.json
@@ -279,7 +279,9 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -372,7 +374,9 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -451,7 +455,9 @@
             "description": "The identifier of the resource to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -552,7 +558,9 @@
             "description": "The identifier of the resource to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -587,7 +595,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -680,7 +690,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -761,7 +773,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -854,7 +868,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -933,7 +949,9 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1001,7 +1019,9 @@
             "description": "The identifier of the resource whose requiredToMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1069,7 +1089,9 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1139,7 +1161,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1232,7 +1256,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1313,7 +1339,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1406,7 +1434,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1485,7 +1515,9 @@
             "description": "The identifier of the resource whose requiredToOne relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1555,7 +1587,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1648,7 +1682,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1729,7 +1765,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1822,7 +1860,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1901,7 +1941,9 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1969,7 +2011,9 @@
             "description": "The identifier of the resource whose toMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2037,7 +2081,9 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2107,7 +2153,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2200,7 +2248,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2281,7 +2331,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2374,7 +2426,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2453,7 +2507,9 @@
             "description": "The identifier of the resource whose toOne relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2661,7 +2717,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "attributes": {
             "allOf": [
@@ -2729,7 +2786,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "links": {
                 "allOf": [
@@ -2797,7 +2855,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -2818,7 +2877,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -3328,7 +3388,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "attributes": {
                 "allOf": [

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/GeneratedSwagger/swagger.g.json
@@ -279,7 +279,9 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -372,7 +374,9 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -451,7 +455,9 @@
             "description": "The identifier of the resource to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -552,7 +558,9 @@
             "description": "The identifier of the resource to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -587,7 +595,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -680,7 +690,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -761,7 +773,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -854,7 +868,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -933,7 +949,9 @@
             "description": "The identifier of the resource whose nonNullableToOne relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1003,7 +1021,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1096,7 +1116,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1177,7 +1199,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1270,7 +1294,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1349,7 +1375,9 @@
             "description": "The identifier of the resource whose nullableToOne relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1419,7 +1447,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1512,7 +1542,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1593,7 +1625,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1686,7 +1720,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1765,7 +1801,9 @@
             "description": "The identifier of the resource whose requiredNonNullableToOne relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1835,7 +1873,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1928,7 +1968,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2009,7 +2051,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2102,7 +2146,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2181,7 +2227,9 @@
             "description": "The identifier of the resource whose requiredNullableToOne relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2251,7 +2299,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2344,7 +2394,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2425,7 +2477,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2518,7 +2572,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2597,7 +2653,9 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2665,7 +2723,9 @@
             "description": "The identifier of the resource whose requiredToMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2733,7 +2793,9 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2803,7 +2865,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2896,7 +2960,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2977,7 +3043,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -3070,7 +3138,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -3149,7 +3219,9 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -3217,7 +3289,9 @@
             "description": "The identifier of the resource whose toMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -3285,7 +3359,9 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -3513,7 +3589,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "attributes": {
             "allOf": [
@@ -3581,7 +3658,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "links": {
                 "allOf": [
@@ -3649,7 +3727,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -3670,7 +3749,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -4219,7 +4299,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "attributes": {
                 "allOf": [

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/GeneratedSwagger/swagger.g.json
@@ -279,7 +279,9 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -372,7 +374,9 @@
             "description": "The identifier of the resource to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -451,7 +455,9 @@
             "description": "The identifier of the resource to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -552,7 +558,9 @@
             "description": "The identifier of the resource to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -587,7 +595,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -680,7 +690,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -761,7 +773,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -854,7 +868,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -933,7 +949,9 @@
             "description": "The identifier of the resource whose nonNullableToOne relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1003,7 +1021,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1096,7 +1116,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1177,7 +1199,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1270,7 +1294,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1349,7 +1375,9 @@
             "description": "The identifier of the resource whose nullableToOne relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1419,7 +1447,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1512,7 +1542,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1593,7 +1625,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1686,7 +1720,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1765,7 +1801,9 @@
             "description": "The identifier of the resource whose requiredNonNullableToOne relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -1835,7 +1873,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -1928,7 +1968,9 @@
             "description": "The identifier of the resource whose related empty to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2009,7 +2051,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2102,7 +2146,9 @@
             "description": "The identifier of the resource whose related empty identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2181,7 +2227,9 @@
             "description": "The identifier of the resource whose requiredNullableToOne relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2251,7 +2299,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2344,7 +2394,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2425,7 +2477,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2518,7 +2572,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2597,7 +2653,9 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2665,7 +2723,9 @@
             "description": "The identifier of the resource whose requiredToMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2733,7 +2793,9 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -2803,7 +2865,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2896,7 +2960,9 @@
             "description": "The identifier of the resource whose related empties to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -2977,7 +3043,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -3070,7 +3138,9 @@
             "description": "The identifier of the resource whose related empty identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           },
           {
@@ -3149,7 +3219,9 @@
             "description": "The identifier of the resource to add empties to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -3217,7 +3289,9 @@
             "description": "The identifier of the resource whose toMany relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -3285,7 +3359,9 @@
             "description": "The identifier of the resource to remove empties from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int32"
             }
           }
         ],
@@ -3509,7 +3585,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           },
           "attributes": {
             "allOf": [
@@ -3577,7 +3654,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "links": {
                 "allOf": [
@@ -3645,7 +3723,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -3666,7 +3745,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -4213,7 +4293,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int32"
               },
               "attributes": {
                 "allOf": [

--- a/test/OpenApiTests/RestrictedControllers/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/RestrictedControllers/GeneratedSwagger/swagger.g.json
@@ -167,7 +167,9 @@
             "description": "The identifier of the dataStream to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -260,7 +262,9 @@
             "description": "The identifier of the dataStream to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -484,7 +488,9 @@
             "description": "The identifier of the readOnlyChannel to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -577,7 +583,9 @@
             "description": "The identifier of the readOnlyChannel to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -658,7 +666,9 @@
             "description": "The identifier of the readOnlyChannel whose related dataStreams to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -751,7 +761,9 @@
             "description": "The identifier of the readOnlyChannel whose related dataStreams to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -832,7 +844,9 @@
             "description": "The identifier of the readOnlyChannel whose related dataStream identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -925,7 +939,9 @@
             "description": "The identifier of the readOnlyChannel whose related dataStream identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1006,7 +1022,9 @@
             "description": "The identifier of the readOnlyChannel whose related dataStream to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1099,7 +1117,9 @@
             "description": "The identifier of the readOnlyChannel whose related dataStream to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1180,7 +1200,9 @@
             "description": "The identifier of the readOnlyChannel whose related dataStream identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1273,7 +1295,9 @@
             "description": "The identifier of the readOnlyChannel whose related dataStream identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1354,7 +1378,9 @@
             "description": "The identifier of the readOnlyChannel whose related dataStream to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1447,7 +1473,9 @@
             "description": "The identifier of the readOnlyChannel whose related dataStream to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1528,7 +1556,9 @@
             "description": "The identifier of the readOnlyChannel whose related dataStream identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1621,7 +1651,9 @@
             "description": "The identifier of the readOnlyChannel whose related dataStream identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1845,7 +1877,9 @@
             "description": "The identifier of the readOnlyResourceChannel to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -1938,7 +1972,9 @@
             "description": "The identifier of the readOnlyResourceChannel to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2019,7 +2055,9 @@
             "description": "The identifier of the readOnlyResourceChannel whose related dataStreams to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2112,7 +2150,9 @@
             "description": "The identifier of the readOnlyResourceChannel whose related dataStreams to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2193,7 +2233,9 @@
             "description": "The identifier of the readOnlyResourceChannel whose related dataStream to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2286,7 +2328,9 @@
             "description": "The identifier of the readOnlyResourceChannel whose related dataStream to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2367,7 +2411,9 @@
             "description": "The identifier of the readOnlyResourceChannel whose related dataStream to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2460,7 +2506,9 @@
             "description": "The identifier of the readOnlyResourceChannel whose related dataStream to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2541,7 +2589,9 @@
             "description": "The identifier of the relationshipChannel whose related dataStream identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2634,7 +2684,9 @@
             "description": "The identifier of the relationshipChannel whose related dataStream identities to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -2713,7 +2765,9 @@
             "description": "The identifier of the relationshipChannel to add dataStreams to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2781,7 +2835,9 @@
             "description": "The identifier of the relationshipChannel whose audioStreams relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2849,7 +2905,9 @@
             "description": "The identifier of the relationshipChannel to remove dataStreams from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -2919,7 +2977,9 @@
             "description": "The identifier of the relationshipChannel whose related dataStream identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3012,7 +3072,9 @@
             "description": "The identifier of the relationshipChannel whose related dataStream identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3091,7 +3153,9 @@
             "description": "The identifier of the relationshipChannel whose ultraHighDefinitionVideoStream relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3161,7 +3225,9 @@
             "description": "The identifier of the relationshipChannel whose related dataStream identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3254,7 +3320,9 @@
             "description": "The identifier of the relationshipChannel whose related dataStream identity to retrieve.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3333,7 +3401,9 @@
             "description": "The identifier of the relationshipChannel whose videoStream relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3517,7 +3587,9 @@
             "description": "The identifier of the writeOnlyChannel to update.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           },
           {
@@ -3618,7 +3690,9 @@
             "description": "The identifier of the writeOnlyChannel to delete.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3653,7 +3727,9 @@
             "description": "The identifier of the writeOnlyChannel to add dataStreams to.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3721,7 +3797,9 @@
             "description": "The identifier of the writeOnlyChannel whose audioStreams relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3789,7 +3867,9 @@
             "description": "The identifier of the writeOnlyChannel to remove dataStreams from.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3859,7 +3939,9 @@
             "description": "The identifier of the writeOnlyChannel whose ultraHighDefinitionVideoStream relationship to assign or clear.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -3929,7 +4011,9 @@
             "description": "The identifier of the writeOnlyChannel whose videoStream relationship to assign.",
             "required": true,
             "schema": {
-              "type": "string"
+              "minLength": 1,
+              "type": "string",
+              "format": "int64"
             }
           }
         ],
@@ -4109,7 +4193,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           },
           "attributes": {
             "allOf": [
@@ -4187,7 +4272,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -4262,7 +4348,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -4283,7 +4370,8 @@
           },
           "id": {
             "minLength": 1,
-            "type": "string"
+            "type": "string",
+            "format": "int64"
           }
         },
         "additionalProperties": false
@@ -4710,7 +4798,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -4877,7 +4966,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [
@@ -5264,7 +5354,8 @@
             "properties": {
               "id": {
                 "minLength": 1,
-                "type": "string"
+                "type": "string",
+                "format": "int64"
               },
               "attributes": {
                 "allOf": [


### PR DESCRIPTION
This PR adds type hints to the string-based `id` parameters and properties.

The resulting experience is less awesome than I hoped. Effectively, it only makes a difference in NSwag/Kiota when `TId` is a guid (`uuid` in OpenAPI). This is because client generators don't generate a numeric type when the type is `string`, despite a type hint such as `int64`. That's understandable, because it would produce an invalid JSON:API request (sending `"id": 3` would fail because the value must be a string).

The type hints do show up in SwaggerUI for all `TId` types, which could be helpful.

![image](https://github.com/user-attachments/assets/39fabd9f-357f-48fd-be3f-6fdefe01a6e9)

A corner case surfaced in NSwag when using `Guid` as the `id` type and `/GenerateNullableReferenceTypes` is turned on, but `GenerateOptionalPropertiesAsNullable` and `GenerateOptionalParameters` are off. In that case, the generated type for the `Id` property becomes `Guid` (non-nullable), so omitting it from the request body sends `Guid.Empty`, which produces an error. This is a problem when `ClientIdGenerationMode` is set to `Allowed`, because there's no way to _not_ send the ID. To fix that, `TId` must be `Guid?`, so a nullable type gets generated. However this is such a corner case that I've updated the existing tests to run with `GenerateOptionalPropertiesAsNullable` and `GenerateOptionalParameters` turned on, which I expect users to do anyway.

Once we update to NSwag v14, its MSBuild properties enable us to set the switches we need/recommend from the `JsonApiDotNetCore.OpenApi.Client.NSwag` NuGet package via an imported `.props` file, so the limitation is even less likely to surface.

Closes #1572.

#### QUALITY CHECKLIST
- [ ] Changes implemented in code
- [ ] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] Adapted tests
- [ ] Documentation updated
