### PR TITLE
Update formatting rules to place call to base in primary constructor on separate line

### DIFF
--- a/JsonApiDotNetCore.sln.DotSettings
+++ b/JsonApiDotNetCore.sln.DotSettings
@@ -137,6 +137,7 @@ JsonApiDotNetCore.ArgumentGuard.NotNull($EXPR$);</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_PRIMARY_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ACCESSOR_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ANONYMOUSMETHOD_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_EMBEDDED_STATEMENT_ON_SAME_LINE/@EntryValue">NEVER</s:String>

--- a/src/Examples/DapperExample/Controllers/OperationsController.cs
+++ b/src/Examples/DapperExample/Controllers/OperationsController.cs
@@ -8,5 +8,5 @@ namespace DapperExample.Controllers;
 
 public sealed class OperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor,
-    request, targetedFields, operationFilter);
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter)
+    : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields, operationFilter);

--- a/src/Examples/DapperExample/TranslationToSql/Builders/DeleteOneToOneStatementBuilder.cs
+++ b/src/Examples/DapperExample/TranslationToSql/Builders/DeleteOneToOneStatementBuilder.cs
@@ -6,7 +6,8 @@ using JsonApiDotNetCore.Queries.Expressions;
 
 namespace DapperExample.TranslationToSql.Builders;
 
-internal sealed class DeleteOneToOneStatementBuilder(IDataModelService dataModelService) : StatementBuilder(dataModelService)
+internal sealed class DeleteOneToOneStatementBuilder(IDataModelService dataModelService)
+    : StatementBuilder(dataModelService)
 {
     public DeleteNode Build(ResourceType resourceType, string whereColumnName, object? whereValue)
     {

--- a/src/Examples/DapperExample/TranslationToSql/Builders/DeleteResourceStatementBuilder.cs
+++ b/src/Examples/DapperExample/TranslationToSql/Builders/DeleteResourceStatementBuilder.cs
@@ -7,7 +7,8 @@ using JsonApiDotNetCore.Queries.Expressions;
 
 namespace DapperExample.TranslationToSql.Builders;
 
-internal sealed class DeleteResourceStatementBuilder(IDataModelService dataModelService) : StatementBuilder(dataModelService)
+internal sealed class DeleteResourceStatementBuilder(IDataModelService dataModelService)
+    : StatementBuilder(dataModelService)
 {
     public DeleteNode Build(ResourceType resourceType, params object[] idValues)
     {

--- a/src/Examples/DapperExample/TranslationToSql/Builders/InsertStatementBuilder.cs
+++ b/src/Examples/DapperExample/TranslationToSql/Builders/InsertStatementBuilder.cs
@@ -7,7 +7,8 @@ using JsonApiDotNetCore.Resources;
 
 namespace DapperExample.TranslationToSql.Builders;
 
-internal sealed class InsertStatementBuilder(IDataModelService dataModelService) : StatementBuilder(dataModelService)
+internal sealed class InsertStatementBuilder(IDataModelService dataModelService)
+    : StatementBuilder(dataModelService)
 {
     public InsertNode Build(ResourceType resourceType, IReadOnlyDictionary<string, object?> columnsToSet)
     {

--- a/src/Examples/DapperExample/TranslationToSql/Builders/UpdateClearOneToOneStatementBuilder.cs
+++ b/src/Examples/DapperExample/TranslationToSql/Builders/UpdateClearOneToOneStatementBuilder.cs
@@ -6,7 +6,8 @@ using JsonApiDotNetCore.Queries.Expressions;
 
 namespace DapperExample.TranslationToSql.Builders;
 
-internal sealed class UpdateClearOneToOneStatementBuilder(IDataModelService dataModelService) : StatementBuilder(dataModelService)
+internal sealed class UpdateClearOneToOneStatementBuilder(IDataModelService dataModelService)
+    : StatementBuilder(dataModelService)
 {
     public UpdateNode Build(ResourceType resourceType, string setColumnName, string whereColumnName, object? whereValue)
     {

--- a/src/Examples/DapperExample/TranslationToSql/Builders/UpdateResourceStatementBuilder.cs
+++ b/src/Examples/DapperExample/TranslationToSql/Builders/UpdateResourceStatementBuilder.cs
@@ -7,7 +7,8 @@ using JsonApiDotNetCore.Queries.Expressions;
 
 namespace DapperExample.TranslationToSql.Builders;
 
-internal sealed class UpdateResourceStatementBuilder(IDataModelService dataModelService) : StatementBuilder(dataModelService)
+internal sealed class UpdateResourceStatementBuilder(IDataModelService dataModelService)
+    : StatementBuilder(dataModelService)
 {
     public UpdateNode Build(ResourceType resourceType, IReadOnlyDictionary<string, object?> columnsToUpdate, params object[] idValues)
     {

--- a/src/Examples/DapperExample/TranslationToSql/DataModel/FromEntitiesDataModelService.cs
+++ b/src/Examples/DapperExample/TranslationToSql/DataModel/FromEntitiesDataModelService.cs
@@ -12,7 +12,8 @@ namespace DapperExample.TranslationToSql.DataModel;
 /// <summary>
 /// Derives foreign keys and connection strings from an existing Entity Framework Core model.
 /// </summary>
-public sealed class FromEntitiesDataModelService(IResourceGraph resourceGraph) : BaseDataModelService(resourceGraph)
+public sealed class FromEntitiesDataModelService(IResourceGraph resourceGraph)
+    : BaseDataModelService(resourceGraph)
 {
     private readonly Dictionary<RelationshipAttribute, RelationshipForeignKey> _foreignKeysByRelationship = [];
     private readonly Dictionary<AttrAttribute, bool> _columnNullabilityPerAttribute = [];

--- a/src/Examples/DapperExample/TranslationToSql/Generators/ParameterGenerator.cs
+++ b/src/Examples/DapperExample/TranslationToSql/Generators/ParameterGenerator.cs
@@ -20,5 +20,6 @@ internal sealed class ParameterGenerator
         _nameGenerator.Reset();
     }
 
-    private sealed class ParameterNameGenerator() : UniqueNameGenerator("@p");
+    private sealed class ParameterNameGenerator()
+        : UniqueNameGenerator("@p");
 }

--- a/src/Examples/DapperExample/TranslationToSql/Generators/TableAliasGenerator.cs
+++ b/src/Examples/DapperExample/TranslationToSql/Generators/TableAliasGenerator.cs
@@ -3,4 +3,5 @@ namespace DapperExample.TranslationToSql.Generators;
 /// <summary>
 /// Generates a SQL table alias with a unique name.
 /// </summary>
-internal sealed class TableAliasGenerator() : UniqueNameGenerator("t");
+internal sealed class TableAliasGenerator()
+    : UniqueNameGenerator("t");

--- a/src/Examples/DapperExample/TranslationToSql/TreeNodes/ColumnInSelectNode.cs
+++ b/src/Examples/DapperExample/TranslationToSql/TreeNodes/ColumnInSelectNode.cs
@@ -10,8 +10,8 @@ namespace DapperExample.TranslationToSql.TreeNodes;
 /// SELECT t2.Id AS Id0 FROM (SELECT t1.Id FROM Users AS t1) AS t2
 /// ]]></code>.
 /// </summary>
-internal sealed class ColumnInSelectNode(ColumnSelectorNode selector, string? tableAlias) : ColumnNode(GetColumnName(selector), selector.Column.Type,
-    tableAlias)
+internal sealed class ColumnInSelectNode(ColumnSelectorNode selector, string? tableAlias)
+    : ColumnNode(GetColumnName(selector), selector.Column.Type, tableAlias)
 {
     public ColumnSelectorNode Selector { get; } = selector;
 

--- a/src/Examples/DapperExample/TranslationToSql/TreeNodes/ColumnInTableNode.cs
+++ b/src/Examples/DapperExample/TranslationToSql/TreeNodes/ColumnInTableNode.cs
@@ -8,7 +8,8 @@ namespace DapperExample.TranslationToSql.TreeNodes;
 /// FROM Users AS t1
 /// ]]></code>.
 /// </summary>
-internal sealed class ColumnInTableNode(string name, ColumnType type, string? tableAlias) : ColumnNode(name, type, tableAlias)
+internal sealed class ColumnInTableNode(string name, ColumnType type, string? tableAlias)
+    : ColumnNode(name, type, tableAlias)
 {
     public override TResult Accept<TArgument, TResult>(SqlTreeNodeVisitor<TArgument, TResult> visitor, TArgument argument)
     {

--- a/src/Examples/DapperExample/TranslationToSql/TreeNodes/CountSelectorNode.cs
+++ b/src/Examples/DapperExample/TranslationToSql/TreeNodes/CountSelectorNode.cs
@@ -8,7 +8,8 @@ namespace DapperExample.TranslationToSql.TreeNodes;
 /// SELECT COUNT(*) FROM Users
 /// ]]></code>.
 /// </summary>
-internal sealed class CountSelectorNode(string? alias) : SelectorNode(alias)
+internal sealed class CountSelectorNode(string? alias)
+    : SelectorNode(alias)
 {
     public override TResult Accept<TArgument, TResult>(SqlTreeNodeVisitor<TArgument, TResult> visitor, TArgument argument)
     {

--- a/src/Examples/DapperExample/TranslationToSql/TreeNodes/FromNode.cs
+++ b/src/Examples/DapperExample/TranslationToSql/TreeNodes/FromNode.cs
@@ -5,7 +5,8 @@ namespace DapperExample.TranslationToSql.TreeNodes;
 /// FROM Customers AS t1
 /// ]]></code>.
 /// </summary>
-internal sealed class FromNode(TableSourceNode source) : TableAccessorNode(source)
+internal sealed class FromNode(TableSourceNode source)
+    : TableAccessorNode(source)
 {
     public override TResult Accept<TArgument, TResult>(SqlTreeNodeVisitor<TArgument, TResult> visitor, TArgument argument)
     {

--- a/src/Examples/DapperExample/TranslationToSql/TreeNodes/OneSelectorNode.cs
+++ b/src/Examples/DapperExample/TranslationToSql/TreeNodes/OneSelectorNode.cs
@@ -8,7 +8,8 @@ namespace DapperExample.TranslationToSql.TreeNodes;
 /// SELECT 1 FROM Users
 /// ]]></code>.
 /// </summary>
-internal sealed class OneSelectorNode(string? alias) : SelectorNode(alias)
+internal sealed class OneSelectorNode(string? alias)
+    : SelectorNode(alias)
 {
     public override TResult Accept<TArgument, TResult>(SqlTreeNodeVisitor<TArgument, TResult> visitor, TArgument argument)
     {

--- a/src/Examples/GettingStarted/Data/SampleDbContext.cs
+++ b/src/Examples/GettingStarted/Data/SampleDbContext.cs
@@ -5,7 +5,8 @@ using Microsoft.EntityFrameworkCore;
 namespace GettingStarted.Data;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public class SampleDbContext(DbContextOptions<SampleDbContext> options) : DbContext(options)
+public class SampleDbContext(DbContextOptions<SampleDbContext> options)
+    : DbContext(options)
 {
     public DbSet<Book> Books => Set<Book>();
 }

--- a/src/Examples/JsonApiDotNetCoreExample/Controllers/OperationsController.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Controllers/OperationsController.cs
@@ -8,5 +8,5 @@ namespace JsonApiDotNetCoreExample.Controllers;
 
 public sealed class OperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor,
-    request, targetedFields, operationFilter);
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter)
+    : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields, operationFilter);

--- a/src/Examples/JsonApiDotNetCoreExample/Data/AppDbContext.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Data/AppDbContext.cs
@@ -8,7 +8,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 namespace JsonApiDotNetCoreExample.Data;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
+    : DbContext(options)
 {
     public DbSet<TodoItem> TodoItems => Set<TodoItem>();
 

--- a/src/Examples/JsonApiDotNetCoreExample/Definitions/TodoItemDefinition.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/Definitions/TodoItemDefinition.cs
@@ -19,7 +19,8 @@ public sealed class TodoItemDefinition(
 #else
     TimeProvider timeProvider
 #endif
-) : JsonApiResourceDefinition<TodoItem, long>(resourceGraph)
+)
+    : JsonApiResourceDefinition<TodoItem, long>(resourceGraph)
 {
 #if NET6_0
     private readonly Func<DateTimeOffset> _getUtcNow = () => systemClock.UtcNow;

--- a/src/Examples/MultiDbContextExample/Data/DbContextA.cs
+++ b/src/Examples/MultiDbContextExample/Data/DbContextA.cs
@@ -5,7 +5,8 @@ using MultiDbContextExample.Models;
 namespace MultiDbContextExample.Data;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class DbContextA(DbContextOptions<DbContextA> options) : DbContext(options)
+public sealed class DbContextA(DbContextOptions<DbContextA> options)
+    : DbContext(options)
 {
     public DbSet<ResourceA> ResourceAs => Set<ResourceA>();
 }

--- a/src/Examples/MultiDbContextExample/Data/DbContextB.cs
+++ b/src/Examples/MultiDbContextExample/Data/DbContextB.cs
@@ -5,7 +5,8 @@ using MultiDbContextExample.Models;
 namespace MultiDbContextExample.Data;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class DbContextB(DbContextOptions<DbContextB> options) : DbContext(options)
+public sealed class DbContextB(DbContextOptions<DbContextB> options)
+    : DbContext(options)
 {
     public DbSet<ResourceB> ResourceBs => Set<ResourceB>();
 }

--- a/src/JsonApiDotNetCore/Controllers/JsonApiOperationsController.cs
+++ b/src/JsonApiDotNetCore/Controllers/JsonApiOperationsController.cs
@@ -14,8 +14,8 @@ namespace JsonApiDotNetCore.Controllers;
 /// </summary>
 public abstract class JsonApiOperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter) : BaseJsonApiOperationsController(options, resourceGraph, loggerFactory, processor,
-    request, targetedFields, operationFilter)
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter)
+    : BaseJsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields, operationFilter)
 {
     /// <inheritdoc />
     [HttpPost]

--- a/src/JsonApiDotNetCore/Errors/CannotClearRequiredRelationshipException.cs
+++ b/src/JsonApiDotNetCore/Errors/CannotClearRequiredRelationshipException.cs
@@ -8,8 +8,8 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when a required relationship is cleared.
 /// </summary>
 [PublicAPI]
-public sealed class CannotClearRequiredRelationshipException(string relationshipName, string resourceType) : JsonApiException(
-    new ErrorObject(HttpStatusCode.BadRequest)
+public sealed class CannotClearRequiredRelationshipException(string relationshipName, string resourceType)
+    : JsonApiException(new ErrorObject(HttpStatusCode.BadRequest)
     {
         Title = "Failed to clear a required relationship.",
         Detail = $"The relationship '{relationshipName}' on resource type '{resourceType}' cannot be cleared because it is a required relationship."

--- a/src/JsonApiDotNetCore/Errors/DuplicateLocalIdValueException.cs
+++ b/src/JsonApiDotNetCore/Errors/DuplicateLocalIdValueException.cs
@@ -8,8 +8,9 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when assigning a local ID that was already assigned in an earlier operation.
 /// </summary>
 [PublicAPI]
-public sealed class DuplicateLocalIdValueException(string localId) : JsonApiException(new ErrorObject(HttpStatusCode.BadRequest)
-{
-    Title = "Another local ID with the same name is already defined at this point.",
-    Detail = $"Another local ID with name '{localId}' is already defined at this point."
-});
+public sealed class DuplicateLocalIdValueException(string localId)
+    : JsonApiException(new ErrorObject(HttpStatusCode.BadRequest)
+    {
+        Title = "Another local ID with the same name is already defined at this point.",
+        Detail = $"Another local ID with name '{localId}' is already defined at this point."
+    });

--- a/src/JsonApiDotNetCore/Errors/FailedOperationException.cs
+++ b/src/JsonApiDotNetCore/Errors/FailedOperationException.cs
@@ -8,8 +8,8 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when an operation in an atomic:operations request failed to be processed for unknown reasons.
 /// </summary>
 [PublicAPI]
-public sealed class FailedOperationException(int operationIndex, Exception innerException) : JsonApiException(
-    new ErrorObject(HttpStatusCode.InternalServerError)
+public sealed class FailedOperationException(int operationIndex, Exception innerException)
+    : JsonApiException(new ErrorObject(HttpStatusCode.InternalServerError)
     {
         Title = "An unhandled error occurred while processing an operation in this request.",
         Detail = innerException.Message,

--- a/src/JsonApiDotNetCore/Errors/IncompatibleLocalIdTypeException.cs
+++ b/src/JsonApiDotNetCore/Errors/IncompatibleLocalIdTypeException.cs
@@ -8,8 +8,8 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when referencing a local ID that was assigned to a different resource type.
 /// </summary>
 [PublicAPI]
-public sealed class IncompatibleLocalIdTypeException(string localId, string declaredType, string currentType) : JsonApiException(
-    new ErrorObject(HttpStatusCode.BadRequest)
+public sealed class IncompatibleLocalIdTypeException(string localId, string declaredType, string currentType)
+    : JsonApiException(new ErrorObject(HttpStatusCode.BadRequest)
     {
         Title = "Incompatible type in Local ID usage.",
         Detail = $"Local ID '{localId}' belongs to resource type '{declaredType}' instead of '{currentType}'."

--- a/src/JsonApiDotNetCore/Errors/InvalidConfigurationException.cs
+++ b/src/JsonApiDotNetCore/Errors/InvalidConfigurationException.cs
@@ -6,4 +6,5 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when configured usage of this library is invalid.
 /// </summary>
 [PublicAPI]
-public sealed class InvalidConfigurationException(string message, Exception? innerException = null) : Exception(message, innerException);
+public sealed class InvalidConfigurationException(string message, Exception? innerException = null)
+    : Exception(message, innerException);

--- a/src/JsonApiDotNetCore/Errors/InvalidModelStateException.cs
+++ b/src/JsonApiDotNetCore/Errors/InvalidModelStateException.cs
@@ -17,8 +17,8 @@ namespace JsonApiDotNetCore.Errors;
 [PublicAPI]
 public sealed class InvalidModelStateException(
     IReadOnlyDictionary<string, ModelStateEntry?> modelState, Type modelType, bool includeExceptionStackTraceInErrors, IResourceGraph resourceGraph,
-    Func<Type, int, Type?>? getCollectionElementTypeCallback = null) : JsonApiException(FromModelStateDictionary(modelState, modelType, resourceGraph,
-    includeExceptionStackTraceInErrors, getCollectionElementTypeCallback))
+    Func<Type, int, Type?>? getCollectionElementTypeCallback = null)
+    : JsonApiException(FromModelStateDictionary(modelState, modelType, resourceGraph, includeExceptionStackTraceInErrors, getCollectionElementTypeCallback))
 {
     private static List<ErrorObject> FromModelStateDictionary(IReadOnlyDictionary<string, ModelStateEntry?> modelState, Type modelType,
         IResourceGraph resourceGraph, bool includeExceptionStackTraceInErrors, Func<Type, int, Type?>? getCollectionElementTypeCallback)
@@ -316,8 +316,8 @@ public sealed class InvalidModelStateException(
     /// </summary>
     private sealed class ArrayIndexerSegment(
         int arrayIndex, Type modelType, bool isInComplexType, string nextKey, string? sourcePointer, ModelStateKeySegment? parent,
-        Func<Type, int, Type?>? getCollectionElementTypeCallback) : ModelStateKeySegment(modelType, isInComplexType, nextKey, sourcePointer, parent,
-        getCollectionElementTypeCallback)
+        Func<Type, int, Type?>? getCollectionElementTypeCallback)
+        : ModelStateKeySegment(modelType, isInComplexType, nextKey, sourcePointer, parent, getCollectionElementTypeCallback)
     {
         private static readonly CollectionConverter CollectionConverter = new();
 

--- a/src/JsonApiDotNetCore/Errors/InvalidQueryException.cs
+++ b/src/JsonApiDotNetCore/Errors/InvalidQueryException.cs
@@ -9,8 +9,9 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when translating a <see cref="QueryLayer" /> to Entity Framework Core fails.
 /// </summary>
 [PublicAPI]
-public sealed class InvalidQueryException(string reason, Exception? innerException) : JsonApiException(new ErrorObject(HttpStatusCode.BadRequest)
-{
-    Title = reason,
-    Detail = innerException?.Message
-}, innerException);
+public sealed class InvalidQueryException(string reason, Exception? innerException)
+    : JsonApiException(new ErrorObject(HttpStatusCode.BadRequest)
+    {
+        Title = reason,
+        Detail = innerException?.Message
+    }, innerException);

--- a/src/JsonApiDotNetCore/Errors/InvalidRequestBodyException.cs
+++ b/src/JsonApiDotNetCore/Errors/InvalidRequestBodyException.cs
@@ -12,20 +12,21 @@ namespace JsonApiDotNetCore.Errors;
 [PublicAPI]
 public sealed class InvalidRequestBodyException(
     string? requestBody, string? genericMessage, string? specificMessage, string? sourcePointer, HttpStatusCode? alternativeStatusCode = null,
-    Exception? innerException = null) : JsonApiException(new ErrorObject(alternativeStatusCode ?? HttpStatusCode.UnprocessableEntity)
-{
-    Title = genericMessage != null ? $"Failed to deserialize request body: {genericMessage}" : "Failed to deserialize request body.",
-    Detail = specificMessage,
-    Source = sourcePointer == null
-        ? null
-        : new ErrorSource
-        {
-            Pointer = sourcePointer
-        },
-    Meta = string.IsNullOrEmpty(requestBody)
-        ? null
-        : new Dictionary<string, object?>
-        {
-            ["RequestBody"] = requestBody
-        }
-}, innerException);
+    Exception? innerException = null)
+    : JsonApiException(new ErrorObject(alternativeStatusCode ?? HttpStatusCode.UnprocessableEntity)
+    {
+        Title = genericMessage != null ? $"Failed to deserialize request body: {genericMessage}" : "Failed to deserialize request body.",
+        Detail = specificMessage,
+        Source = sourcePointer == null
+            ? null
+            : new ErrorSource
+            {
+                Pointer = sourcePointer
+            },
+        Meta = string.IsNullOrEmpty(requestBody)
+            ? null
+            : new Dictionary<string, object?>
+            {
+                ["RequestBody"] = requestBody
+            }
+    }, innerException);

--- a/src/JsonApiDotNetCore/Errors/LocalIdSingleOperationException.cs
+++ b/src/JsonApiDotNetCore/Errors/LocalIdSingleOperationException.cs
@@ -8,8 +8,9 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when assigning and referencing a local ID within the same operation.
 /// </summary>
 [PublicAPI]
-public sealed class LocalIdSingleOperationException(string localId) : JsonApiException(new ErrorObject(HttpStatusCode.BadRequest)
-{
-    Title = "Local ID cannot be both defined and used within the same operation.",
-    Detail = $"Local ID '{localId}' cannot be both defined and used within the same operation."
-});
+public sealed class LocalIdSingleOperationException(string localId)
+    : JsonApiException(new ErrorObject(HttpStatusCode.BadRequest)
+    {
+        Title = "Local ID cannot be both defined and used within the same operation.",
+        Detail = $"Local ID '{localId}' cannot be both defined and used within the same operation."
+    });

--- a/src/JsonApiDotNetCore/Errors/MissingTransactionSupportException.cs
+++ b/src/JsonApiDotNetCore/Errors/MissingTransactionSupportException.cs
@@ -8,8 +8,9 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when accessing a repository that does not support transactions during an atomic:operations request.
 /// </summary>
 [PublicAPI]
-public sealed class MissingTransactionSupportException(string resourceType) : JsonApiException(new ErrorObject(HttpStatusCode.UnprocessableEntity)
-{
-    Title = "Unsupported resource type in atomic:operations request.",
-    Detail = $"Operations on resources of type '{resourceType}' cannot be used because transaction support is unavailable."
-});
+public sealed class MissingTransactionSupportException(string resourceType)
+    : JsonApiException(new ErrorObject(HttpStatusCode.UnprocessableEntity)
+    {
+        Title = "Unsupported resource type in atomic:operations request.",
+        Detail = $"Operations on resources of type '{resourceType}' cannot be used because transaction support is unavailable."
+    });

--- a/src/JsonApiDotNetCore/Errors/NonParticipatingTransactionException.cs
+++ b/src/JsonApiDotNetCore/Errors/NonParticipatingTransactionException.cs
@@ -8,8 +8,9 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when a repository does not participate in the overarching transaction during an atomic:operations request.
 /// </summary>
 [PublicAPI]
-public sealed class NonParticipatingTransactionException() : JsonApiException(new ErrorObject(HttpStatusCode.UnprocessableEntity)
-{
-    Title = "Unsupported combination of resource types in atomic:operations request.",
-    Detail = "All operations need to participate in a single shared transaction, which is not the case for this request."
-});
+public sealed class NonParticipatingTransactionException()
+    : JsonApiException(new ErrorObject(HttpStatusCode.UnprocessableEntity)
+    {
+        Title = "Unsupported combination of resource types in atomic:operations request.",
+        Detail = "All operations need to participate in a single shared transaction, which is not the case for this request."
+    });

--- a/src/JsonApiDotNetCore/Errors/RelationshipNotFoundException.cs
+++ b/src/JsonApiDotNetCore/Errors/RelationshipNotFoundException.cs
@@ -8,8 +8,9 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when a relationship does not exist.
 /// </summary>
 [PublicAPI]
-public sealed class RelationshipNotFoundException(string relationshipName, string resourceType) : JsonApiException(new ErrorObject(HttpStatusCode.NotFound)
-{
-    Title = "The requested relationship does not exist.",
-    Detail = $"Resource of type '{resourceType}' does not contain a relationship named '{relationshipName}'."
-});
+public sealed class RelationshipNotFoundException(string relationshipName, string resourceType)
+    : JsonApiException(new ErrorObject(HttpStatusCode.NotFound)
+    {
+        Title = "The requested relationship does not exist.",
+        Detail = $"Resource of type '{resourceType}' does not contain a relationship named '{relationshipName}'."
+    });

--- a/src/JsonApiDotNetCore/Errors/ResourceAlreadyExistsException.cs
+++ b/src/JsonApiDotNetCore/Errors/ResourceAlreadyExistsException.cs
@@ -8,8 +8,9 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when creating a resource with an ID that already exists.
 /// </summary>
 [PublicAPI]
-public sealed class ResourceAlreadyExistsException(string resourceId, string resourceType) : JsonApiException(new ErrorObject(HttpStatusCode.Conflict)
-{
-    Title = "Another resource with the specified ID already exists.",
-    Detail = $"Another resource of type '{resourceType}' with ID '{resourceId}' already exists."
-});
+public sealed class ResourceAlreadyExistsException(string resourceId, string resourceType)
+    : JsonApiException(new ErrorObject(HttpStatusCode.Conflict)
+    {
+        Title = "Another resource with the specified ID already exists.",
+        Detail = $"Another resource of type '{resourceType}' with ID '{resourceId}' already exists."
+    });

--- a/src/JsonApiDotNetCore/Errors/ResourceNotFoundException.cs
+++ b/src/JsonApiDotNetCore/Errors/ResourceNotFoundException.cs
@@ -8,8 +8,9 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when a resource does not exist.
 /// </summary>
 [PublicAPI]
-public sealed class ResourceNotFoundException(string resourceId, string resourceType) : JsonApiException(new ErrorObject(HttpStatusCode.NotFound)
-{
-    Title = "The requested resource does not exist.",
-    Detail = $"Resource of type '{resourceType}' with ID '{resourceId}' does not exist."
-});
+public sealed class ResourceNotFoundException(string resourceId, string resourceType)
+    : JsonApiException(new ErrorObject(HttpStatusCode.NotFound)
+    {
+        Title = "The requested resource does not exist.",
+        Detail = $"Resource of type '{resourceType}' with ID '{resourceId}' does not exist."
+    });

--- a/src/JsonApiDotNetCore/Errors/RouteNotAvailableException.cs
+++ b/src/JsonApiDotNetCore/Errors/RouteNotAvailableException.cs
@@ -8,11 +8,12 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when a request is received for an HTTP route that is not exposed.
 /// </summary>
 [PublicAPI]
-public sealed class RouteNotAvailableException(HttpMethod method, string route) : JsonApiException(new ErrorObject(HttpStatusCode.Forbidden)
-{
-    Title = "The requested endpoint is not accessible.",
-    Detail = $"Endpoint '{route}' is not accessible for {method} requests."
-})
+public sealed class RouteNotAvailableException(HttpMethod method, string route)
+    : JsonApiException(new ErrorObject(HttpStatusCode.Forbidden)
+    {
+        Title = "The requested endpoint is not accessible.",
+        Detail = $"Endpoint '{route}' is not accessible for {method} requests."
+    })
 {
     public HttpMethod Method { get; } = method;
 }

--- a/src/JsonApiDotNetCore/Errors/UnknownLocalIdValueException.cs
+++ b/src/JsonApiDotNetCore/Errors/UnknownLocalIdValueException.cs
@@ -8,8 +8,9 @@ namespace JsonApiDotNetCore.Errors;
 /// The error that is thrown when referencing a local ID that hasn't been assigned.
 /// </summary>
 [PublicAPI]
-public sealed class UnknownLocalIdValueException(string localId) : JsonApiException(new ErrorObject(HttpStatusCode.BadRequest)
-{
-    Title = "Server-generated value for local ID is not available at this point.",
-    Detail = $"Server-generated value for local ID '{localId}' is not available at this point."
-});
+public sealed class UnknownLocalIdValueException(string localId)
+    : JsonApiException(new ErrorObject(HttpStatusCode.BadRequest)
+    {
+        Title = "Server-generated value for local ID is not available at this point.",
+        Detail = $"Server-generated value for local ID '{localId}' is not available at this point."
+    });

--- a/src/JsonApiDotNetCore/QueryStrings/FieldChains/FieldChainFormatException.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/FieldChains/FieldChainFormatException.cs
@@ -3,7 +3,8 @@ namespace JsonApiDotNetCore.QueryStrings.FieldChains;
 /// <summary>
 /// The exception that is thrown when the format of a dot-separated resource field chain is invalid.
 /// </summary>
-internal sealed class FieldChainFormatException(int position, string message) : FormatException(message)
+internal sealed class FieldChainFormatException(int position, string message)
+    : FormatException(message)
 {
     /// <summary>
     /// Gets the zero-based error position in the field chain, or at its end.

--- a/src/JsonApiDotNetCore/QueryStrings/FieldChains/PatternFormatException.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/FieldChains/PatternFormatException.cs
@@ -6,7 +6,8 @@ namespace JsonApiDotNetCore.QueryStrings.FieldChains;
 /// The exception that is thrown when the format of a <see cref="FieldChainPattern" /> is invalid.
 /// </summary>
 [PublicAPI]
-public sealed class PatternFormatException(string pattern, int position, string message) : FormatException(message)
+public sealed class PatternFormatException(string pattern, int position, string message)
+    : FormatException(message)
 {
     /// <summary>
     /// Gets the text of the invalid pattern.

--- a/src/JsonApiDotNetCore/Repositories/DataStoreUpdateException.cs
+++ b/src/JsonApiDotNetCore/Repositories/DataStoreUpdateException.cs
@@ -6,4 +6,5 @@ namespace JsonApiDotNetCore.Repositories;
 /// The error that is thrown when the underlying data store is unable to persist changes.
 /// </summary>
 [PublicAPI]
-public sealed class DataStoreUpdateException(Exception? innerException) : Exception("Failed to persist changes in the underlying data store.", innerException);
+public sealed class DataStoreUpdateException(Exception? innerException)
+    : Exception("Failed to persist changes in the underlying data store.", innerException);

--- a/test/DiscoveryTests/PrivateResourceDefinition.cs
+++ b/test/DiscoveryTests/PrivateResourceDefinition.cs
@@ -5,4 +5,5 @@ using JsonApiDotNetCore.Resources;
 namespace DiscoveryTests;
 
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-public sealed class PrivateResourceDefinition(IResourceGraph resourceGraph) : JsonApiResourceDefinition<PrivateResource, int>(resourceGraph);
+public sealed class PrivateResourceDefinition(IResourceGraph resourceGraph)
+    : JsonApiResourceDefinition<PrivateResource, int>(resourceGraph);

--- a/test/DiscoveryTests/PrivateResourceService.cs
+++ b/test/DiscoveryTests/PrivateResourceService.cs
@@ -13,5 +13,6 @@ namespace DiscoveryTests;
 public sealed class PrivateResourceService(
     IResourceRepositoryAccessor repositoryAccessor, IQueryLayerComposer queryLayerComposer, IPaginationContext paginationContext, IJsonApiOptions options,
     ILoggerFactory loggerFactory, IJsonApiRequest request, IResourceChangeTracker<PrivateResource> resourceChangeTracker,
-    IResourceDefinitionAccessor resourceDefinitionAccessor) : JsonApiResourceService<PrivateResource, int>(repositoryAccessor, queryLayerComposer,
-    paginationContext, options, loggerFactory, request, resourceChangeTracker, resourceDefinitionAccessor);
+    IResourceDefinitionAccessor resourceDefinitionAccessor)
+    : JsonApiResourceService<PrivateResource, int>(repositoryAccessor, queryLayerComposer, paginationContext, options, loggerFactory, request,
+        resourceChangeTracker, resourceDefinitionAccessor);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Archiving/TelevisionDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Archiving/TelevisionDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.Archiving;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class TelevisionDbContext(DbContextOptions<TelevisionDbContext> options) : TestableDbContext(options)
+public sealed class TelevisionDbContext(DbContextOptions<TelevisionDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<TelevisionNetwork> Networks => Set<TelevisionNetwork>();
     public DbSet<TelevisionStation> Stations => Set<TelevisionStation>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Controllers/CreateMusicTrackOperationsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Controllers/CreateMusicTrackOperationsController.cs
@@ -13,8 +13,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Controllers;
 [Route("/operations/musicTracks/create")]
 public sealed class CreateMusicTrackOperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields,
-    OnlyCreateMusicTracksOperationFilter.Instance)
+    ITargetedFields targetedFields)
+    : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields, OnlyCreateMusicTracksOperationFilter.Instance)
 {
     private sealed class OnlyCreateMusicTracksOperationFilter : IAtomicOperationFilter
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/OperationsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/OperationsController.cs
@@ -9,5 +9,5 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations;
 
 public sealed class OperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor,
-    request, targetedFields, operationFilter);
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter)
+    : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields, operationFilter);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/OperationsDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/OperationsDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class OperationsDbContext(DbContextOptions<OperationsDbContext> options) : TestableDbContext(options)
+public sealed class OperationsDbContext(DbContextOptions<OperationsDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Playlist> Playlists => Set<Playlist>();
     public DbSet<MusicTrack> MusicTracks => Set<MusicTrack>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Transactions/ExtraDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Transactions/ExtraDbContext.cs
@@ -5,4 +5,5 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.AtomicOperations.Transactions;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ExtraDbContext(DbContextOptions<ExtraDbContext> options) : TestableDbContext(options);
+public sealed class ExtraDbContext(DbContextOptions<ExtraDbContext> options)
+    : TestableDbContext(options);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/OperationsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/OperationsController.cs
@@ -12,8 +12,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
 
 public sealed class OperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor,
-    request, targetedFields, operationFilter)
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter)
+    : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields, operationFilter)
 {
     public override async Task<IActionResult> PostOperationsAsync(IList<OperationContainer> operations, CancellationToken cancellationToken)
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopesDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Authorization/Scopes/ScopesDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.Authorization.Scopes;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ScopesDbContext(DbContextOptions<ScopesDbContext> options) : TestableDbContext(options)
+public sealed class ScopesDbContext(DbContextOptions<ScopesDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Movie> Movies => Set<Movie>();
     public DbSet<Actor> Actors => Set<Actor>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Blobs/BlobDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Blobs/BlobDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.Blobs;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class BlobDbContext(DbContextOptions<BlobDbContext> options) : TestableDbContext(options)
+public sealed class BlobDbContext(DbContextOptions<BlobDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<ImageContainer> ImageContainers => Set<ImageContainer>();
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/CompositeDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CompositeKeys/CompositeDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.CompositeKeys;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class CompositeDbContext(DbContextOptions<CompositeDbContext> options) : TestableDbContext(options)
+public sealed class CompositeDbContext(DbContextOptions<CompositeDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Car> Cars => Set<Car>();
     public DbSet<Engine> Engines => Set<Engine>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/OperationsController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/OperationsController.cs
@@ -9,5 +9,5 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ContentNegotiation;
 
 public sealed class OperationsController(
     IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
-    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter) : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor,
-    request, targetedFields, operationFilter);
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter)
+    : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields, operationFilter);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/PolicyDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/PolicyDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ContentNegotiation;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class PolicyDbContext(DbContextOptions<PolicyDbContext> options) : TestableDbContext(options)
+public sealed class PolicyDbContext(DbContextOptions<PolicyDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Policy> Policies => Set<Policy>();
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ControllerActionResults/ActionResultDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ControllerActionResults/ActionResultDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ControllerActionResults;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ActionResultDbContext(DbContextOptions<ActionResultDbContext> options) : TestableDbContext(options)
+public sealed class ActionResultDbContext(DbContextOptions<ActionResultDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Toothbrush> Toothbrushes => Set<Toothbrush>();
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/CustomRoutes/CustomRouteDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/CustomRoutes/CustomRouteDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.CustomRoutes;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class CustomRouteDbContext(DbContextOptions<CustomRouteDbContext> options) : TestableDbContext(options)
+public sealed class CustomRouteDbContext(DbContextOptions<CustomRouteDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Town> Towns => Set<Town>();
     public DbSet<Civilian> Civilians => Set<Civilian>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/EagerLoading/EagerLoadingDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/EagerLoading/EagerLoadingDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.EagerLoading;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class EagerLoadingDbContext(DbContextOptions<EagerLoadingDbContext> options) : TestableDbContext(options)
+public sealed class EagerLoadingDbContext(DbContextOptions<EagerLoadingDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<State> States => Set<State>();
     public DbSet<Street> Streets => Set<Street>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ExceptionHandling/AlternateExceptionHandler.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ExceptionHandling/AlternateExceptionHandler.cs
@@ -5,7 +5,8 @@ using Microsoft.Extensions.Logging;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ExceptionHandling;
 
-public sealed class AlternateExceptionHandler(ILoggerFactory loggerFactory, IJsonApiOptions options) : ExceptionHandler(loggerFactory, options)
+public sealed class AlternateExceptionHandler(ILoggerFactory loggerFactory, IJsonApiOptions options)
+    : ExceptionHandler(loggerFactory, options)
 {
     protected override LogLevel GetLogLevel(Exception exception)
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ExceptionHandling/ConsumerArticleIsNoLongerAvailableException.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ExceptionHandling/ConsumerArticleIsNoLongerAvailableException.cs
@@ -4,8 +4,8 @@ using JsonApiDotNetCore.Serialization.Objects;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ExceptionHandling;
 
-internal sealed class ConsumerArticleIsNoLongerAvailableException(string articleCode, string supportEmailAddress) : JsonApiException(
-    new ErrorObject(HttpStatusCode.Gone)
+internal sealed class ConsumerArticleIsNoLongerAvailableException(string articleCode, string supportEmailAddress)
+    : JsonApiException(new ErrorObject(HttpStatusCode.Gone)
     {
         Title = "The requested article is no longer available.",
         Detail = $"Article with code '{articleCode}' is no longer available."

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ExceptionHandling/ConsumerArticleService.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ExceptionHandling/ConsumerArticleService.cs
@@ -13,8 +13,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ExceptionHandling;
 public sealed class ConsumerArticleService(
     IResourceRepositoryAccessor repositoryAccessor, IQueryLayerComposer queryLayerComposer, IPaginationContext paginationContext, IJsonApiOptions options,
     ILoggerFactory loggerFactory, IJsonApiRequest request, IResourceChangeTracker<ConsumerArticle> resourceChangeTracker,
-    IResourceDefinitionAccessor resourceDefinitionAccessor) : JsonApiResourceService<ConsumerArticle, int>(repositoryAccessor, queryLayerComposer,
-    paginationContext, options, loggerFactory, request, resourceChangeTracker, resourceDefinitionAccessor)
+    IResourceDefinitionAccessor resourceDefinitionAccessor)
+    : JsonApiResourceService<ConsumerArticle, int>(repositoryAccessor, queryLayerComposer, paginationContext, options, loggerFactory, request,
+        resourceChangeTracker, resourceDefinitionAccessor)
 {
     private const string SupportEmailAddress = "company@email.com";
     internal const string UnavailableArticlePrefix = "X";

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ExceptionHandling/ErrorDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ExceptionHandling/ErrorDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ExceptionHandling;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ErrorDbContext(DbContextOptions<ErrorDbContext> options) : TestableDbContext(options)
+public sealed class ErrorDbContext(DbContextOptions<ErrorDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<ConsumerArticle> ConsumerArticles => Set<ConsumerArticle>();
     public DbSet<ThrowingArticle> ThrowingArticles => Set<ThrowingArticle>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/HostingInIIS/HostingDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/HostingInIIS/HostingDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.HostingInIIS;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class HostingDbContext(DbContextOptions<HostingDbContext> options) : TestableDbContext(options)
+public sealed class HostingDbContext(DbContextOptions<HostingDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<ArtGallery> ArtGalleries => Set<ArtGallery>();
     public DbSet<Painting> Paintings => Set<Painting>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/IdObfuscation/ObfuscationDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/IdObfuscation/ObfuscationDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.IdObfuscation;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ObfuscationDbContext(DbContextOptions<ObfuscationDbContext> options) : TestableDbContext(options)
+public sealed class ObfuscationDbContext(DbContextOptions<ObfuscationDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<BankAccount> BankAccounts => Set<BankAccount>();
     public DbSet<DebitCard> DebitCards => Set<DebitCard>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/ModelStateDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/ModelState/ModelStateDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.InputValidation.ModelState;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ModelStateDbContext(DbContextOptions<ModelStateDbContext> options) : TestableDbContext(options)
+public sealed class ModelStateDbContext(DbContextOptions<ModelStateDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<SystemVolume> Volumes => Set<SystemVolume>();
     public DbSet<SystemDirectory> Directories => Set<SystemDirectory>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/RequestBody/WorkflowDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/RequestBody/WorkflowDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.InputValidation.RequestBody;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class WorkflowDbContext(DbContextOptions<WorkflowDbContext> options) : TestableDbContext(options)
+public sealed class WorkflowDbContext(DbContextOptions<WorkflowDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Workflow> Workflows => Set<Workflow>();
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/RequestBody/WorkflowDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/InputValidation/RequestBody/WorkflowDefinition.cs
@@ -9,7 +9,8 @@ using JsonApiDotNetCore.Serialization.Objects;
 namespace JsonApiDotNetCoreTests.IntegrationTests.InputValidation.RequestBody;
 
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-public sealed class WorkflowDefinition(IResourceGraph resourceGraph) : JsonApiResourceDefinition<Workflow, Guid>(resourceGraph)
+public sealed class WorkflowDefinition(IResourceGraph resourceGraph)
+    : JsonApiResourceDefinition<Workflow, Guid>(resourceGraph)
 {
     private static readonly Dictionary<WorkflowStage, WorkflowStage[]> StageTransitionTable = new()
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Links/LinksDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Links/LinksDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.Links;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class LinksDbContext(DbContextOptions<LinksDbContext> options) : TestableDbContext(options)
+public sealed class LinksDbContext(DbContextOptions<LinksDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<PhotoAlbum> PhotoAlbums => Set<PhotoAlbum>();
     public DbSet<Photo> Photos => Set<Photo>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Logging/LoggingDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Logging/LoggingDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.Logging;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class LoggingDbContext(DbContextOptions<LoggingDbContext> options) : TestableDbContext(options)
+public sealed class LoggingDbContext(DbContextOptions<LoggingDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<AuditEntry> AuditEntries => Set<AuditEntry>();
     public DbSet<FruitBowl> FruitBowls => Set<FruitBowl>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/MetaDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Meta/MetaDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.Meta;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class MetaDbContext(DbContextOptions<MetaDbContext> options) : TestableDbContext(options)
+public sealed class MetaDbContext(DbContextOptions<MetaDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<ProductFamily> ProductFamilies => Set<ProductFamily>();
     public DbSet<SupportTicket> SupportTickets => Set<SupportTicket>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/FireAndForgetDelivery/FireForgetDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.FireAndForgetDelivery;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class FireForgetDbContext(DbContextOptions<FireForgetDbContext> options) : TestableDbContext(options)
+public sealed class FireForgetDbContext(DbContextOptions<FireForgetDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<DomainUser> Users => Set<DomainUser>();
     public DbSet<DomainGroup> Groups => Set<DomainGroup>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Microservices/TransactionalOutboxPattern/OutboxDbContext.cs
@@ -6,7 +6,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.Microservices.TransactionalOutboxPattern;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class OutboxDbContext(DbContextOptions<OutboxDbContext> options) : TestableDbContext(options)
+public sealed class OutboxDbContext(DbContextOptions<OutboxDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<DomainUser> Users => Set<DomainUser>();
     public DbSet<DomainGroup> Groups => Set<DomainGroup>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/MultiTenancyDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/MultiTenancy/MultiTenancyDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.MultiTenancy;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class MultiTenancyDbContext(DbContextOptions<MultiTenancyDbContext> options, ITenantProvider tenantProvider) : TestableDbContext(options)
+public sealed class MultiTenancyDbContext(DbContextOptions<MultiTenancyDbContext> options, ITenantProvider tenantProvider)
+    : TestableDbContext(options)
 {
     private readonly ITenantProvider _tenantProvider = tenantProvider;
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/NamingDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NamingConventions/NamingDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.NamingConventions;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class NamingDbContext(DbContextOptions<NamingDbContext> options) : TestableDbContext(options)
+public sealed class NamingDbContext(DbContextOptions<NamingDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<SwimmingPool> SwimmingPools => Set<SwimmingPool>();
     public DbSet<WaterSlide> WaterSlides => Set<WaterSlide>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NonJsonApiControllers/EmptyDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NonJsonApiControllers/EmptyDbContext.cs
@@ -5,4 +5,5 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.NonJsonApiControllers;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class EmptyDbContext(DbContextOptions<EmptyDbContext> options) : TestableDbContext(options);
+public sealed class EmptyDbContext(DbContextOptions<EmptyDbContext> options)
+    : TestableDbContext(options);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/NonJsonApiControllers/KnownDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/NonJsonApiControllers/KnownDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.NonJsonApiControllers;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class KnownDbContext(DbContextOptions<KnownDbContext> options) : TestableDbContext(options)
+public sealed class KnownDbContext(DbContextOptions<KnownDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<KnownResource> KnownResources => Set<KnownResource>();
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/IsUpperCase/IsUpperCaseFilterParser.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/IsUpperCase/IsUpperCaseFilterParser.cs
@@ -6,7 +6,8 @@ using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.CustomFunctions.IsUpperCase;
 
-internal sealed class IsUpperCaseFilterParser(IResourceFactory resourceFactory) : FilterParser(resourceFactory)
+internal sealed class IsUpperCaseFilterParser(IResourceFactory resourceFactory)
+    : FilterParser(resourceFactory)
 {
     protected override FilterExpression ParseFilter()
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/StringLength/LengthFilterParser.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/StringLength/LengthFilterParser.cs
@@ -6,7 +6,8 @@ using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.CustomFunctions.StringLength;
 
-internal sealed class LengthFilterParser(IResourceFactory resourceFactory) : FilterParser(resourceFactory)
+internal sealed class LengthFilterParser(IResourceFactory resourceFactory)
+    : FilterParser(resourceFactory)
 {
     protected override bool IsFunction(string name)
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/Sum/SumFilterParser.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/Sum/SumFilterParser.cs
@@ -6,7 +6,8 @@ using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.CustomFunctions.Sum;
 
-internal sealed class SumFilterParser(IResourceFactory resourceFactory) : FilterParser(resourceFactory)
+internal sealed class SumFilterParser(IResourceFactory resourceFactory)
+    : FilterParser(resourceFactory)
 {
     private static readonly FieldChainPattern SingleToManyRelationshipChain = FieldChainPattern.Parse("M");
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/TimeOffset/TimeOffsetFilterParser.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/TimeOffset/TimeOffsetFilterParser.cs
@@ -4,7 +4,8 @@ using JsonApiDotNetCore.Resources;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.CustomFunctions.TimeOffset;
 
-internal sealed class TimeOffsetFilterParser(IResourceFactory resourceFactory) : FilterParser(resourceFactory)
+internal sealed class TimeOffsetFilterParser(IResourceFactory resourceFactory)
+    : FilterParser(resourceFactory)
 {
     protected override bool IsFunction(string name)
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Filtering/FilterDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Filtering/FilterDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.Filtering;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class FilterDbContext(DbContextOptions<FilterDbContext> options) : TestableDbContext(options)
+public sealed class FilterDbContext(DbContextOptions<FilterDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<FilterableResource> FilterableResources => Set<FilterableResource>();
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/QueryStringDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/QueryStringDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class QueryStringDbContext(DbContextOptions<QueryStringDbContext> options) : TestableDbContext(options)
+public sealed class QueryStringDbContext(DbContextOptions<QueryStringDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Blog> Blogs => Set<Blog>();
     public DbSet<BlogPost> Posts => Set<BlogPost>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/SparseFieldSets/ResultCapturingRepository.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/SparseFieldSets/ResultCapturingRepository.cs
@@ -14,8 +14,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.SparseFieldSets;
 public sealed class ResultCapturingRepository<TResource, TId>(
     ITargetedFields targetedFields, IDbContextResolver dbContextResolver, IResourceGraph resourceGraph, IResourceFactory resourceFactory,
     IEnumerable<IQueryConstraintProvider> constraintProviders, ILoggerFactory loggerFactory, IResourceDefinitionAccessor resourceDefinitionAccessor,
-    ResourceCaptureStore captureStore) : EntityFrameworkCoreRepository<TResource, TId>(targetedFields, dbContextResolver, resourceGraph, resourceFactory,
-    constraintProviders, loggerFactory, resourceDefinitionAccessor)
+    ResourceCaptureStore captureStore)
+    : EntityFrameworkCoreRepository<TResource, TId>(targetedFields, dbContextResolver, resourceGraph, resourceFactory, constraintProviders, loggerFactory,
+        resourceDefinitionAccessor)
     where TResource : class, IIdentifiable<TId>
 {
     private readonly ResourceCaptureStore _captureStore = captureStore;

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/AssignIdToRgbColorDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Creating/AssignIdToRgbColorDefinition.cs
@@ -6,7 +6,8 @@ using JsonApiDotNetCore.Resources;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ReadWrite.Creating;
 
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-internal sealed class AssignIdToRgbColorDefinition(IResourceGraph resourceGraph) : JsonApiResourceDefinition<RgbColor, string?>(resourceGraph)
+internal sealed class AssignIdToRgbColorDefinition(IResourceGraph resourceGraph)
+    : JsonApiResourceDefinition<RgbColor, string?>(resourceGraph)
 {
     internal const string DefaultId = "0x000000";
     internal const string DefaultName = "Black";

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/ReadWriteDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/ReadWriteDbContext.cs
@@ -8,7 +8,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ReadWrite;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ReadWriteDbContext(DbContextOptions<ReadWriteDbContext> options) : TestableDbContext(options)
+public sealed class ReadWriteDbContext(DbContextOptions<ReadWriteDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<WorkItem> WorkItems => Set<WorkItem>();
     public DbSet<WorkTag> WorkTags => Set<WorkTag>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Relationships/RemoveFromToManyRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Updating/Relationships/RemoveFromToManyRelationshipTests.cs
@@ -1142,7 +1142,8 @@ public sealed class RemoveFromToManyRelationshipTests : IClassFixture<Integratio
     }
 
     [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-    private sealed class RemoveExtraFromWorkItemDefinition(IResourceGraph resourceGraph) : JsonApiResourceDefinition<WorkItem, int>(resourceGraph)
+    private sealed class RemoveExtraFromWorkItemDefinition(IResourceGraph resourceGraph)
+        : JsonApiResourceDefinition<WorkItem, int>(resourceGraph)
     {
         // Enables to verify that not the full relationship was loaded upfront.
         public HashSet<UserAccount> PreloadedSubscribers { get; } = new(IdentifiableComparer.Instance);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/RequiredRelationships/DefaultBehaviorDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/RequiredRelationships/DefaultBehaviorDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.RequiredRelationships;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class DefaultBehaviorDbContext(DbContextOptions<DefaultBehaviorDbContext> options) : TestableDbContext(options)
+public sealed class DefaultBehaviorDbContext(DbContextOptions<DefaultBehaviorDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Customer> Customers => Set<Customer>();
     public DbSet<Order> Orders => Set<Order>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/UniverseDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/UniverseDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class UniverseDbContext(DbContextOptions<UniverseDbContext> options) : TestableDbContext(options)
+public sealed class UniverseDbContext(DbContextOptions<UniverseDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Star> Stars => Set<Star>();
     public DbSet<Planet> Planets => Set<Planet>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/SerializationDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Serialization/SerializationDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Serialization;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class SerializationDbContext(DbContextOptions<SerializationDbContext> options) : TestableDbContext(options)
+public sealed class SerializationDbContext(DbContextOptions<SerializationDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Student> Students => Set<Student>();
     public DbSet<Scholarship> Scholarships => Set<Scholarship>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ChangeTracking/ChangeTrackingDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ChangeTracking/ChangeTrackingDbContext.cs
@@ -5,7 +5,8 @@ using Microsoft.EntityFrameworkCore;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceInheritance.ChangeTracking;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ChangeTrackingDbContext(DbContextOptions<ChangeTrackingDbContext> options) : ResourceInheritanceDbContext(options)
+public sealed class ChangeTrackingDbContext(DbContextOptions<ChangeTrackingDbContext> options)
+    : ResourceInheritanceDbContext(options)
 {
     public DbSet<AlwaysMovingTandem> AlwaysMovingTandems => Set<AlwaysMovingTandem>();
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceDbContext.cs
@@ -6,7 +6,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceInheritance;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public abstract class ResourceInheritanceDbContext(DbContextOptions options) : TestableDbContext(options)
+public abstract class ResourceInheritanceDbContext(DbContextOptions options)
+    : TestableDbContext(options)
 {
     public DbSet<Vehicle> Vehicles => Set<Vehicle>();
     public DbSet<Bike> Bikes => Set<Bike>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerConcreteType/TablePerConcreteTypeDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerConcreteType/TablePerConcreteTypeDbContext.cs
@@ -7,7 +7,8 @@ using Microsoft.EntityFrameworkCore;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceInheritance.TablePerConcreteType;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class TablePerConcreteTypeDbContext(DbContextOptions<TablePerConcreteTypeDbContext> options) : ResourceInheritanceDbContext(options)
+public sealed class TablePerConcreteTypeDbContext(DbContextOptions<TablePerConcreteTypeDbContext> options)
+    : ResourceInheritanceDbContext(options)
 {
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerHierarchy/TablePerHierarchyDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerHierarchy/TablePerHierarchyDbContext.cs
@@ -4,4 +4,5 @@ using Microsoft.EntityFrameworkCore;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceInheritance.TablePerHierarchy;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class TablePerHierarchyDbContext(DbContextOptions<TablePerHierarchyDbContext> options) : ResourceInheritanceDbContext(options);
+public sealed class TablePerHierarchyDbContext(DbContextOptions<TablePerHierarchyDbContext> options)
+    : ResourceInheritanceDbContext(options);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerType/TablePerTypeDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/TablePerType/TablePerTypeDbContext.cs
@@ -7,7 +7,8 @@ using Microsoft.EntityFrameworkCore;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceInheritance.TablePerType;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class TablePerTypeDbContext(DbContextOptions<TablePerTypeDbContext> options) : ResourceInheritanceDbContext(options)
+public sealed class TablePerTypeDbContext(DbContextOptions<TablePerTypeDbContext> options)
+    : ResourceInheritanceDbContext(options)
 {
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/RestrictionDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/RestrictionDbContext.cs
@@ -5,7 +5,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.RestrictedControllers;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class RestrictionDbContext(DbContextOptions<RestrictionDbContext> options) : TestableDbContext(options)
+public sealed class RestrictionDbContext(DbContextOptions<RestrictionDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Table> Tables => Set<Table>();
     public DbSet<Chair> Chairs => Set<Chair>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/SerializationDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Serialization/SerializationDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.Serialization;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class SerializationDbContext(DbContextOptions<SerializationDbContext> options) : TestableDbContext(options)
+public sealed class SerializationDbContext(DbContextOptions<SerializationDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Meeting> Meetings => Set<Meeting>();
     public DbSet<MeetingAttendee> Attendees => Set<MeetingAttendee>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/SoftDeletion/SoftDeletionDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/SoftDeletion/SoftDeletionDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.SoftDeletion;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class SoftDeletionDbContext(DbContextOptions<SoftDeletionDbContext> options) : TestableDbContext(options)
+public sealed class SoftDeletionDbContext(DbContextOptions<SoftDeletionDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Company> Companies => Set<Company>();
     public DbSet<Department> Departments => Set<Department>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/ZeroKeyDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ZeroKeys/ZeroKeyDbContext.cs
@@ -7,7 +7,8 @@ using TestBuildingBlocks;
 namespace JsonApiDotNetCoreTests.IntegrationTests.ZeroKeys;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-public sealed class ZeroKeyDbContext(DbContextOptions<ZeroKeyDbContext> options) : TestableDbContext(options)
+public sealed class ZeroKeyDbContext(DbContextOptions<ZeroKeyDbContext> options)
+    : TestableDbContext(options)
 {
     public DbSet<Game> Games => Set<Game>();
     public DbSet<Player> Players => Set<Player>();

--- a/test/JsonApiDotNetCoreTests/UnitTests/Configuration/ServiceCollectionExtensionsTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Configuration/ServiceCollectionExtensionsTests.cs
@@ -567,7 +567,8 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [UsedImplicitly(ImplicitUseTargetFlags.Members)]
-    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : TestableDbContext(options)
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options)
+        : TestableDbContext(options)
     {
         public DbSet<ResourceOfInt32> ResourcesOfInt32 => Set<ResourceOfInt32>();
         public DbSet<ResourceOfGuid> ResourcesOfGuid => Set<ResourceOfGuid>();

--- a/test/JsonApiDotNetCoreTests/UnitTests/QueryStringParameters/FilterParseTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/QueryStringParameters/FilterParseTests.cs
@@ -249,7 +249,8 @@ public sealed class FilterParseTests : BaseParseTests
         action.Should().ThrowExactly<InvalidOperationException>().WithMessage("No resource type is currently in scope. Call Parse() first.");
     }
 
-    private sealed class NotDisposingFilterParser(IResourceFactory resourceFactory) : FilterParser(resourceFactory)
+    private sealed class NotDisposingFilterParser(IResourceFactory resourceFactory)
+        : FilterParser(resourceFactory)
     {
         protected override FilterExpression ParseFilter()
         {
@@ -260,7 +261,8 @@ public sealed class FilterParseTests : BaseParseTests
         }
     }
 
-    private sealed class ResourceTypeAccessingFilterParser(IResourceFactory resourceFactory) : FilterParser(resourceFactory)
+    private sealed class ResourceTypeAccessingFilterParser(IResourceFactory resourceFactory)
+        : FilterParser(resourceFactory)
     {
         protected override void Tokenize(string source)
         {

--- a/test/JsonApiDotNetCoreTests/UnitTests/ResourceDefinitions/CreateSortExpressionFromLambdaTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/ResourceDefinitions/CreateSortExpressionFromLambdaTests.cs
@@ -345,7 +345,8 @@ public sealed class CreateSortExpressionFromLambdaTests
         // @formatter:wrap_before_first_method_call restore
     }
 
-    private sealed class WrapperResourceDefinition<TResource, TId>(IResourceGraph resourceGraph) : JsonApiResourceDefinition<TResource, TId>(resourceGraph)
+    private sealed class WrapperResourceDefinition<TResource, TId>(IResourceGraph resourceGraph)
+        : JsonApiResourceDefinition<TResource, TId>(resourceGraph)
         where TResource : class, IIdentifiable<TId>
     {
         public SortExpression GetSortExpressionFromLambda(PropertySortOrder sortOrder)

--- a/test/TestBuildingBlocks/TestableDbContext.cs
+++ b/test/TestBuildingBlocks/TestableDbContext.cs
@@ -5,7 +5,8 @@ using Microsoft.Extensions.Logging;
 
 namespace TestBuildingBlocks;
 
-public abstract class TestableDbContext(DbContextOptions options) : DbContext(options)
+public abstract class TestableDbContext(DbContextOptions options)
+    : DbContext(options)
 {
     protected override void OnConfiguring(DbContextOptionsBuilder builder)
     {


### PR DESCRIPTION
Use the Resharper formatter option introduced in https://youtrack.jetbrains.com/issue/RSRP-495410/Wrapping-and-line-breaks-in-primary-constructor-base-calls.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
