### PR TITLE
Update to NSwag v14.1

### DIFF
--- a/package-versions.props
+++ b/package-versions.props
@@ -20,7 +20,7 @@
     <InheritDocVersion>2.0.*</InheritDocVersion>
     <KiotaVersion>1.*</KiotaVersion>
     <MicrosoftApiClientVersion>8.0.*</MicrosoftApiClientVersion>
-    <NSwagApiClientVersion>13.20.*</NSwagApiClientVersion>
+    <NSwagApiClientVersion>14.1.*</NSwagApiClientVersion>
     <NewtonsoftJsonVersion>13.0.*</NewtonsoftJsonVersion>
     <SourceLinkVersion>8.0.*</SourceLinkVersion>
     <SwashbuckleVersion>6.*-*</SwashbuckleVersion>

--- a/src/Examples/OpenApiNSwagClientExample/ExampleApiClient.cs
+++ b/src/Examples/OpenApiNSwagClientExample/ExampleApiClient.cs
@@ -7,12 +7,14 @@ namespace OpenApiNSwagClientExample;
 [UsedImplicitly(ImplicitUseTargetFlags.Itself)]
 public partial class ExampleApiClient : JsonApiClient
 {
-    partial void UpdateJsonSerializerSettings(JsonSerializerSettings settings)
+    partial void Initialize()
     {
-        SetSerializerSettingsForJsonApi(settings);
+        _instanceSettings = new JsonSerializerSettings(_settings.Value);
 
 #if DEBUG
-        settings.Formatting = Formatting.Indented;
+        _instanceSettings.Formatting = Formatting.Indented;
 #endif
+
+        SetSerializerSettingsForJsonApi(_instanceSettings);
     }
 }

--- a/src/Examples/OpenApiNSwagClientExample/OpenApiNSwagClientExample.csproj
+++ b/src/Examples/OpenApiNSwagClientExample/OpenApiNSwagClientExample.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\..\package-versions.props" />
+  <Import Project="..\..\JsonApiDotNetCore.OpenApi.Client.NSwag\Build\JsonApiDotNetCore.OpenApi.Client.NSwag.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\JsonApiDotNetCore.OpenApi.Client.NSwag\JsonApiDotNetCore.OpenApi.Client.NSwag.csproj" />
@@ -20,11 +21,11 @@
 
   <ItemGroup>
     <OpenApiReference Include="..\JsonApiDotNetCoreExample\GeneratedSwagger\JsonApiDotNetCoreExample.json">
-      <Namespace>OpenApiNSwagClientExample</Namespace>
-      <ClassName>ExampleApiClient</ClassName>
-      <OutputPath>ExampleApiClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/GenerateExceptionClasses:false /WrapResponses:true /GenerateResponseClasses:false /ResponseClass:ApiResponse /GenerateNullableReferenceTypes:true /GenerateOptionalPropertiesAsNullable:true /GenerateOptionalParameters:true /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag</Options>
+      <Name>ExampleApi</Name>
+      <Namespace>$(MSBuildProjectName)</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
+      <NSwagWrapResponses>true</NSwagWrapResponses>
     </OpenApiReference>
   </ItemGroup>
 </Project>

--- a/src/JsonApiDotNetCore.OpenApi.Client.NSwag/Build/JsonApiDotNetCore.OpenApi.Client.NSwag.props
+++ b/src/JsonApiDotNetCore.OpenApi.Client.NSwag/Build/JsonApiDotNetCore.OpenApi.Client.NSwag.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <CodeGenerator>NSwagCSharp</CodeGenerator>
+    <NSwagGenerateExceptionClasses>false</NSwagGenerateExceptionClasses>
+    <NSwagGenerateResponseClasses>false</NSwagGenerateResponseClasses>
+    <NSwagResponseClass>ApiResponse</NSwagResponseClass>
+    <NSwagAdditionalNamespaceUsages>JsonApiDotNetCore.OpenApi.Client.NSwag</NSwagAdditionalNamespaceUsages>
+    <NSwagGenerateNullableReferenceTypes>true</NSwagGenerateNullableReferenceTypes>
+    <NSwagGenerateOptionalPropertiesAsNullable>true</NSwagGenerateOptionalPropertiesAsNullable>
+    <NSwagGenerateOptionalParameters>true</NSwagGenerateOptionalParameters>
+  </PropertyGroup>
+</Project>

--- a/src/JsonApiDotNetCore.OpenApi.Client.NSwag/JsonApiDotNetCore.OpenApi.Client.NSwag.csproj
+++ b/src/JsonApiDotNetCore.OpenApi.Client.NSwag/JsonApiDotNetCore.OpenApi.Client.NSwag.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <None Include="..\..\package-icon.png" Visible="false" Pack="True" PackagePath="" />
     <None Include="..\..\PackageReadme.md" Visible="false" Pack="True" PackagePath="" />
+    <None Include="Build\*.props" Pack="True" PackagePath="build" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiObjects/Relationships/NullableToOneRelationshipInResponse.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiObjects/Relationships/NullableToOneRelationshipInResponse.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiObjects.Links;
@@ -15,7 +14,7 @@ internal sealed class NullableToOneRelationshipInResponse<TResource>
     [JsonPropertyName("links")]
     public RelationshipLinks Links { get; set; } = null!;
 
-    [Required]
+    // Non-required because related data may not be included in the response.
     [JsonPropertyName("data")]
     public ResourceIdentifierInResponse<TResource>? Data { get; set; }
 

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiObjects/Relationships/ToManyRelationshipInResponse.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiObjects/Relationships/ToManyRelationshipInResponse.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiObjects.Links;
@@ -15,7 +14,7 @@ internal sealed class ToManyRelationshipInResponse<TResource>
     [JsonPropertyName("links")]
     public RelationshipLinks Links { get; set; } = null!;
 
-    [Required]
+    // Non-required because related data may not be included in the response.
     [JsonPropertyName("data")]
     public ICollection<ResourceIdentifierInResponse<TResource>> Data { get; set; } = null!;
 

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiObjects/Relationships/ToOneRelationshipInResponse.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiObjects/Relationships/ToOneRelationshipInResponse.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiObjects.Links;
@@ -15,7 +14,7 @@ internal sealed class ToOneRelationshipInResponse<TResource>
     [JsonPropertyName("links")]
     public RelationshipLinks Links { get; set; } = null!;
 
-    [Required]
+    // Non-required because related data may not be included in the response.
     [JsonPropertyName("data")]
     public ResourceIdentifierInResponse<TResource> Data { get; set; } = null!;
 

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SwaggerComponents/DocumentationOpenApiOperationFilter.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SwaggerComponents/DocumentationOpenApiOperationFilter.cs
@@ -540,7 +540,7 @@ internal sealed class DocumentationOpenApiOperationFilter : IOperationFilter
         // The next best thing is to expose the query string parameters as unstructured and optional.
         // - This makes SwaggerUI ask for JSON, which is a bit odd, but it works. For example: {"sort":"-id"} produces: ?sort=-id
         // - This makes NSwag produce a C# client with method signature: GetAsync(IDictionary<string, string?>? query)
-        //     when combined with <Options>/GenerateNullableReferenceTypes:true</Options> in the project file.
+        //     when combined with <NSwagGenerateNullableReferenceTypes>true</NSwagGenerateNullableReferenceTypes> in the project file.
 
         operation.Parameters.Add(new OpenApiParameter
         {

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SwaggerComponents/ResourceFieldSchemaBuilder.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SwaggerComponents/ResourceFieldSchemaBuilder.cs
@@ -207,8 +207,6 @@ internal sealed class ResourceFieldSchemaBuilder
         if (JsonApiSchemaFacts.IsRelationshipInResponseType(relationshipSchemaType))
         {
             _linksVisibilitySchemaGenerator.UpdateSchemaForRelationship(relationshipSchemaType, fullSchema, schemaRepository);
-
-            fullSchema.Required.Remove(JsonApiPropertyName.Data);
         }
 
         return referenceSchema;

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicCreateResourceTests.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicCreateResourceTests.cs
@@ -69,7 +69,8 @@ public sealed class AtomicCreateResourceTests : IClassFixture<IntegrationTestCon
         response.AtomicResults.ShouldHaveCount(1);
         TeacherDataInResponse teacherDataInResponse = response.AtomicResults.ElementAt(0).Data.Should().BeOfType<TeacherDataInResponse>().Which;
 
-        teacherDataInResponse.Attributes!.Name.Should().Be(newTeacher.Name);
+        teacherDataInResponse.Attributes.ShouldNotBeNull();
+        teacherDataInResponse.Attributes.Name.Should().Be(newTeacher.Name);
         teacherDataInResponse.Attributes.EmailAddress.Should().Be(newTeacher.EmailAddress);
 
         long newTeacherId = long.Parse(teacherDataInResponse.Id!);
@@ -147,7 +148,8 @@ public sealed class AtomicCreateResourceTests : IClassFixture<IntegrationTestCon
         response.AtomicResults.ShouldHaveCount(1);
         EnrollmentDataInResponse enrollmentDataInResponse = response.AtomicResults.ElementAt(0).Data.Should().BeOfType<EnrollmentDataInResponse>().Which;
 
-        enrollmentDataInResponse.Attributes!.EnrolledAt.Should().Be((Date)newEnrollment.EnrolledAt);
+        enrollmentDataInResponse.Attributes.ShouldNotBeNull();
+        enrollmentDataInResponse.Attributes.EnrolledAt.Should().Be((Date)newEnrollment.EnrolledAt);
         enrollmentDataInResponse.Attributes.GraduatedAt.Should().BeNull();
         enrollmentDataInResponse.Attributes.HasGraduated.Should().BeFalse();
 

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicLocalIdTests.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicLocalIdTests.cs
@@ -180,7 +180,8 @@ public sealed class AtomicLocalIdTests : IClassFixture<IntegrationTestContext<Op
         response.AtomicResults.ShouldHaveCount(7);
 
         TeacherDataInResponse teacherInResponse = response.AtomicResults.ElementAt(0).Data.Should().BeOfType<TeacherDataInResponse>().Which;
-        teacherInResponse.Attributes!.Name.Should().Be(newTeacher.Name);
+        teacherInResponse.Attributes.ShouldNotBeNull();
+        teacherInResponse.Attributes.Name.Should().Be(newTeacher.Name);
         teacherInResponse.Attributes.EmailAddress.Should().Be(newTeacher.EmailAddress);
         long newTeacherId = long.Parse(teacherInResponse.Id!);
 
@@ -188,12 +189,14 @@ public sealed class AtomicLocalIdTests : IClassFixture<IntegrationTestContext<Op
         response.AtomicResults.ElementAt(2).Data.Should().BeNull();
 
         StudentDataInResponse studentInResponse = response.AtomicResults.ElementAt(3).Data.Should().BeOfType<StudentDataInResponse>().Which;
-        studentInResponse.Attributes!.Name.Should().Be(newStudent.Name);
+        studentInResponse.Attributes.ShouldNotBeNull();
+        studentInResponse.Attributes.Name.Should().Be(newStudent.Name);
         studentInResponse.Attributes.EmailAddress.Should().Be(newStudent.EmailAddress);
         long newStudentId = long.Parse(studentInResponse.Id!);
 
         EnrollmentDataInResponse enrollmentInResponse = response.AtomicResults.ElementAt(4).Data.Should().BeOfType<EnrollmentDataInResponse>().Which;
-        enrollmentInResponse.Attributes!.EnrolledAt.Should().Be((Date)newEnrolledAt);
+        enrollmentInResponse.Attributes.ShouldNotBeNull();
+        enrollmentInResponse.Attributes.EnrolledAt.Should().Be((Date)newEnrolledAt);
         long newEnrollmentId = long.Parse(enrollmentInResponse.Id!);
 
         response.AtomicResults.ElementAt(5).Data.Should().BeNull();

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicUpdateResourceTests.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/AtomicUpdateResourceTests.cs
@@ -85,7 +85,8 @@ public sealed class AtomicUpdateResourceTests : IClassFixture<IntegrationTestCon
         StudentDataInResponse studentDataInResponse = response.AtomicResults.ElementAt(0).Data.Should().BeOfType<StudentDataInResponse>().Which;
 
         studentDataInResponse.Id.Should().Be(existingStudent.StringId);
-        studentDataInResponse.Attributes!.Name.Should().Be(newName);
+        studentDataInResponse.Attributes.ShouldNotBeNull();
+        studentDataInResponse.Attributes.Name.Should().Be(newName);
         studentDataInResponse.Attributes.EmailAddress.Should().Be(newEmailAddress);
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -148,7 +149,8 @@ public sealed class AtomicUpdateResourceTests : IClassFixture<IntegrationTestCon
         StudentDataInResponse studentDataInResponse = response.AtomicResults.ElementAt(0).Data.Should().BeOfType<StudentDataInResponse>().Which;
 
         studentDataInResponse.Id.Should().Be(existingStudent.StringId);
-        studentDataInResponse.Attributes!.Name.Should().Be(existingStudent.Name);
+        studentDataInResponse.Attributes.ShouldNotBeNull();
+        studentDataInResponse.Attributes.Name.Should().Be(existingStudent.Name);
         studentDataInResponse.Attributes.EmailAddress.Should().Be(newEmailAddress);
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -230,7 +232,8 @@ public sealed class AtomicUpdateResourceTests : IClassFixture<IntegrationTestCon
         EnrollmentDataInResponse enrollmentDataInResponse = response.AtomicResults.ElementAt(0).Data.Should().BeOfType<EnrollmentDataInResponse>().Which;
 
         enrollmentDataInResponse.Id.Should().Be(existingEnrollment.StringId);
-        enrollmentDataInResponse.Attributes!.EnrolledAt.Should().Be((Date)newEnrolledAt);
+        enrollmentDataInResponse.Attributes.ShouldNotBeNull();
+        enrollmentDataInResponse.Attributes.EnrolledAt.Should().Be((Date)newEnrolledAt);
         enrollmentDataInResponse.Attributes.GraduatedAt.Should().Be((Date)existingEnrollment.GraduatedAt!.Value);
         enrollmentDataInResponse.Attributes.HasGraduated.Should().Be(existingEnrollment.HasGraduated);
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/FilterTests.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/FilterTests.cs
@@ -57,8 +57,13 @@ public sealed class FilterTests : IClassFixture<IntegrationTestContext<OpenApiSt
             response.ShouldNotBeNull();
             response.Data.ShouldHaveCount(1);
             response.Data.ElementAt(0).Id.Should().Be(nodes[1].StringId);
-            response.Data.ElementAt(0).Attributes!.Name.Should().Be(nodes[1].Name);
-            response.Data.ElementAt(0).Attributes!.Comment.Should().Be(nodes[1].Comment);
+
+            response.Data.ElementAt(0).Attributes.ShouldNotBeNull().With(attributes =>
+            {
+                attributes.Name.Should().Be(nodes[1].Name);
+                attributes.Comment.Should().Be(nodes[1].Comment);
+            });
+
             response.Meta.ShouldNotBeNull();
             response.Meta.AdditionalData.ShouldContainKey("total").With(total => total.Should().Be(1));
         }
@@ -97,8 +102,13 @@ public sealed class FilterTests : IClassFixture<IntegrationTestContext<OpenApiSt
             response.ShouldNotBeNull();
             response.Data.ShouldHaveCount(1);
             response.Data.ElementAt(0).Id.Should().Be(node.Children.ElementAt(1).StringId);
-            response.Data.ElementAt(0).Attributes!.Name.Should().Be(node.Children.ElementAt(1).Name);
-            response.Data.ElementAt(0).Attributes!.Comment.Should().Be(node.Children.ElementAt(1).Comment);
+
+            response.Data.ElementAt(0).Attributes.ShouldNotBeNull().With(attributes =>
+            {
+                attributes.Name.Should().Be(node.Children.ElementAt(1).Name);
+                attributes.Comment.Should().Be(node.Children.ElementAt(1).Comment);
+            });
+
             response.Meta.ShouldNotBeNull();
             response.Meta.AdditionalData.ShouldContainKey("total").With(total => total.Should().Be(1));
         }

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/SparseFieldSetTests.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/SparseFieldSetTests.cs
@@ -55,9 +55,13 @@ public sealed class SparseFieldSetTests : IClassFixture<IntegrationTestContext<O
             response.ShouldNotBeNull();
             response.Data.ShouldHaveCount(1);
             response.Data.ElementAt(0).Id.Should().Be(node.StringId);
-            response.Data.ElementAt(0).Attributes.ShouldNotBeNull();
-            response.Data.ElementAt(0).Attributes!.Name.Should().Be(node.Name);
-            response.Data.ElementAt(0).Attributes!.Comment.Should().BeNull();
+
+            response.Data.ElementAt(0).Attributes.ShouldNotBeNull().With(attributes =>
+            {
+                attributes.Name.Should().Be(node.Name);
+                attributes.Comment.Should().BeNull();
+            });
+
             response.Data.ElementAt(0).Relationships.Should().BeNull();
         }
     }
@@ -131,12 +135,18 @@ public sealed class SparseFieldSetTests : IClassFixture<IntegrationTestContext<O
             response.ShouldNotBeNull();
             response.Data.ShouldHaveCount(1);
             response.Data.ElementAt(0).Id.Should().Be(node.Children.ElementAt(0).StringId);
-            response.Data.ElementAt(0).Attributes.ShouldNotBeNull();
-            response.Data.ElementAt(0).Attributes!.Name.Should().BeNull();
-            response.Data.ElementAt(0).Attributes!.Comment.Should().Be(node.Children.ElementAt(0).Comment);
-            response.Data.ElementAt(0).Relationships.ShouldNotBeNull();
-            response.Data.ElementAt(0).Relationships!.Parent.Should().BeNull();
-            response.Data.ElementAt(0).Relationships!.Children.ShouldNotBeNull();
+
+            response.Data.ElementAt(0).Attributes.ShouldNotBeNull().With(attributes =>
+            {
+                attributes.Name.Should().BeNull();
+                attributes.Comment.Should().Be(node.Children.ElementAt(0).Comment);
+            });
+
+            response.Data.ElementAt(0).Relationships.ShouldNotBeNull().With(relationships =>
+            {
+                relationships.Parent.Should().BeNull();
+                relationships.Children.ShouldNotBeNull();
+            });
         }
     }
 

--- a/test/OpenApiNSwagClientTests/LegacyOpenApi/GeneratedCode/LegacyClient.cs
+++ b/test/OpenApiNSwagClientTests/LegacyOpenApi/GeneratedCode/LegacyClient.cs
@@ -5,10 +5,13 @@ namespace OpenApiNSwagClientTests.LegacyOpenApi.GeneratedCode;
 
 internal partial class LegacyClient : JsonApiClient
 {
-    partial void UpdateJsonSerializerSettings(JsonSerializerSettings settings)
+    partial void Initialize()
     {
-        SetSerializerSettingsForJsonApi(settings);
+        _instanceSettings = new JsonSerializerSettings(_settings.Value)
+        {
+            Formatting = Formatting.Indented
+        };
 
-        settings.Formatting = Formatting.Indented;
+        SetSerializerSettingsForJsonApi(_instanceSettings);
     }
 }

--- a/test/OpenApiNSwagClientTests/OpenApiNSwagClientTests.csproj
+++ b/test/OpenApiNSwagClientTests/OpenApiNSwagClientTests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\package-versions.props" />
+  <Import Project="..\..\src\JsonApiDotNetCore.OpenApi.Client.NSwag\Build\JsonApiDotNetCore.OpenApi.Client.NSwag.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\JsonApiDotNetCore.OpenApi.Client.NSwag\JsonApiDotNetCore.OpenApi.Client.NSwag.csproj" />
@@ -22,62 +23,73 @@
     <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="$(MicrosoftApiClientVersion)" PrivateAssets="All" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <NSwagClientClassAccessModifier>internal</NSwagClientClassAccessModifier>
+  </PropertyGroup>
+
   <ItemGroup>
     <OpenApiReference Include="..\OpenApiTests\LegacyOpenApi\GeneratedSwagger\swagger.g.json">
-      <Namespace>OpenApiNSwagClientTests.LegacyOpenApi.GeneratedCode</Namespace>
+      <Namespace>$(MSBuildProjectName).LegacyOpenApi.GeneratedCode</Namespace>
       <ClassName>LegacyClient</ClassName>
-      <OutputPath>LegacyClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/GenerateClientInterfaces:true /ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag</Options>
+      <OutputPath>%(ClassName).cs</OutputPath>
+      <NSwagGenerateClientInterfaces>true</NSwagGenerateClientInterfaces>
+      <NSwagGenerateNullableReferenceTypes>false</NSwagGenerateNullableReferenceTypes>
+      <NSwagGenerateOptionalPropertiesAsNullable>false</NSwagGenerateOptionalPropertiesAsNullable>
+      <NSwagGenerateOptionalParameters>false</NSwagGenerateOptionalParameters>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\NamingConventions\KebabCase\GeneratedSwagger\swagger.g.json">
-      <Namespace>OpenApiNSwagClientTests.NamingConventions.KebabCase.GeneratedCode</Namespace>
-      <ClassName>KebabCaseClient</ClassName>
-      <OutputPath>KebabCaseClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag</Options>
+      <Name>KebabCase</Name>
+      <Namespace>$(MSBuildProjectName).NamingConventions.%(Name).GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\NamingConventions\CamelCase\GeneratedSwagger\swagger.g.json">
-      <Namespace>OpenApiNSwagClientTests.NamingConventions.CamelCase.GeneratedCode</Namespace>
-      <ClassName>CamelCaseClient</ClassName>
-      <OutputPath>CamelCaseClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag</Options>
+      <Name>CamelCase</Name>
+      <Namespace>$(MSBuildProjectName).NamingConventions.%(Name).GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\NamingConventions\PascalCase\GeneratedSwagger\swagger.g.json">
-      <Namespace>OpenApiNSwagClientTests.NamingConventions.PascalCase.GeneratedCode</Namespace>
-      <ClassName>PascalCaseClient</ClassName>
-      <OutputPath>PascalCaseClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag</Options>
+      <Name>PascalCase</Name>
+      <Namespace>$(MSBuildProjectName).NamingConventions.%(Name).GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\ResourceFieldValidation\NullableReferenceTypesOff\ModelStateValidationOff\GeneratedSwagger\swagger.g.json">
-      <ClassName>NrtOffMsvOffClient</ClassName>
-      <OutputPath>NrtOffMsvOffClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Namespace>OpenApiNSwagClientTests.ResourceFieldValidation.NullableReferenceTypesOff.ModelStateValidationOff.GeneratedCode</Namespace>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:false</Options>
+      <Name>NrtOffMsvOff</Name>
+      <Namespace>$(MSBuildProjectName).ResourceFieldValidation.NullableReferenceTypesOff.ModelStateValidationOff.GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
+      <NSwagGenerateNullableReferenceTypes>false</NSwagGenerateNullableReferenceTypes>
+      <NSwagGenerateOptionalPropertiesAsNullable>false</NSwagGenerateOptionalPropertiesAsNullable>
+      <NSwagGenerateOptionalParameters>false</NSwagGenerateOptionalParameters>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\ResourceFieldValidation\NullableReferenceTypesOff\ModelStateValidationOn\GeneratedSwagger\swagger.g.json">
-      <ClassName>NrtOffMsvOnClient</ClassName>
-      <OutputPath>NrtOffMsvOnClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Namespace>OpenApiNSwagClientTests.ResourceFieldValidation.NullableReferenceTypesOff.ModelStateValidationOn.GeneratedCode</Namespace>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:false</Options>
+      <Name>NrtOffMsvOn</Name>
+      <Namespace>$(MSBuildProjectName).ResourceFieldValidation.NullableReferenceTypesOff.ModelStateValidationOn.GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
+      <NSwagGenerateNullableReferenceTypes>false</NSwagGenerateNullableReferenceTypes>
+      <NSwagGenerateOptionalPropertiesAsNullable>false</NSwagGenerateOptionalPropertiesAsNullable>
+      <NSwagGenerateOptionalParameters>false</NSwagGenerateOptionalParameters>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\ResourceFieldValidation\NullableReferenceTypesOn\ModelStateValidationOff\GeneratedSwagger\swagger.g.json">
-      <ClassName>NrtOnMsvOffClient</ClassName>
-      <OutputPath>NrtOnMsvOffClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Namespace>OpenApiNSwagClientTests.ResourceFieldValidation.NullableReferenceTypesOn.ModelStateValidationOff.GeneratedCode</Namespace>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true</Options>
+      <Name>NrtOnMsvOff</Name>
+      <Namespace>$(MSBuildProjectName).ResourceFieldValidation.NullableReferenceTypesOn.ModelStateValidationOff.GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
+      <NSwagGenerateNullableReferenceTypes>true</NSwagGenerateNullableReferenceTypes>
+      <NSwagGenerateOptionalPropertiesAsNullable>false</NSwagGenerateOptionalPropertiesAsNullable>
+      <NSwagGenerateOptionalParameters>false</NSwagGenerateOptionalParameters>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\ResourceFieldValidation\NullableReferenceTypesOn\ModelStateValidationOn\GeneratedSwagger\swagger.g.json">
-      <ClassName>NrtOnMsvOnClient</ClassName>
-      <OutputPath>NrtOnMsvOnClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Namespace>OpenApiNSwagClientTests.ResourceFieldValidation.NullableReferenceTypesOn.ModelStateValidationOn.GeneratedCode</Namespace>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true</Options>
+      <Name>NrtOnMsvOn</Name>
+      <Namespace>$(MSBuildProjectName).ResourceFieldValidation.NullableReferenceTypesOn.ModelStateValidationOn.GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
+      <NSwagGenerateNullableReferenceTypes>true</NSwagGenerateNullableReferenceTypes>
+      <NSwagGenerateOptionalPropertiesAsNullable>false</NSwagGenerateOptionalPropertiesAsNullable>
+      <NSwagGenerateOptionalParameters>false</NSwagGenerateOptionalParameters>
     </OpenApiReference>
   </ItemGroup>
 </Project>

--- a/test/OpenApiNSwagClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/GeneratedCode/NrtOffMsvOffClient.cs
+++ b/test/OpenApiNSwagClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/GeneratedCode/NrtOffMsvOffClient.cs
@@ -5,10 +5,13 @@ namespace OpenApiNSwagClientTests.ResourceFieldValidation.NullableReferenceTypes
 
 internal partial class NrtOffMsvOffClient : JsonApiClient
 {
-    partial void UpdateJsonSerializerSettings(JsonSerializerSettings settings)
+    partial void Initialize()
     {
-        SetSerializerSettingsForJsonApi(settings);
+        _instanceSettings = new JsonSerializerSettings(_settings.Value)
+        {
+            Formatting = Formatting.Indented
+        };
 
-        settings.Formatting = Formatting.Indented;
+        SetSerializerSettingsForJsonApi(_instanceSettings);
     }
 }

--- a/test/OpenApiNSwagClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/GeneratedCode/NrtOffMsvOnClient.cs
+++ b/test/OpenApiNSwagClientTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/GeneratedCode/NrtOffMsvOnClient.cs
@@ -5,10 +5,13 @@ namespace OpenApiNSwagClientTests.ResourceFieldValidation.NullableReferenceTypes
 
 internal partial class NrtOffMsvOnClient : JsonApiClient
 {
-    partial void UpdateJsonSerializerSettings(JsonSerializerSettings settings)
+    partial void Initialize()
     {
-        SetSerializerSettingsForJsonApi(settings);
+        _instanceSettings = new JsonSerializerSettings(_settings.Value)
+        {
+            Formatting = Formatting.Indented
+        };
 
-        settings.Formatting = Formatting.Indented;
+        SetSerializerSettingsForJsonApi(_instanceSettings);
     }
 }

--- a/test/OpenApiNSwagClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/GeneratedCode/NrtOnMsvOffClient.cs
+++ b/test/OpenApiNSwagClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/GeneratedCode/NrtOnMsvOffClient.cs
@@ -5,10 +5,13 @@ namespace OpenApiNSwagClientTests.ResourceFieldValidation.NullableReferenceTypes
 
 internal partial class NrtOnMsvOffClient : JsonApiClient
 {
-    partial void UpdateJsonSerializerSettings(JsonSerializerSettings settings)
+    partial void Initialize()
     {
-        SetSerializerSettingsForJsonApi(settings);
+        _instanceSettings = new JsonSerializerSettings(_settings.Value)
+        {
+            Formatting = Formatting.Indented
+        };
 
-        settings.Formatting = Formatting.Indented;
+        SetSerializerSettingsForJsonApi(_instanceSettings);
     }
 }

--- a/test/OpenApiNSwagClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/GeneratedCode/NrtOnMsvOnClient.cs
+++ b/test/OpenApiNSwagClientTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/GeneratedCode/NrtOnMsvOnClient.cs
@@ -5,10 +5,13 @@ namespace OpenApiNSwagClientTests.ResourceFieldValidation.NullableReferenceTypes
 
 internal partial class NrtOnMsvOnClient : JsonApiClient
 {
-    partial void UpdateJsonSerializerSettings(JsonSerializerSettings settings)
+    partial void Initialize()
     {
-        SetSerializerSettingsForJsonApi(settings);
+        _instanceSettings = new JsonSerializerSettings(_settings.Value)
+        {
+            Formatting = Formatting.Indented
+        };
 
-        settings.Formatting = Formatting.Indented;
+        SetSerializerSettingsForJsonApi(_instanceSettings);
     }
 }

--- a/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicCreateResourceTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicCreateResourceTests.cs
@@ -66,6 +66,7 @@ public sealed class AtomicCreateResourceTests : IClassFixture<IntegrationTestCon
         response.Atomic_results.ShouldHaveCount(1);
         TeacherDataInResponse teacherDataInResponse = response.Atomic_results.ElementAt(0).Data.Should().BeOfType<TeacherDataInResponse>().Which;
 
+        teacherDataInResponse.Attributes.ShouldNotBeNull();
         teacherDataInResponse.Attributes.Name.Should().Be(newTeacher.Name);
         teacherDataInResponse.Attributes.EmailAddress.Should().Be(newTeacher.EmailAddress);
 
@@ -140,6 +141,7 @@ public sealed class AtomicCreateResourceTests : IClassFixture<IntegrationTestCon
         response.Atomic_results.ShouldHaveCount(1);
         EnrollmentDataInResponse enrollmentDataInResponse = response.Atomic_results.ElementAt(0).Data.Should().BeOfType<EnrollmentDataInResponse>().Which;
 
+        enrollmentDataInResponse.Attributes.ShouldNotBeNull();
         enrollmentDataInResponse.Attributes.EnrolledAt.Should().Be(newEnrollment.EnrolledAt.ToDateTime(TimeOnly.MinValue));
         enrollmentDataInResponse.Attributes.GraduatedAt.Should().BeNull();
         enrollmentDataInResponse.Attributes.HasGraduated.Should().BeFalse();

--- a/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicLocalIdTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicLocalIdTests.cs
@@ -158,6 +158,7 @@ public sealed class AtomicLocalIdTests : IClassFixture<IntegrationTestContext<Op
         response.Atomic_results.ShouldHaveCount(7);
 
         TeacherDataInResponse teacherInResponse = response.Atomic_results.ElementAt(0).Data.Should().BeOfType<TeacherDataInResponse>().Which;
+        teacherInResponse.Attributes.ShouldNotBeNull();
         teacherInResponse.Attributes.Name.Should().Be(newTeacher.Name);
         teacherInResponse.Attributes.EmailAddress.Should().Be(newTeacher.EmailAddress);
         long newTeacherId = long.Parse(teacherInResponse.Id);
@@ -166,11 +167,13 @@ public sealed class AtomicLocalIdTests : IClassFixture<IntegrationTestContext<Op
         response.Atomic_results.ElementAt(2).Data.Should().BeNull();
 
         StudentDataInResponse studentInResponse = response.Atomic_results.ElementAt(3).Data.Should().BeOfType<StudentDataInResponse>().Which;
+        studentInResponse.Attributes.ShouldNotBeNull();
         studentInResponse.Attributes.Name.Should().Be(newStudent.Name);
         studentInResponse.Attributes.EmailAddress.Should().Be(newStudent.EmailAddress);
         long newStudentId = long.Parse(studentInResponse.Id);
 
         EnrollmentDataInResponse enrollmentInResponse = response.Atomic_results.ElementAt(4).Data.Should().BeOfType<EnrollmentDataInResponse>().Which;
+        enrollmentInResponse.Attributes.ShouldNotBeNull();
         enrollmentInResponse.Attributes.EnrolledAt.Should().Be(newEnrolledAt.ToDateTime(TimeOnly.MinValue));
         long newEnrollmentId = long.Parse(enrollmentInResponse.Id);
 

--- a/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicUpdateResourceTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/AtomicOperations/AtomicUpdateResourceTests.cs
@@ -81,6 +81,7 @@ public sealed class AtomicUpdateResourceTests : IClassFixture<IntegrationTestCon
         StudentDataInResponse studentDataInResponse = response.Atomic_results.ElementAt(0).Data.Should().BeOfType<StudentDataInResponse>().Which;
 
         studentDataInResponse.Id.Should().Be(existingStudent.StringId);
+        studentDataInResponse.Attributes.ShouldNotBeNull();
         studentDataInResponse.Attributes.Name.Should().Be(newName);
         studentDataInResponse.Attributes.EmailAddress.Should().Be(newEmailAddress);
 
@@ -141,6 +142,7 @@ public sealed class AtomicUpdateResourceTests : IClassFixture<IntegrationTestCon
         StudentDataInResponse studentDataInResponse = response.Atomic_results.ElementAt(0).Data.Should().BeOfType<StudentDataInResponse>().Which;
 
         studentDataInResponse.Id.Should().Be(existingStudent.StringId);
+        studentDataInResponse.Attributes.ShouldNotBeNull();
         studentDataInResponse.Attributes.Name.Should().Be(existingStudent.Name);
         studentDataInResponse.Attributes.EmailAddress.Should().Be(newEmailAddress);
 
@@ -219,6 +221,7 @@ public sealed class AtomicUpdateResourceTests : IClassFixture<IntegrationTestCon
         EnrollmentDataInResponse enrollmentDataInResponse = response.Atomic_results.ElementAt(0).Data.Should().BeOfType<EnrollmentDataInResponse>().Which;
 
         enrollmentDataInResponse.Id.Should().Be(existingEnrollment.StringId);
+        enrollmentDataInResponse.Attributes.ShouldNotBeNull();
         enrollmentDataInResponse.Attributes.EnrolledAt.Should().Be(newEnrolledAt.ToDateTime(TimeOnly.MinValue));
         enrollmentDataInResponse.Attributes.GraduatedAt.Should().Be(existingEnrollment.GraduatedAt!.Value.ToDateTime(TimeOnly.MinValue));
         enrollmentDataInResponse.Attributes.HasGraduated.Should().Be(existingEnrollment.HasGraduated);

--- a/test/OpenApiNSwagEndToEndTests/Headers/ETagTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/Headers/ETagTests.cs
@@ -42,7 +42,7 @@ public sealed class ETagTests : IClassFixture<IntegrationTestContext<OpenApiStar
         var apiClient = new HeadersClient(httpClient);
 
         // Act
-        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryCollectionAsync(null, null));
+        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryCollectionAsync());
 
         // Assert
         response.StatusCode.Should().Be((int)HttpStatusCode.OK);
@@ -69,8 +69,7 @@ public sealed class ETagTests : IClassFixture<IntegrationTestContext<OpenApiStar
         var apiClient = new HeadersClient(httpClient);
 
         // Act
-        ApiResponse<CountryCollectionResponseDocument?> response =
-            await ApiResponse.TranslateAsync(async () => await apiClient.GetCountryCollectionAsync(null, null));
+        ApiResponse<CountryCollectionResponseDocument?> response = await ApiResponse.TranslateAsync(async () => await apiClient.GetCountryCollectionAsync());
 
         // Assert
         response.StatusCode.Should().Be((int)HttpStatusCode.OK);
@@ -92,7 +91,7 @@ public sealed class ETagTests : IClassFixture<IntegrationTestContext<OpenApiStar
         var apiClient = new HeadersClient(httpClient);
 
         // Act
-        Func<Task> action = async () => await ApiResponse.TranslateAsync(async () => await apiClient.GetCountryAsync(unknownCountryId, null, null));
+        Func<Task> action = async () => await ApiResponse.TranslateAsync(async () => await apiClient.GetCountryAsync(unknownCountryId));
 
         // Assert
         ApiException<ErrorResponseDocument> exception = (await action.Should().ThrowExactlyAsync<ApiException<ErrorResponseDocument>>()).Which;
@@ -129,8 +128,7 @@ public sealed class ETagTests : IClassFixture<IntegrationTestContext<OpenApiStar
         };
 
         // Act
-        ApiResponse<CountryPrimaryResponseDocument?> response =
-            await ApiResponse.TranslateAsync(async () => await apiClient.PostCountryAsync(null, requestBody));
+        ApiResponse<CountryPrimaryResponseDocument?> response = await ApiResponse.TranslateAsync(async () => await apiClient.PostCountryAsync(requestBody));
 
         // Assert
         response.StatusCode.Should().Be((int)HttpStatusCode.Created);
@@ -156,8 +154,7 @@ public sealed class ETagTests : IClassFixture<IntegrationTestContext<OpenApiStar
         using HttpClient httpClient = _testContext.Factory.CreateDefaultClient(_logHttpMessageHandler);
         var apiClient = new HeadersClient(httpClient);
 
-        ApiResponse<CountryCollectionResponseDocument?> response1 =
-            await ApiResponse.TranslateAsync(async () => await apiClient.GetCountryCollectionAsync(null, null));
+        ApiResponse<CountryCollectionResponseDocument?> response1 = await ApiResponse.TranslateAsync(async () => await apiClient.GetCountryCollectionAsync());
 
         string responseETag = response1.Headers[HeaderNames.ETag].Single();
 

--- a/test/OpenApiNSwagEndToEndTests/Headers/HeaderTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/Headers/HeaderTests.cs
@@ -47,8 +47,7 @@ public sealed class HeaderTests : IClassFixture<IntegrationTestContext<OpenApiSt
         };
 
         // Act
-        ApiResponse<CountryPrimaryResponseDocument?> response =
-            await ApiResponse.TranslateAsync(async () => await apiClient.PostCountryAsync(null, requestBody));
+        ApiResponse<CountryPrimaryResponseDocument?> response = await ApiResponse.TranslateAsync(async () => await apiClient.PostCountryAsync(requestBody));
 
         // Assert
         response.StatusCode.Should().Be((int)HttpStatusCode.Created);
@@ -77,7 +76,7 @@ public sealed class HeaderTests : IClassFixture<IntegrationTestContext<OpenApiSt
         var apiClient = new HeadersClient(httpClient);
 
         // Act
-        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryCollectionAsync(null, null));
+        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryCollectionAsync());
 
         // Assert
         response.StatusCode.Should().Be((int)HttpStatusCode.OK);
@@ -103,7 +102,7 @@ public sealed class HeaderTests : IClassFixture<IntegrationTestContext<OpenApiSt
         var apiClient = new HeadersClient(httpClient);
 
         // Act
-        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryAsync(existingCountry.Id, null, null));
+        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryAsync(existingCountry.Id));
 
         // Assert
         response.StatusCode.Should().Be((int)HttpStatusCode.OK);
@@ -130,7 +129,7 @@ public sealed class HeaderTests : IClassFixture<IntegrationTestContext<OpenApiSt
         var apiClient = new HeadersClient(httpClient);
 
         // Act
-        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryLanguagesAsync(existingCountry.Id, null, null));
+        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryLanguagesAsync(existingCountry.Id));
 
         // Assert
         response.StatusCode.Should().Be((int)HttpStatusCode.OK);
@@ -157,8 +156,7 @@ public sealed class HeaderTests : IClassFixture<IntegrationTestContext<OpenApiSt
         var apiClient = new HeadersClient(httpClient);
 
         // Act
-        ApiResponse response =
-            await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryLanguagesRelationshipAsync(existingCountry.Id, null, null));
+        ApiResponse response = await ApiResponse.TranslateAsync(async () => await apiClient.HeadCountryLanguagesRelationshipAsync(existingCountry.Id));
 
         // Assert
         response.StatusCode.Should().Be((int)HttpStatusCode.OK);

--- a/test/OpenApiNSwagEndToEndTests/Links/AlternateOpenApiRouteTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/Links/AlternateOpenApiRouteTests.cs
@@ -43,7 +43,7 @@ public sealed class AlternateOpenApiRouteTests : IClassFixture<IntegrationTestCo
         });
 
         // Act
-        ExcursionPrimaryResponseDocument response = await apiClient.GetExcursionAsync(excursion.StringId!, null, null);
+        ExcursionPrimaryResponseDocument response = await apiClient.GetExcursionAsync(excursion.StringId!);
 
         // Assert
         response.Links.Describedby.Should().Be("/api-docs/v1/swagger.yaml");

--- a/test/OpenApiNSwagEndToEndTests/OpenApiNSwagEndToEndTests.csproj
+++ b/test/OpenApiNSwagEndToEndTests/OpenApiNSwagEndToEndTests.csproj
@@ -25,8 +25,6 @@
 
   <PropertyGroup>
     <NSwagClientClassAccessModifier>internal</NSwagClientClassAccessModifier>
-    <NSwagGenerateOptionalPropertiesAsNullable>false</NSwagGenerateOptionalPropertiesAsNullable>
-    <NSwagGenerateOptionalParameters>false</NSwagGenerateOptionalParameters>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,16 +33,12 @@
       <Namespace>$(MSBuildProjectName).%(Name).GeneratedCode</Namespace>
       <ClassName>%(Name)Client</ClassName>
       <OutputPath>%(ClassName).cs</OutputPath>
-      <NSwagGenerateOptionalPropertiesAsNullable>true</NSwagGenerateOptionalPropertiesAsNullable>
-      <NSwagGenerateOptionalParameters>true</NSwagGenerateOptionalParameters>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\ModelStateValidation\GeneratedSwagger\$(TargetFramework)\swagger.g.json">
       <Name>ModelStateValidation</Name>
       <Namespace>$(MSBuildProjectName).%(Name).GeneratedCode</Namespace>
       <ClassName>%(Name)Client</ClassName>
       <OutputPath>%(ClassName).cs</OutputPath>
-      <NSwagGenerateOptionalPropertiesAsNullable>true</NSwagGenerateOptionalPropertiesAsNullable>
-      <NSwagGenerateOptionalParameters>true</NSwagGenerateOptionalParameters>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\Headers\GeneratedSwagger\swagger.g.json">
       <Name>Headers</Name>

--- a/test/OpenApiNSwagEndToEndTests/OpenApiNSwagEndToEndTests.csproj
+++ b/test/OpenApiNSwagEndToEndTests/OpenApiNSwagEndToEndTests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\package-versions.props" />
+  <Import Project="..\..\src\JsonApiDotNetCore.OpenApi.Client.NSwag\Build\JsonApiDotNetCore.OpenApi.Client.NSwag.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\JsonApiDotNetCore.OpenApi.Client.NSwag\JsonApiDotNetCore.OpenApi.Client.NSwag.csproj" />
@@ -22,55 +23,59 @@
     <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="$(MicrosoftApiClientVersion)" PrivateAssets="All" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <NSwagClientClassAccessModifier>internal</NSwagClientClassAccessModifier>
+    <NSwagGenerateOptionalPropertiesAsNullable>false</NSwagGenerateOptionalPropertiesAsNullable>
+    <NSwagGenerateOptionalParameters>false</NSwagGenerateOptionalParameters>
+  </PropertyGroup>
+
   <ItemGroup>
     <OpenApiReference Include="..\OpenApiTests\ClientIdGenerationModes\GeneratedSwagger\swagger.g.json">
-      <Namespace>OpenApiNSwagEndToEndTests.ClientIdGenerationModes.GeneratedCode</Namespace>
-      <ClassName>ClientIdGenerationModesClient</ClassName>
-      <OutputPath>ClientIdGenerationModesClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true /GenerateOptionalPropertiesAsNullable:true /GenerateOptionalParameters:true</Options>
+      <Name>ClientIdGenerationModes</Name>
+      <Namespace>$(MSBuildProjectName).%(Name).GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
+      <NSwagGenerateOptionalPropertiesAsNullable>true</NSwagGenerateOptionalPropertiesAsNullable>
+      <NSwagGenerateOptionalParameters>true</NSwagGenerateOptionalParameters>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\ModelStateValidation\GeneratedSwagger\$(TargetFramework)\swagger.g.json">
-      <Namespace>OpenApiNSwagEndToEndTests.ModelStateValidation.GeneratedCode</Namespace>
-      <ClassName>ModelStateValidationClient</ClassName>
-      <OutputPath>ModelStateValidationClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true /GenerateOptionalPropertiesAsNullable:true /GenerateOptionalParameters:true</Options>
+      <Name>ModelStateValidation</Name>
+      <Namespace>$(MSBuildProjectName).%(Name).GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
+      <NSwagGenerateOptionalPropertiesAsNullable>true</NSwagGenerateOptionalPropertiesAsNullable>
+      <NSwagGenerateOptionalParameters>true</NSwagGenerateOptionalParameters>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\Headers\GeneratedSwagger\swagger.g.json">
-      <Namespace>OpenApiNSwagEndToEndTests.Headers.GeneratedCode</Namespace>
-      <ClassName>HeadersClient</ClassName>
-      <OutputPath>HeadersClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /WrapResponses:true /GenerateResponseClasses:false /ResponseClass:ApiResponse /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true</Options>
+      <Name>Headers</Name>
+      <Namespace>$(MSBuildProjectName).%(Name).GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
+      <NSwagWrapResponses>true</NSwagWrapResponses>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\QueryStrings\GeneratedSwagger\swagger.g.json">
-      <Namespace>OpenApiNSwagEndToEndTests.QueryStrings.GeneratedCode</Namespace>
-      <ClassName>QueryStringsClient</ClassName>
-      <OutputPath>QueryStringsClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true</Options>
+      <Name>QueryStrings</Name>
+      <Namespace>$(MSBuildProjectName).%(Name).GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\RestrictedControllers\GeneratedSwagger\swagger.g.json">
-      <Namespace>OpenApiNSwagEndToEndTests.RestrictedControllers.GeneratedCode</Namespace>
-      <ClassName>RestrictedControllersClient</ClassName>
-      <OutputPath>RestrictedControllersClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true</Options>
+      <Name>RestrictedControllers</Name>
+      <Namespace>$(MSBuildProjectName).%(Name).GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\Links\Enabled\GeneratedSwagger\swagger.g.json">
-      <Namespace>OpenApiNSwagEndToEndTests.Links.GeneratedCode</Namespace>
-      <ClassName>LinksClient</ClassName>
-      <OutputPath>LinksClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true</Options>
+      <Name>Links</Name>
+      <Namespace>$(MSBuildProjectName).%(Name).GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
     </OpenApiReference>
     <OpenApiReference Include="..\OpenApiTests\AtomicOperations\GeneratedSwagger\swagger.g.json">
-      <Namespace>OpenApiNSwagEndToEndTests.AtomicOperations.GeneratedCode</Namespace>
-      <ClassName>AtomicOperationsClient</ClassName>
-      <OutputPath>AtomicOperationsClient.cs</OutputPath>
-      <CodeGenerator>NSwagCSharp</CodeGenerator>
-      <Options>/ClientClassAccessModifier:internal /GenerateExceptionClasses:false /AdditionalNamespaceUsages:JsonApiDotNetCore.OpenApi.Client.NSwag /GenerateNullableReferenceTypes:true</Options>
+      <Name>AtomicOperations</Name>
+      <Namespace>$(MSBuildProjectName).%(Name).GeneratedCode</Namespace>
+      <ClassName>%(Name)Client</ClassName>
+      <OutputPath>%(ClassName).cs</OutputPath>
     </OpenApiReference>
   </ItemGroup>
 </Project>

--- a/test/OpenApiNSwagEndToEndTests/QueryStrings/FilterTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/QueryStrings/FilterTests.cs
@@ -48,13 +48,18 @@ public sealed class FilterTests : IClassFixture<IntegrationTestContext<OpenApiSt
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeCollectionAsync(queryString, null);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeCollectionAsync(queryString);
 
         // Assert
         response.Data.ShouldHaveCount(1);
         response.Data.ElementAt(0).Id.Should().Be(nodes[1].StringId);
-        response.Data.ElementAt(0).Attributes.Name.Should().Be(nodes[1].Name);
-        response.Data.ElementAt(0).Attributes.Comment.Should().Be(nodes[1].Comment);
+
+        response.Data.ElementAt(0).Attributes.ShouldNotBeNull().With(attributes =>
+        {
+            attributes.Name.Should().Be(nodes[1].Name);
+            attributes.Comment.Should().Be(nodes[1].Comment);
+        });
+
         response.Meta.ShouldNotBeNull();
         response.Meta.ShouldContainKey("total").With(total => total.Should().Be(1));
     }
@@ -84,13 +89,18 @@ public sealed class FilterTests : IClassFixture<IntegrationTestContext<OpenApiSt
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.StringId!, queryString, null);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.ShouldHaveCount(1);
         response.Data.ElementAt(0).Id.Should().Be(node.Children.ElementAt(1).StringId);
-        response.Data.ElementAt(0).Attributes.Name.Should().Be(node.Children.ElementAt(1).Name);
-        response.Data.ElementAt(0).Attributes.Comment.Should().Be(node.Children.ElementAt(1).Comment);
+
+        response.Data.ElementAt(0).Attributes.ShouldNotBeNull().With(attributes =>
+        {
+            attributes.Name.Should().Be(node.Children.ElementAt(1).Name);
+            attributes.Comment.Should().Be(node.Children.ElementAt(1).Comment);
+        });
+
         response.Meta.ShouldNotBeNull();
         response.Meta.ShouldContainKey("total").With(total => total.Should().Be(1));
     }
@@ -120,7 +130,7 @@ public sealed class FilterTests : IClassFixture<IntegrationTestContext<OpenApiSt
         };
 
         // Act
-        NodeIdentifierCollectionResponseDocument response = await apiClient.GetNodeChildrenRelationshipAsync(node.StringId!, queryString, null);
+        NodeIdentifierCollectionResponseDocument response = await apiClient.GetNodeChildrenRelationshipAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.ShouldHaveCount(1);
@@ -144,7 +154,7 @@ public sealed class FilterTests : IClassFixture<IntegrationTestContext<OpenApiSt
         };
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(Unknown.StringId.Int64, queryString, null);
+        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(Unknown.StringId.Int64, queryString);
 
         // Assert
         ApiException<ErrorResponseDocument> exception = (await action.Should().ThrowExactlyAsync<ApiException<ErrorResponseDocument>>()).Which;

--- a/test/OpenApiNSwagEndToEndTests/QueryStrings/IncludeTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/QueryStrings/IncludeTests.cs
@@ -46,7 +46,7 @@ public sealed class IncludeTests : IClassFixture<IntegrationTestContext<OpenApiS
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeCollectionAsync(queryString, null);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeCollectionAsync(queryString);
 
         // Assert
         response.Data.ShouldHaveCount(1);
@@ -85,7 +85,7 @@ public sealed class IncludeTests : IClassFixture<IntegrationTestContext<OpenApiS
         };
 
         // Act
-        NodePrimaryResponseDocument response = await apiClient.GetNodeAsync(node.StringId!, queryString, null);
+        NodePrimaryResponseDocument response = await apiClient.GetNodeAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Id.Should().Be(node.StringId);
@@ -126,7 +126,7 @@ public sealed class IncludeTests : IClassFixture<IntegrationTestContext<OpenApiS
         };
 
         // Act
-        NameValuePairCollectionResponseDocument response = await apiClient.GetNodeValuesAsync(node.StringId!, queryString, null);
+        NameValuePairCollectionResponseDocument response = await apiClient.GetNodeValuesAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.ShouldHaveCount(2);
@@ -160,7 +160,7 @@ public sealed class IncludeTests : IClassFixture<IntegrationTestContext<OpenApiS
         };
 
         // Act
-        NullableNodeSecondaryResponseDocument response = await apiClient.GetNodeParentAsync(node.StringId!, queryString, null);
+        NullableNodeSecondaryResponseDocument response = await apiClient.GetNodeParentAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.ShouldNotBeNull();
@@ -170,6 +170,7 @@ public sealed class IncludeTests : IClassFixture<IntegrationTestContext<OpenApiS
 
         NodeDataInResponse? include = response.Included.ElementAt(0).Should().BeOfType<NodeDataInResponse>().Subject;
         include.Id.Should().Be(node.Parent.Parent.StringId);
+        include.Attributes.ShouldNotBeNull();
         include.Attributes.Name.Should().Be(node.Parent.Parent.Name);
     }
 
@@ -194,7 +195,7 @@ public sealed class IncludeTests : IClassFixture<IntegrationTestContext<OpenApiS
         };
 
         // Act
-        NodePrimaryResponseDocument response = await apiClient.GetNodeAsync(node.StringId!, queryString, null);
+        NodePrimaryResponseDocument response = await apiClient.GetNodeAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Id.Should().Be(node.StringId);

--- a/test/OpenApiNSwagEndToEndTests/QueryStrings/PaginationTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/QueryStrings/PaginationTests.cs
@@ -47,7 +47,7 @@ public sealed class PaginationTests : IClassFixture<IntegrationTestContext<OpenA
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeCollectionAsync(queryString, null);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeCollectionAsync(queryString);
 
         // Assert
         response.Data.ShouldHaveCount(1);
@@ -80,7 +80,7 @@ public sealed class PaginationTests : IClassFixture<IntegrationTestContext<OpenA
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.StringId!, queryString, null);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.ShouldHaveCount(2);
@@ -114,7 +114,7 @@ public sealed class PaginationTests : IClassFixture<IntegrationTestContext<OpenA
         };
 
         // Act
-        NodeIdentifierCollectionResponseDocument response = await apiClient.GetNodeChildrenRelationshipAsync(node.StringId!, queryString, null);
+        NodeIdentifierCollectionResponseDocument response = await apiClient.GetNodeChildrenRelationshipAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.ShouldHaveCount(1);
@@ -136,7 +136,7 @@ public sealed class PaginationTests : IClassFixture<IntegrationTestContext<OpenA
         };
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(Unknown.StringId.Int64, queryString, null);
+        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(Unknown.StringId.Int64, queryString);
 
         // Assert
         ApiException<ErrorResponseDocument> exception = (await action.Should().ThrowExactlyAsync<ApiException<ErrorResponseDocument>>()).Which;
@@ -165,7 +165,7 @@ public sealed class PaginationTests : IClassFixture<IntegrationTestContext<OpenA
         };
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(Unknown.StringId.Int64, queryString, null);
+        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(Unknown.StringId.Int64, queryString);
 
         // Assert
         ApiException<ErrorResponseDocument> exception = (await action.Should().ThrowExactlyAsync<ApiException<ErrorResponseDocument>>()).Which;

--- a/test/OpenApiNSwagEndToEndTests/QueryStrings/SortTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/QueryStrings/SortTests.cs
@@ -48,7 +48,7 @@ public sealed class SortTests : IClassFixture<IntegrationTestContext<OpenApiStar
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeCollectionAsync(queryString, null);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeCollectionAsync(queryString);
 
         // Assert
         response.Data.ShouldHaveCount(2);
@@ -81,7 +81,7 @@ public sealed class SortTests : IClassFixture<IntegrationTestContext<OpenApiStar
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.StringId!, queryString, null);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.ShouldHaveCount(2);
@@ -114,7 +114,7 @@ public sealed class SortTests : IClassFixture<IntegrationTestContext<OpenApiStar
         };
 
         // Act
-        NodeIdentifierCollectionResponseDocument response = await apiClient.GetNodeChildrenRelationshipAsync(node.StringId!, queryString, null);
+        NodeIdentifierCollectionResponseDocument response = await apiClient.GetNodeChildrenRelationshipAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.ShouldHaveCount(2);
@@ -135,7 +135,7 @@ public sealed class SortTests : IClassFixture<IntegrationTestContext<OpenApiStar
         };
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(Unknown.StringId.Int64, queryString, null);
+        Func<Task> action = async () => _ = await apiClient.GetNodeAsync(Unknown.StringId.Int64, queryString);
 
         // Assert
         ApiException<ErrorResponseDocument> exception = (await action.Should().ThrowExactlyAsync<ApiException<ErrorResponseDocument>>()).Which;

--- a/test/OpenApiNSwagEndToEndTests/QueryStrings/SparseFieldSetTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/QueryStrings/SparseFieldSetTests.cs
@@ -45,13 +45,18 @@ public sealed class SparseFieldSetTests : IClassFixture<IntegrationTestContext<O
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeCollectionAsync(queryString, null);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeCollectionAsync(queryString);
 
         // Assert
         response.Data.ShouldHaveCount(1);
         response.Data.ElementAt(0).Id.Should().Be(node.StringId);
-        response.Data.ElementAt(0).Attributes.Name.Should().Be(node.Name);
-        response.Data.ElementAt(0).Attributes.Comment.Should().BeNull();
+
+        response.Data.ElementAt(0).Attributes.ShouldNotBeNull().With(attributes =>
+        {
+            attributes.Name.Should().Be(node.Name);
+            attributes.Comment.Should().BeNull();
+        });
+
         response.Data.ElementAt(0).Relationships.Should().BeNull();
     }
 
@@ -76,12 +81,14 @@ public sealed class SparseFieldSetTests : IClassFixture<IntegrationTestContext<O
         };
 
         // Act
-        NodePrimaryResponseDocument response = await apiClient.GetNodeAsync(node.StringId!, queryString, null);
+        NodePrimaryResponseDocument response = await apiClient.GetNodeAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Id.Should().Be(node.StringId);
+        response.Data.Attributes.ShouldNotBeNull();
         response.Data.Attributes.Name.Should().BeNull();
         response.Data.Attributes.Comment.Should().Be(node.Comment);
+        response.Data.Relationships.ShouldNotBeNull();
         response.Data.Relationships.Parent.ShouldNotBeNull();
         response.Data.Relationships.Children.Should().BeNull();
     }
@@ -109,15 +116,23 @@ public sealed class SparseFieldSetTests : IClassFixture<IntegrationTestContext<O
         };
 
         // Act
-        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.StringId!, queryString, null);
+        NodeCollectionResponseDocument response = await apiClient.GetNodeChildrenAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.ShouldHaveCount(1);
         response.Data.ElementAt(0).Id.Should().Be(node.Children.ElementAt(0).StringId);
-        response.Data.ElementAt(0).Attributes.Name.Should().BeNull();
-        response.Data.ElementAt(0).Attributes.Comment.Should().Be(node.Children.ElementAt(0).Comment);
-        response.Data.ElementAt(0).Relationships.Parent.Should().BeNull();
-        response.Data.ElementAt(0).Relationships.Children.ShouldNotBeNull();
+
+        response.Data.ElementAt(0).Attributes.ShouldNotBeNull().With(attributes =>
+        {
+            attributes.Name.Should().BeNull();
+            attributes.Comment.Should().Be(node.Children.ElementAt(0).Comment);
+        });
+
+        response.Data.ElementAt(0).Relationships.ShouldNotBeNull().With(relationships =>
+        {
+            relationships.Parent.Should().BeNull();
+            relationships.Children.ShouldNotBeNull();
+        });
     }
 
     [Fact]
@@ -142,13 +157,15 @@ public sealed class SparseFieldSetTests : IClassFixture<IntegrationTestContext<O
         };
 
         // Act
-        NullableNodeSecondaryResponseDocument response = await apiClient.GetNodeParentAsync(node.StringId!, queryString, null);
+        NullableNodeSecondaryResponseDocument response = await apiClient.GetNodeParentAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.ShouldNotBeNull();
         response.Data.Id.Should().Be(node.Parent.StringId);
+        response.Data.Attributes.ShouldNotBeNull();
         response.Data.Attributes.Name.Should().BeNull();
         response.Data.Attributes.Comment.Should().Be(node.Parent.Comment);
+        response.Data.Relationships.ShouldNotBeNull();
         response.Data.Relationships.Parent.Should().BeNull();
         response.Data.Relationships.Children.ShouldNotBeNull();
     }
@@ -174,7 +191,7 @@ public sealed class SparseFieldSetTests : IClassFixture<IntegrationTestContext<O
         };
 
         // Act
-        NodePrimaryResponseDocument response = await apiClient.GetNodeAsync(node.StringId!, queryString, null);
+        NodePrimaryResponseDocument response = await apiClient.GetNodeAsync(node.StringId!, queryString);
 
         // Assert
         response.Data.Id.Should().Be(node.StringId);

--- a/test/OpenApiNSwagEndToEndTests/RestrictedControllers/FetchRelationshipTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/RestrictedControllers/FetchRelationshipTests.cs
@@ -42,7 +42,7 @@ public sealed class FetchRelationshipTests : IClassFixture<IntegrationTestContex
         var apiClient = new RestrictedControllersClient(httpClient);
 
         // Act
-        DataStreamIdentifierResponseDocument response = await apiClient.GetReadOnlyChannelVideoStreamRelationshipAsync(channel.StringId!, null, null);
+        DataStreamIdentifierResponseDocument response = await apiClient.GetReadOnlyChannelVideoStreamRelationshipAsync(channel.StringId!);
 
         // Assert
         response.Data.ShouldNotBeNull();
@@ -67,7 +67,7 @@ public sealed class FetchRelationshipTests : IClassFixture<IntegrationTestContex
 
         // Act
         NullableDataStreamIdentifierResponseDocument response =
-            await apiClient.GetReadOnlyChannelUltraHighDefinitionVideoStreamRelationshipAsync(channel.StringId!, null, null);
+            await apiClient.GetReadOnlyChannelUltraHighDefinitionVideoStreamRelationshipAsync(channel.StringId!);
 
         // Assert
         response.Data.Should().BeNull();
@@ -91,8 +91,7 @@ public sealed class FetchRelationshipTests : IClassFixture<IntegrationTestContex
         var apiClient = new RestrictedControllersClient(httpClient);
 
         // Act
-        DataStreamIdentifierCollectionResponseDocument
-            response = await apiClient.GetReadOnlyChannelAudioStreamsRelationshipAsync(channel.StringId!, null, null);
+        DataStreamIdentifierCollectionResponseDocument response = await apiClient.GetReadOnlyChannelAudioStreamsRelationshipAsync(channel.StringId!);
 
         // Assert
         response.Data.ShouldHaveCount(2);
@@ -117,8 +116,7 @@ public sealed class FetchRelationshipTests : IClassFixture<IntegrationTestContex
         var apiClient = new RestrictedControllersClient(httpClient);
 
         // Act
-        DataStreamIdentifierCollectionResponseDocument
-            response = await apiClient.GetReadOnlyChannelAudioStreamsRelationshipAsync(channel.StringId!, null, null);
+        DataStreamIdentifierCollectionResponseDocument response = await apiClient.GetReadOnlyChannelAudioStreamsRelationshipAsync(channel.StringId!);
 
         // Assert
         response.Data.ShouldHaveCount(0);
@@ -134,7 +132,7 @@ public sealed class FetchRelationshipTests : IClassFixture<IntegrationTestContex
         var apiClient = new RestrictedControllersClient(httpClient);
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.GetReadOnlyChannelVideoStreamRelationshipAsync(unknownChannelId, null, null);
+        Func<Task> action = async () => _ = await apiClient.GetReadOnlyChannelVideoStreamRelationshipAsync(unknownChannelId);
 
         // Assert
         ApiException<ErrorResponseDocument> exception = (await action.Should().ThrowExactlyAsync<ApiException<ErrorResponseDocument>>()).Which;

--- a/test/OpenApiNSwagEndToEndTests/RestrictedControllers/FetchResourceTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/RestrictedControllers/FetchResourceTests.cs
@@ -43,25 +43,35 @@ public sealed class FetchResourceTests : IClassFixture<IntegrationTestContext<Op
         var apiClient = new RestrictedControllersClient(httpClient);
 
         // Act
-        ReadOnlyChannelCollectionResponseDocument response = await apiClient.GetReadOnlyChannelCollectionAsync(null, null);
+        ReadOnlyChannelCollectionResponseDocument response = await apiClient.GetReadOnlyChannelCollectionAsync();
 
         // Assert
         response.Data.ShouldHaveCount(2);
 
         ReadOnlyChannelDataInResponse channel1 = response.Data.Single(channel => channel.Id == channels.ElementAt(0).StringId);
+        channel1.Attributes.ShouldNotBeNull();
         channel1.Attributes.Name.Should().Be(channels[0].Name);
         channel1.Attributes.IsCommercial.Should().Be(channels[0].IsCommercial);
         channel1.Attributes.IsAdultOnly.Should().Be(channels[0].IsAdultOnly);
+        channel1.Relationships.ShouldNotBeNull();
+        channel1.Relationships.VideoStream.ShouldNotBeNull();
         channel1.Relationships.VideoStream.Data.Should().BeNull();
+        channel1.Relationships.UltraHighDefinitionVideoStream.ShouldNotBeNull();
         channel1.Relationships.UltraHighDefinitionVideoStream.Data.Should().BeNull();
+        channel1.Relationships.AudioStreams.ShouldNotBeNull();
         channel1.Relationships.AudioStreams.Data.Should().BeNull();
 
         ReadOnlyChannelDataInResponse channel2 = response.Data.Single(channel => channel.Id == channels.ElementAt(1).StringId);
+        channel2.Attributes.ShouldNotBeNull();
         channel2.Attributes.Name.Should().Be(channels[1].Name);
         channel2.Attributes.IsCommercial.Should().Be(channels[1].IsCommercial);
         channel2.Attributes.IsAdultOnly.Should().Be(channels[1].IsAdultOnly);
+        channel2.Relationships.ShouldNotBeNull();
+        channel2.Relationships.VideoStream.ShouldNotBeNull();
         channel2.Relationships.VideoStream.Data.Should().BeNull();
+        channel2.Relationships.UltraHighDefinitionVideoStream.ShouldNotBeNull();
         channel2.Relationships.UltraHighDefinitionVideoStream.Data.Should().BeNull();
+        channel2.Relationships.AudioStreams.ShouldNotBeNull();
         channel2.Relationships.AudioStreams.Data.Should().BeNull();
     }
 
@@ -82,16 +92,21 @@ public sealed class FetchResourceTests : IClassFixture<IntegrationTestContext<Op
         var apiClient = new RestrictedControllersClient(httpClient);
 
         // Act
-        ReadOnlyChannelPrimaryResponseDocument response = await apiClient.GetReadOnlyChannelAsync(channel.StringId!, null, null);
+        ReadOnlyChannelPrimaryResponseDocument response = await apiClient.GetReadOnlyChannelAsync(channel.StringId!);
 
         // Assert
         response.Data.ShouldNotBeNull();
         response.Data.Id.Should().Be(channel.StringId);
+        response.Data.Attributes.ShouldNotBeNull();
         response.Data.Attributes.Name.Should().Be(channel.Name);
         response.Data.Attributes.IsCommercial.Should().Be(channel.IsCommercial);
         response.Data.Attributes.IsAdultOnly.Should().Be(channel.IsAdultOnly);
+        response.Data.Relationships.ShouldNotBeNull();
+        response.Data.Relationships.VideoStream.ShouldNotBeNull();
         response.Data.Relationships.VideoStream.Data.Should().BeNull();
+        response.Data.Relationships.UltraHighDefinitionVideoStream.ShouldNotBeNull();
         response.Data.Relationships.UltraHighDefinitionVideoStream.Data.Should().BeNull();
+        response.Data.Relationships.AudioStreams.ShouldNotBeNull();
         response.Data.Relationships.AudioStreams.Data.Should().BeNull();
     }
 
@@ -105,7 +120,7 @@ public sealed class FetchResourceTests : IClassFixture<IntegrationTestContext<Op
         var apiClient = new RestrictedControllersClient(httpClient);
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.GetReadOnlyChannelAsync(unknownChannelId, null, null);
+        Func<Task> action = async () => _ = await apiClient.GetReadOnlyChannelAsync(unknownChannelId);
 
         // Assert
         ApiException<ErrorResponseDocument> exception = (await action.Should().ThrowExactlyAsync<ApiException<ErrorResponseDocument>>()).Which;
@@ -136,11 +151,12 @@ public sealed class FetchResourceTests : IClassFixture<IntegrationTestContext<Op
         var apiClient = new RestrictedControllersClient(httpClient);
 
         // Act
-        DataStreamSecondaryResponseDocument response = await apiClient.GetReadOnlyChannelVideoStreamAsync(channel.StringId!, null, null);
+        DataStreamSecondaryResponseDocument response = await apiClient.GetReadOnlyChannelVideoStreamAsync(channel.StringId!);
 
         // Assert
         response.Data.ShouldNotBeNull();
         response.Data.Id.Should().Be(channel.VideoStream.StringId);
+        response.Data.Attributes.ShouldNotBeNull();
         response.Data.Attributes.BytesTransmitted.Should().Be((long?)channel.VideoStream.BytesTransmitted);
     }
 
@@ -161,8 +177,7 @@ public sealed class FetchResourceTests : IClassFixture<IntegrationTestContext<Op
         var apiClient = new RestrictedControllersClient(httpClient);
 
         // Act
-        NullableDataStreamSecondaryResponseDocument response =
-            await apiClient.GetReadOnlyChannelUltraHighDefinitionVideoStreamAsync(channel.StringId!, null, null);
+        NullableDataStreamSecondaryResponseDocument response = await apiClient.GetReadOnlyChannelUltraHighDefinitionVideoStreamAsync(channel.StringId!);
 
         // Assert
         response.Data.Should().BeNull();
@@ -186,15 +201,17 @@ public sealed class FetchResourceTests : IClassFixture<IntegrationTestContext<Op
         var apiClient = new RestrictedControllersClient(httpClient);
 
         // Act
-        DataStreamCollectionResponseDocument response = await apiClient.GetReadOnlyChannelAudioStreamsAsync(channel.StringId!, null, null);
+        DataStreamCollectionResponseDocument response = await apiClient.GetReadOnlyChannelAudioStreamsAsync(channel.StringId!);
 
         // Assert
         response.Data.ShouldHaveCount(2);
 
         DataStreamDataInResponse audioStream1 = response.Data.Single(autoStream => autoStream.Id == channel.AudioStreams.ElementAt(0).StringId);
+        audioStream1.Attributes.ShouldNotBeNull();
         audioStream1.Attributes.BytesTransmitted.Should().Be((long?)channel.AudioStreams.ElementAt(0).BytesTransmitted);
 
         DataStreamDataInResponse audioStream2 = response.Data.Single(autoStream => autoStream.Id == channel.AudioStreams.ElementAt(1).StringId);
+        audioStream2.Attributes.ShouldNotBeNull();
         audioStream2.Attributes.BytesTransmitted.Should().Be((long?)channel.AudioStreams.ElementAt(1).BytesTransmitted);
     }
 
@@ -215,7 +232,7 @@ public sealed class FetchResourceTests : IClassFixture<IntegrationTestContext<Op
         var apiClient = new RestrictedControllersClient(httpClient);
 
         // Act
-        DataStreamCollectionResponseDocument response = await apiClient.GetReadOnlyChannelAudioStreamsAsync(channel.StringId!, null, null);
+        DataStreamCollectionResponseDocument response = await apiClient.GetReadOnlyChannelAudioStreamsAsync(channel.StringId!);
 
         // Assert
         response.Data.ShouldHaveCount(0);
@@ -231,7 +248,7 @@ public sealed class FetchResourceTests : IClassFixture<IntegrationTestContext<Op
         var apiClient = new RestrictedControllersClient(httpClient);
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.GetReadOnlyChannelVideoStreamAsync(unknownChannelId, null, null);
+        Func<Task> action = async () => _ = await apiClient.GetReadOnlyChannelVideoStreamAsync(unknownChannelId);
 
         // Assert
         ApiException<ErrorResponseDocument> exception = (await action.Should().ThrowExactlyAsync<ApiException<ErrorResponseDocument>>()).Which;

--- a/test/OpenApiNSwagEndToEndTests/RestrictedControllers/UpdateResourceTests.cs
+++ b/test/OpenApiNSwagEndToEndTests/RestrictedControllers/UpdateResourceTests.cs
@@ -91,16 +91,21 @@ public sealed class UpdateResourceTests : IClassFixture<IntegrationTestContext<O
 
         // Act
         WriteOnlyChannelPrimaryResponseDocument? response = await ApiResponse.TranslateAsync(async () =>
-            await apiClient.PatchWriteOnlyChannelAsync(existingChannel.StringId!, queryString, requestBody));
+            await apiClient.PatchWriteOnlyChannelAsync(existingChannel.StringId!, requestBody, queryString));
 
         response.ShouldNotBeNull();
 
         response.Data.Id.Should().Be(existingChannel.StringId);
+        response.Data.Attributes.ShouldNotBeNull();
         response.Data.Attributes.Name.Should().Be(newChannelName);
         response.Data.Attributes.IsCommercial.Should().Be(existingChannel.IsCommercial);
         response.Data.Attributes.IsAdultOnly.Should().BeNull();
+        response.Data.Relationships.ShouldNotBeNull();
+        response.Data.Relationships.VideoStream.ShouldNotBeNull();
+        response.Data.Relationships.VideoStream.Data.ShouldNotBeNull();
         response.Data.Relationships.VideoStream.Data.Id.Should().Be(existingVideoStream.StringId);
         response.Data.Relationships.UltraHighDefinitionVideoStream.Should().BeNull();
+        response.Data.Relationships.AudioStreams.ShouldNotBeNull();
         response.Data.Relationships.AudioStreams.Data.Should().BeEmpty();
 
         response.Included.ShouldHaveCount(1);
@@ -165,16 +170,21 @@ public sealed class UpdateResourceTests : IClassFixture<IntegrationTestContext<O
 
         // Act
         WriteOnlyChannelPrimaryResponseDocument? response =
-            await ApiResponse.TranslateAsync(async () => await apiClient.PatchWriteOnlyChannelAsync(existingChannel.StringId!, null, requestBody));
+            await ApiResponse.TranslateAsync(async () => await apiClient.PatchWriteOnlyChannelAsync(existingChannel.StringId!, requestBody));
 
         response.ShouldNotBeNull();
 
         response.Data.Id.Should().Be(existingChannel.StringId);
+        response.Data.Attributes.ShouldNotBeNull();
         response.Data.Attributes.Name.Should().Be(existingChannel.Name);
         response.Data.Attributes.IsCommercial.Should().Be(existingChannel.IsCommercial);
         response.Data.Attributes.IsAdultOnly.Should().Be(existingChannel.IsAdultOnly);
+        response.Data.Relationships.ShouldNotBeNull();
+        response.Data.Relationships.VideoStream.ShouldNotBeNull();
         response.Data.Relationships.VideoStream.Data.Should().BeNull();
+        response.Data.Relationships.UltraHighDefinitionVideoStream.ShouldNotBeNull();
         response.Data.Relationships.UltraHighDefinitionVideoStream.Data.Should().BeNull();
+        response.Data.Relationships.AudioStreams.ShouldNotBeNull();
         response.Data.Relationships.AudioStreams.Data.Should().BeNull();
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
@@ -224,7 +234,7 @@ public sealed class UpdateResourceTests : IClassFixture<IntegrationTestContext<O
         UpdateWriteOnlyChannelRequestDocument requestBody = null!;
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.PatchWriteOnlyChannelAsync(existingChannel.StringId!, null, requestBody);
+        Func<Task> action = async () => _ = await apiClient.PatchWriteOnlyChannelAsync(existingChannel.StringId!, requestBody);
 
         // Assert
         await action.Should().ThrowExactlyAsync<ArgumentNullException>().WithParameterName("body");
@@ -277,7 +287,7 @@ public sealed class UpdateResourceTests : IClassFixture<IntegrationTestContext<O
         };
 
         // Act
-        Func<Task> action = async () => _ = await apiClient.PatchWriteOnlyChannelAsync(existingChannel.StringId!, null, requestBody);
+        Func<Task> action = async () => _ = await apiClient.PatchWriteOnlyChannelAsync(existingChannel.StringId!, requestBody);
 
         // Assert
         ApiException<ErrorResponseDocument> exception = (await action.Should().ThrowExactlyAsync<ApiException<ErrorResponseDocument>>()).Which;


### PR DESCRIPTION
This PR updates to NSwag v14.1, which has a slightly different way of registering our partial PATCH support.
Thanks to the introduction of NSwag-specific MSBuild properties, we now distribute the required and recommended settings from our NuGet package.

> [!NOTE]
> Don't use `<Options>` in `<OpenApiReference>` anymore, they tend to conflict with the MSBuild properties.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [x] Documentation updated
