### PR TITLE
Run tests and examples against .NET 9

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2024.2.7",
+      "version": "2024.3.0",
       "commands": [
         "jb"
       ],

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
         dotnet-version: |
           6.0.x
           8.0.x
+          9.0.x
     - name: Show installed versions
       shell: pwsh
       run: |
@@ -166,6 +167,7 @@ jobs:
         dotnet-version: |
           6.0.x
           8.0.x
+          9.0.x
     - name: Git checkout
       uses: actions/checkout@v4
     - name: Restore tools
@@ -221,6 +223,7 @@ jobs:
         dotnet-version: |
           6.0.x
           8.0.x
+          9.0.x
     - name: Git checkout
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,7 @@ jobs:
         dotnet-version: |
           6.0.x
           8.0.x
+          9.0.x
     - name: Git checkout
       uses: actions/checkout@v4
     - name: Initialize CodeQL

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,6 +24,12 @@
     <NoWarn>$(NoWarn);$(UseCollectionExpressionRules)</NoWarn>
   </PropertyGroup>
 
+  <!-- Specific to .NET 9 -->
+  <PropertyGroup>
+    <NuGetAuditMode>direct</NuGetAuditMode>
+    <NoWarn>$(NoWarn);NU1608;NETSDK1215</NoWarn>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <NoWarn>$(NoWarn);AV2210</NoWarn>
   </PropertyGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="pomelo-nightly"
+      value="https://pkgs.dev.azure.com/pomelo-efcore/Pomelo.EntityFrameworkCore.MySql/_packaging/pomelo-efcore-public/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/package-versions.props
+++ b/package-versions.props
@@ -20,6 +20,17 @@
     <XunitVisualStudioVersion>2.8.*</XunitVisualStudioVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <!-- Published dependencies (only update on major version change) -->
+    <EntityFrameworkCoreFrozenVersion>N/A</EntityFrameworkCoreFrozenVersion>
+
+    <!-- Non-published dependencies (these are safe to update, won't cause a breaking change) -->
+    <AspNetCoreVersion>9.0.*</AspNetCoreVersion>
+    <EntityFrameworkCoreVersion>9.0.*</EntityFrameworkCoreVersion>
+    <EntityFrameworkCorePomeloVersion>9.0.0-*</EntityFrameworkCorePomeloVersion>
+    <SystemTextJsonVersion>$(AspNetCoreVersion)</SystemTextJsonVersion>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <!-- Published dependencies (only update on major version change) -->
     <EntityFrameworkCoreFrozenVersion>8.0.0</EntityFrameworkCoreFrozenVersion>
@@ -27,6 +38,7 @@
     <!-- Non-published dependencies (these are safe to update, won't cause a breaking change) -->
     <AspNetCoreVersion>8.0.*</AspNetCoreVersion>
     <EntityFrameworkCoreVersion>8.0.*</EntityFrameworkCoreVersion>
+    <EntityFrameworkCorePomeloVersion>$(EntityFrameworkCoreVersion)</EntityFrameworkCorePomeloVersion>
     <SystemTextJsonVersion>$(AspNetCoreVersion)</SystemTextJsonVersion>
   </PropertyGroup>
 
@@ -38,6 +50,7 @@
     <AspNetCoreVersion>6.0.*</AspNetCoreVersion>
     <DateOnlyTimeOnlyVersion>2.1.*</DateOnlyTimeOnlyVersion>
     <EntityFrameworkCoreVersion>7.0.*</EntityFrameworkCoreVersion>
+    <EntityFrameworkCorePomeloVersion>$(EntityFrameworkCoreVersion)</EntityFrameworkCorePomeloVersion>
     <SystemTextJsonVersion>8.0.*</SystemTextJsonVersion>
   </PropertyGroup>
 </Project>

--- a/src/Examples/DapperExample/DapperExample.csproj
+++ b/src/Examples/DapperExample/DapperExample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\package-versions.props" />
@@ -16,6 +16,11 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EntityFrameworkCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EntityFrameworkCoreVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(EntityFrameworkCorePomeloVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <!-- Temporary workaround for version range constraint on Pomelo.EntityFrameworkCore.MySql pre-release package -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EntityFrameworkCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Examples/DapperExample/Program.cs
+++ b/src/Examples/DapperExample/Program.cs
@@ -31,8 +31,13 @@ switch (databaseProvider)
     }
     case DatabaseProvider.MySql:
     {
-        builder.Services.AddMySql<AppDbContext>(connectionString, ServerVersion.AutoDetect(connectionString),
-            optionsAction: options => SetDbContextDebugOptions(options));
+#if NET9_0_OR_GREATER
+        ServerVersion serverVersion = await ServerVersion.AutoDetectAsync(connectionString);
+#else
+        ServerVersion serverVersion = ServerVersion.AutoDetect(connectionString);
+#endif
+
+        builder.Services.AddMySql<AppDbContext>(connectionString, serverVersion, optionsAction: options => SetDbContextDebugOptions(options));
 
         break;
     }

--- a/src/Examples/DatabasePerTenantExample/DatabasePerTenantExample.csproj
+++ b/src/Examples/DatabasePerTenantExample/DatabasePerTenantExample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\package-versions.props" />

--- a/src/Examples/GettingStarted/GettingStarted.csproj
+++ b/src/Examples/GettingStarted/GettingStarted.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\package-versions.props" />

--- a/src/Examples/JsonApiDotNetCoreExample/JsonApiDotNetCoreExample.csproj
+++ b/src/Examples/JsonApiDotNetCoreExample/JsonApiDotNetCoreExample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\package-versions.props" />

--- a/src/Examples/MultiDbContextExample/MultiDbContextExample.csproj
+++ b/src/Examples/MultiDbContextExample/MultiDbContextExample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\package-versions.props" />

--- a/src/Examples/NoEntityFrameworkExample/NoEntityFrameworkExample.csproj
+++ b/src/Examples/NoEntityFrameworkExample/NoEntityFrameworkExample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\package-versions.props" />

--- a/src/Examples/ReportsExample/ReportsExample.csproj
+++ b/src/Examples/ReportsExample/ReportsExample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\..\package-versions.props" />

--- a/test/AnnotationTests/AnnotationTests.csproj
+++ b/test/AnnotationTests/AnnotationTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\package-versions.props" />

--- a/test/DapperTests/DapperTests.csproj
+++ b/test/DapperTests/DapperTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\package-versions.props" />

--- a/test/DiscoveryTests/DiscoveryTests.csproj
+++ b/test/DiscoveryTests/DiscoveryTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\package-versions.props" />

--- a/test/JsonApiDotNetCoreTests/JsonApiDotNetCoreTests.csproj
+++ b/test/JsonApiDotNetCoreTests/JsonApiDotNetCoreTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\package-versions.props" />

--- a/test/MultiDbContextTests/MultiDbContextTests.csproj
+++ b/test/MultiDbContextTests/MultiDbContextTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\package-versions.props" />

--- a/test/NoEntityFrameworkTests/NoEntityFrameworkTests.csproj
+++ b/test/NoEntityFrameworkTests/NoEntityFrameworkTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\package-versions.props" />

--- a/test/SourceGeneratorTests/SourceGeneratorTests.csproj
+++ b/test/SourceGeneratorTests/SourceGeneratorTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\package-versions.props" />

--- a/test/TestBuildingBlocks/CapturingLoggerProvider.cs
+++ b/test/TestBuildingBlocks/CapturingLoggerProvider.cs
@@ -10,7 +10,11 @@ public sealed class CapturingLoggerProvider : ILoggerProvider
     private static readonly Func<string, LogLevel, bool> DefaultFilter = (_, _) => true;
     private readonly Func<string, LogLevel, bool> _filter;
 
+#if NET9_0_OR_GREATER
+    private readonly Lock _lockObject = new();
+#else
     private readonly object _lockObject = new();
+#endif
     private readonly List<LogMessage> _messages = [];
 
     public CapturingLoggerProvider()

--- a/test/TestBuildingBlocks/TestBuildingBlocks.csproj
+++ b/test/TestBuildingBlocks/TestBuildingBlocks.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\package-versions.props" />

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <Import Project="..\..\package-versions.props" />


### PR DESCRIPTION
Demonstrates that all tests are green when running on .NET 9 with EF Core 9, while still referencing JADNC that targets only .NET 8 and 6.

While there are breaking changes in the EF Core driver API (so you'll need matching EF Core versions for PostgreSQL, MySQL, SQL Server, etc.), the current stable version of JADNC is already compatible. This means there's no need to release a new version.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
