### PR TITLE
Emit warning about renamed NuGet package on build

### DIFF
--- a/src/JsonApiDotNetCore.OpenApi/Build/JsonApiDotNetCore.OpenApi.targets
+++ b/src/JsonApiDotNetCore.OpenApi/Build/JsonApiDotNetCore.OpenApi.targets
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="WarnAboutObsoletePackage" BeforeTargets="BeforeBuild">
+    <!-- Add <NoWarn>$(NoWarn);JADNC-OA</NoWarn> in a PropertyGroup in your project file to suppress this warning. -->
+    <Warning Code="JADNC-OA" Text="The 'JsonApiDotNetCore.OpenApi' package has been renamed, please use 'JsonApiDotNetCore.OpenApi.Swashbuckle' instead." />
+  </Target>
+</Project>

--- a/src/JsonApiDotNetCore.OpenApi/JsonApiDotNetCore.OpenApi.csproj
+++ b/src/JsonApiDotNetCore.OpenApi/JsonApiDotNetCore.OpenApi.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <None Include="..\..\package-icon.png" Visible="false" Pack="True" PackagePath="" />
     <None Include="..\..\PackageReadme.md" Visible="false" Pack="True" PackagePath="" />
+    <None Include="Build\*.targets" Pack="True" PackagePath="build" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This helps notify users using the preview packages from GitHub Actions to migrate.

![image](https://github.com/user-attachments/assets/b95846fd-522f-4d9c-ba8c-985fd8a50cbe)

To suppress the warning, add the following to your .csproj:
```xml
<PropertyGroup>
    <NoWarn>$(NoWarn);JADNC-OA</NoWarn>
</PropertyGroup>
```

Contributes to #1578.