### PR TITLE
Resource inheritance fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,8 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodingGuidelines.ruleset</CodeAnalysisRuleSet>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)tests.runsettings</RunSettingsFilePath>
     <JsonApiDotNetCoreVersionPrefix>5.6.1</JsonApiDotNetCoreVersionPrefix>
+    <NuGetAuditMode>direct</NuGetAuditMode>
+    <NoWarn>$(NoWarn);NETSDK1215</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/JsonApiDotNetCore.sln.DotSettings
+++ b/JsonApiDotNetCore.sln.DotSettings
@@ -668,6 +668,7 @@ $left$ = $right$;</s:String>
 	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=D29C3A091CD9E74BBFDF1B8974F5A977/SearchPattern/@EntryValue">if ($argument$ is null) throw new ArgumentNullException(nameof($argument$));</s:String>
 	<s:String x:Key="/Default/PatternsAndTemplates/StructuralSearch/Pattern/=D29C3A091CD9E74BBFDF1B8974F5A977/Severity/@EntryValue">WARNING</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Accurize/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=accurized/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Assignee/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Contoso/@EntryIndexedValue">True</s:Boolean>

--- a/src/Examples/DapperExample/Repositories/DapperRepository.cs
+++ b/src/Examples/DapperExample/Repositories/DapperRepository.cs
@@ -103,7 +103,6 @@ public sealed partial class DapperRepository<TResource, TId> : IResourceReposito
     private readonly SqlCaptureStore _captureStore;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<DapperRepository<TResource, TId>> _logger;
-    private readonly CollectionConverter _collectionConverter = new();
     private readonly ParameterFormatter _parameterFormatter = new();
     private readonly DapperFacade _dapperFacade;
 
@@ -270,12 +269,12 @@ public sealed partial class DapperRepository<TResource, TId> : IResourceReposito
 
         if (relationship is HasManyAttribute hasManyRelationship)
         {
-            HashSet<IIdentifiable> rightResourceIds = _collectionConverter.ExtractResources(rightValue).ToHashSet(IdentifiableComparer.Instance);
+            HashSet<IIdentifiable> rightResourceIds = CollectionConverter.Instance.ExtractResources(rightValue).ToHashSet(IdentifiableComparer.Instance);
 
             await _resourceDefinitionAccessor.OnSetToManyRelationshipAsync(leftResource, hasManyRelationship, rightResourceIds, writeOperation,
                 cancellationToken);
 
-            return _collectionConverter.CopyToTypedCollection(rightResourceIds, relationship.Property.PropertyType);
+            return CollectionConverter.Instance.CopyToTypedCollection(rightResourceIds, relationship.Property.PropertyType);
         }
 
         return rightValue;
@@ -464,7 +463,9 @@ public sealed partial class DapperRepository<TResource, TId> : IResourceReposito
         leftPlaceholderResource.Id = leftId;
 
         await _resourceDefinitionAccessor.OnAddToRelationshipAsync(leftPlaceholderResource, relationship, rightResourceIds, cancellationToken);
-        relationship.SetValue(leftPlaceholderResource, _collectionConverter.CopyToTypedCollection(rightResourceIds, relationship.Property.PropertyType));
+
+        relationship.SetValue(leftPlaceholderResource,
+            CollectionConverter.Instance.CopyToTypedCollection(rightResourceIds, relationship.Property.PropertyType));
 
         await _resourceDefinitionAccessor.OnWritingAsync(leftPlaceholderResource, WriteOperationKind.AddToRelationship, cancellationToken);
 
@@ -500,7 +501,7 @@ public sealed partial class DapperRepository<TResource, TId> : IResourceReposito
         var relationship = (HasManyAttribute)_targetedFields.Relationships.Single();
 
         await _resourceDefinitionAccessor.OnRemoveFromRelationshipAsync(leftResource, relationship, rightResourceIds, cancellationToken);
-        relationship.SetValue(leftResource, _collectionConverter.CopyToTypedCollection(rightResourceIds, relationship.Property.PropertyType));
+        relationship.SetValue(leftResource, CollectionConverter.Instance.CopyToTypedCollection(rightResourceIds, relationship.Property.PropertyType));
 
         await _resourceDefinitionAccessor.OnWritingAsync(leftResource, WriteOperationKind.RemoveFromRelationship, cancellationToken);
 

--- a/src/Examples/DapperExample/Repositories/ResourceChangeDetector.cs
+++ b/src/Examples/DapperExample/Repositories/ResourceChangeDetector.cs
@@ -12,7 +12,6 @@ namespace DapperExample.Repositories;
 /// </summary>
 internal sealed class ResourceChangeDetector
 {
-    private readonly CollectionConverter _collectionConverter = new();
     private readonly IDataModelService _dataModelService;
 
     private Dictionary<string, object?> _currentColumnValues = [];
@@ -69,7 +68,7 @@ internal sealed class ResourceChangeDetector
         foreach (RelationshipAttribute relationship in ResourceType.Relationships)
         {
             object? rightValue = relationship.GetValue(resource);
-            HashSet<IIdentifiable> rightResources = _collectionConverter.ExtractResources(rightValue).ToHashSet(IdentifiableComparer.Instance);
+            HashSet<IIdentifiable> rightResources = CollectionConverter.Instance.ExtractResources(rightValue).ToHashSet(IdentifiableComparer.Instance);
 
             relationshipValues[relationship] = rightResources;
         }

--- a/src/JsonApiDotNetCore.Annotations/CollectionConverter.cs
+++ b/src/JsonApiDotNetCore.Annotations/CollectionConverter.cs
@@ -15,6 +15,12 @@ internal sealed class CollectionConverter
         typeof(IEnumerable<>)
     ];
 
+    public static CollectionConverter Instance { get; } = new();
+
+    private CollectionConverter()
+    {
+    }
+
     /// <summary>
     /// Creates a collection instance based on the specified collection type and copies the specified elements into it.
     /// </summary>
@@ -22,7 +28,11 @@ internal sealed class CollectionConverter
     /// Source to copy from.
     /// </param>
     /// <param name="collectionType">
-    /// Target collection type, for example: typeof(List{Article}) or typeof(ISet{Person}).
+    /// Target collection type, for example: <code><![CDATA[
+    /// typeof(List<Article>)
+    /// ]]></code> or <code><![CDATA[
+    /// typeof(ISet<Person>)
+    /// ]]></code>.
     /// </param>
     public IEnumerable CopyToTypedCollection(IEnumerable source, Type collectionType)
     {
@@ -41,7 +51,12 @@ internal sealed class CollectionConverter
     }
 
     /// <summary>
-    /// Returns a compatible collection type that can be instantiated, for example IList{Article} -> List{Article} or ISet{Article} -> HashSet{Article}
+    /// Returns a compatible collection type that can be instantiated, for example: <code><![CDATA[
+    /// IList<Article> -> List<Article>
+    /// ]]></code> or
+    /// <code><![CDATA[
+    /// ISet<Article> -> HashSet<Article>
+    /// ]]></code>.
     /// </summary>
     private Type ToConcreteCollectionType(Type collectionType)
     {
@@ -80,7 +95,12 @@ internal sealed class CollectionConverter
     }
 
     /// <summary>
-    /// Returns the element type if the specified type is a generic collection, for example: IList{string} -> string or IList -> null.
+    /// Returns the element type if the specified type is a generic collection, for example: <code><![CDATA[
+    /// IList<string> -> string
+    /// ]]></code> or
+    /// <code><![CDATA[
+    /// IList -> null
+    /// ]]></code>.
     /// </summary>
     public Type? FindCollectionElementType(Type? type)
     {
@@ -96,8 +116,12 @@ internal sealed class CollectionConverter
     }
 
     /// <summary>
-    /// Indicates whether a <see cref="HashSet{T}" /> instance can be assigned to the specified type, for example IList{Article} -> false or ISet{Article} ->
-    /// true.
+    /// Indicates whether a <see cref="HashSet{T}" /> instance can be assigned to the specified type, for example:
+    /// <code><![CDATA[
+    /// IList<Article> -> false
+    /// ]]></code> or <code><![CDATA[
+    /// ISet<Article> -> true
+    /// ]]></code>.
     /// </summary>
     public bool TypeCanContainHashSet(Type collectionType)
     {

--- a/src/JsonApiDotNetCore.Annotations/Resources/Annotations/HasManyAttribute.cs
+++ b/src/JsonApiDotNetCore.Annotations/Resources/Annotations/HasManyAttribute.cs
@@ -59,7 +59,7 @@ public sealed class HasManyAttribute : RelationshipAttribute
     {
         if (InverseNavigationProperty != null)
         {
-            Type? elementType = CollectionConverter.FindCollectionElementType(InverseNavigationProperty.PropertyType);
+            Type? elementType = CollectionConverter.Instance.FindCollectionElementType(InverseNavigationProperty.PropertyType);
             return elementType != null;
         }
 
@@ -103,14 +103,14 @@ public sealed class HasManyAttribute : RelationshipAttribute
         ArgumentGuard.NotNull(resourceToAdd);
 
         object? rightValue = GetValue(resource);
-        List<IIdentifiable> rightResources = CollectionConverter.ExtractResources(rightValue).ToList();
+        List<IIdentifiable> rightResources = CollectionConverter.Instance.ExtractResources(rightValue).ToList();
 
         if (!rightResources.Exists(nextResource => nextResource == resourceToAdd))
         {
             rightResources.Add(resourceToAdd);
 
             Type collectionType = rightValue?.GetType() ?? Property.PropertyType;
-            IEnumerable typedCollection = CollectionConverter.CopyToTypedCollection(rightResources, collectionType);
+            IEnumerable typedCollection = CollectionConverter.Instance.CopyToTypedCollection(rightResources, collectionType);
             base.SetValue(resource, typedCollection);
         }
     }

--- a/src/JsonApiDotNetCore.Annotations/Resources/Annotations/HasOneAttribute.cs
+++ b/src/JsonApiDotNetCore.Annotations/Resources/Annotations/HasOneAttribute.cs
@@ -57,7 +57,7 @@ public sealed class HasOneAttribute : RelationshipAttribute
     {
         if (InverseNavigationProperty != null)
         {
-            Type? elementType = CollectionConverter.FindCollectionElementType(InverseNavigationProperty.PropertyType);
+            Type? elementType = CollectionConverter.Instance.FindCollectionElementType(InverseNavigationProperty.PropertyType);
             return elementType == null;
         }
 

--- a/src/JsonApiDotNetCore.Annotations/Resources/Annotations/RelationshipAttribute.cs
+++ b/src/JsonApiDotNetCore.Annotations/Resources/Annotations/RelationshipAttribute.cs
@@ -12,8 +12,6 @@ namespace JsonApiDotNetCore.Resources.Annotations;
 [PublicAPI]
 public abstract class RelationshipAttribute : ResourceFieldAttribute
 {
-    private protected static readonly CollectionConverter CollectionConverter = new();
-
     // This field is definitely assigned after building the resource graph, which is why its public equivalent is declared as non-nullable.
     private ResourceType? _rightType;
 

--- a/src/JsonApiDotNetCore/AtomicOperations/Processors/SetRelationshipProcessor.cs
+++ b/src/JsonApiDotNetCore/AtomicOperations/Processors/SetRelationshipProcessor.cs
@@ -10,7 +10,6 @@ namespace JsonApiDotNetCore.AtomicOperations.Processors;
 public class SetRelationshipProcessor<TResource, TId> : ISetRelationshipProcessor<TResource, TId>
     where TResource : class, IIdentifiable<TId>
 {
-    private readonly CollectionConverter _collectionConverter = new();
     private readonly ISetRelationshipService<TResource, TId> _service;
 
     public SetRelationshipProcessor(ISetRelationshipService<TResource, TId> service)
@@ -40,7 +39,7 @@ public class SetRelationshipProcessor<TResource, TId> : ISetRelationshipProcesso
 
         if (relationship is HasManyAttribute)
         {
-            IReadOnlyCollection<IIdentifiable> rightResources = _collectionConverter.ExtractResources(rightValue);
+            IReadOnlyCollection<IIdentifiable> rightResources = CollectionConverter.Instance.ExtractResources(rightValue);
             return rightResources.ToHashSet(IdentifiableComparer.Instance);
         }
 

--- a/src/JsonApiDotNetCore/Errors/InvalidModelStateException.cs
+++ b/src/JsonApiDotNetCore/Errors/InvalidModelStateException.cs
@@ -319,8 +319,6 @@ public sealed class InvalidModelStateException(
         Func<Type, int, Type?>? getCollectionElementTypeCallback)
         : ModelStateKeySegment(modelType, isInComplexType, nextKey, sourcePointer, parent, getCollectionElementTypeCallback)
     {
-        private static readonly CollectionConverter CollectionConverter = new();
-
         public int ArrayIndex { get; } = arrayIndex;
 
         public Type GetCollectionElementType()
@@ -333,7 +331,7 @@ public sealed class InvalidModelStateException(
         {
             if (ModelType != typeof(string))
             {
-                Type? elementType = CollectionConverter.FindCollectionElementType(ModelType);
+                Type? elementType = CollectionConverter.Instance.FindCollectionElementType(ModelType);
 
                 if (elementType != null)
                 {

--- a/src/JsonApiDotNetCore/Queries/QueryLayerComposer.cs
+++ b/src/JsonApiDotNetCore/Queries/QueryLayerComposer.cs
@@ -212,7 +212,7 @@ public class QueryLayerComposer : IQueryLayerComposer
         foreach (IncludeElementExpression includeElement in includeElementsEvaluated)
         {
             parentLayer.Selection ??= new FieldSelection();
-            FieldSelectors selectors = parentLayer.Selection.GetOrCreateSelectors(parentLayer.ResourceType);
+            FieldSelectors selectors = parentLayer.Selection.GetOrCreateSelectors(includeElement.Relationship.LeftType);
 
             if (!selectors.ContainsField(includeElement.Relationship))
             {

--- a/src/JsonApiDotNetCore/Queries/QueryLayerComposer.cs
+++ b/src/JsonApiDotNetCore/Queries/QueryLayerComposer.cs
@@ -14,7 +14,6 @@ namespace JsonApiDotNetCore.Queries;
 [PublicAPI]
 public class QueryLayerComposer : IQueryLayerComposer
 {
-    private readonly CollectionConverter _collectionConverter = new();
     private readonly IQueryConstraintProvider[] _constraintProviders;
     private readonly IResourceDefinitionAccessor _resourceDefinitionAccessor;
     private readonly IJsonApiOptions _options;
@@ -413,7 +412,7 @@ public class QueryLayerComposer : IQueryLayerComposer
         foreach (RelationshipAttribute relationship in _targetedFields.Relationships)
         {
             object? rightValue = relationship.GetValue(primaryResource);
-            HashSet<IIdentifiable> rightResourceIds = _collectionConverter.ExtractResources(rightValue).ToHashSet(IdentifiableComparer.Instance);
+            HashSet<IIdentifiable> rightResourceIds = CollectionConverter.Instance.ExtractResources(rightValue).ToHashSet(IdentifiableComparer.Instance);
 
             if (rightResourceIds.Count > 0)
             {

--- a/src/JsonApiDotNetCore/Queries/QueryableBuilding/QueryClauseBuilderContext.cs
+++ b/src/JsonApiDotNetCore/Queries/QueryableBuilding/QueryClauseBuilderContext.cs
@@ -61,6 +61,7 @@ public sealed class QueryClauseBuilderContext
         ArgumentGuard.NotNull(lambdaScopeFactory);
         ArgumentGuard.NotNull(lambdaScope);
         ArgumentGuard.NotNull(queryableBuilder);
+        AssertSameType(source.Type, resourceType);
 
         Source = source;
         ResourceType = resourceType;
@@ -70,6 +71,17 @@ public sealed class QueryClauseBuilderContext
         LambdaScopeFactory = lambdaScopeFactory;
         QueryableBuilder = queryableBuilder;
         State = state;
+    }
+
+    private static void AssertSameType(Type sourceType, ResourceType resourceType)
+    {
+        Type? sourceElementType = CollectionConverter.Instance.FindCollectionElementType(sourceType);
+
+        if (sourceElementType != resourceType.ClrType)
+        {
+            throw new InvalidOperationException(
+                $"Internal error: Mismatch between expression type '{sourceElementType?.Name}' and resource type '{resourceType.ClrType.Name}'.");
+        }
     }
 
     public QueryClauseBuilderContext WithSource(Expression source)

--- a/src/JsonApiDotNetCore/Queries/QueryableBuilding/QueryableBuilder.cs
+++ b/src/JsonApiDotNetCore/Queries/QueryableBuilding/QueryableBuilder.cs
@@ -35,6 +35,7 @@ public class QueryableBuilder : IQueryableBuilder
     {
         ArgumentGuard.NotNull(layer);
         ArgumentGuard.NotNull(context);
+        AssertSameType(layer.ResourceType, context.ElementType);
 
         Expression expression = context.Source;
 
@@ -64,6 +65,15 @@ public class QueryableBuilder : IQueryableBuilder
         }
 
         return expression;
+    }
+
+    private static void AssertSameType(ResourceType resourceType, Type elementType)
+    {
+        if (elementType != resourceType.ClrType)
+        {
+            throw new InvalidOperationException(
+                $"Internal error: Mismatch between query layer type '{resourceType.ClrType.Name}' and query element type '{elementType.Name}'.");
+        }
     }
 
     protected virtual Expression ApplyInclude(Expression source, IncludeExpression include, ResourceType resourceType, QueryableBuilderContext context)

--- a/src/JsonApiDotNetCore/Queries/QueryableBuilding/SelectClauseBuilder.cs
+++ b/src/JsonApiDotNetCore/Queries/QueryableBuilding/SelectClauseBuilder.cs
@@ -29,36 +29,47 @@ public class SelectClauseBuilder : QueryClauseBuilder, ISelectClauseBuilder
     {
         ArgumentGuard.NotNull(selection);
 
-        Expression bodyInitializer = CreateLambdaBodyInitializer(selection, context.ResourceType, context.LambdaScope, false, context);
+        Expression bodyInitializer = CreateLambdaBodyInitializer(selection, context.ResourceType, false, context);
 
         LambdaExpression lambda = Expression.Lambda(bodyInitializer, context.LambdaScope.Parameter);
 
         return SelectExtensionMethodCall(context.ExtensionType, context.Source, context.LambdaScope.Parameter.Type, lambda);
     }
 
-    private Expression CreateLambdaBodyInitializer(FieldSelection selection, ResourceType resourceType, LambdaScope lambdaScope,
-        bool lambdaAccessorRequiresTestForNull, QueryClauseBuilderContext context)
+    private Expression CreateLambdaBodyInitializer(FieldSelection selection, ResourceType resourceType, bool lambdaAccessorRequiresTestForNull,
+        QueryClauseBuilderContext context)
     {
+        AssertSameType(context.LambdaScope.Accessor.Type, resourceType);
+
         IReadOnlyEntityType entityType = context.EntityModel.FindEntityType(resourceType.ClrType)!;
         IReadOnlyEntityType[] concreteEntityTypes = entityType.GetConcreteDerivedTypesInclusive().ToArray();
 
         Expression bodyInitializer = concreteEntityTypes.Length > 1
-            ? CreateLambdaBodyInitializerForTypeHierarchy(selection, resourceType, concreteEntityTypes, lambdaScope, context)
-            : CreateLambdaBodyInitializerForSingleType(selection, resourceType, lambdaScope, context);
+            ? CreateLambdaBodyInitializerForTypeHierarchy(selection, resourceType, concreteEntityTypes, context)
+            : CreateLambdaBodyInitializerForSingleType(selection, resourceType, context);
 
         if (!lambdaAccessorRequiresTestForNull)
         {
             return bodyInitializer;
         }
 
-        return TestForNull(lambdaScope.Accessor, bodyInitializer);
+        return TestForNull(context.LambdaScope.Accessor, bodyInitializer);
+    }
+
+    private static void AssertSameType(Type lambdaAccessorType, ResourceType resourceType)
+    {
+        if (lambdaAccessorType != resourceType.ClrType)
+        {
+            throw new InvalidOperationException(
+                $"Internal error: Mismatch between lambda accessor type '{lambdaAccessorType.Name}' and resource type '{resourceType.ClrType.Name}'.");
+        }
     }
 
     private Expression CreateLambdaBodyInitializerForTypeHierarchy(FieldSelection selection, ResourceType baseResourceType,
-        IEnumerable<IReadOnlyEntityType> concreteEntityTypes, LambdaScope lambdaScope, QueryClauseBuilderContext context)
+        IEnumerable<IReadOnlyEntityType> concreteEntityTypes, QueryClauseBuilderContext context)
     {
         IReadOnlySet<ResourceType> resourceTypes = selection.GetResourceTypes();
-        Expression rootCondition = lambdaScope.Accessor;
+        Expression rootCondition = context.LambdaScope.Accessor;
 
         foreach (IReadOnlyEntityType entityType in concreteEntityTypes)
         {
@@ -73,14 +84,14 @@ public class SelectClauseBuilder : QueryClauseBuilder, ISelectClauseBuilder
                     Dictionary<PropertyInfo, PropertySelector>.ValueCollection propertySelectors =
                         ToPropertySelectors(fieldSelectors, resourceType, entityType.ClrType, context.EntityModel);
 
-                    MemberBinding[] propertyAssignments = propertySelectors.Select(selector => CreatePropertyAssignment(selector, lambdaScope, context))
+                    MemberBinding[] propertyAssignments = propertySelectors.Select(selector => CreatePropertyAssignment(selector, context))
                         .Cast<MemberBinding>().ToArray();
 
                     NewExpression createInstance = _resourceFactory.CreateNewExpression(entityType.ClrType);
                     MemberInitExpression memberInit = Expression.MemberInit(createInstance, propertyAssignments);
                     UnaryExpression castToBaseType = Expression.Convert(memberInit, baseResourceType.ClrType);
 
-                    BinaryExpression typeCheck = CreateRuntimeTypeCheck(lambdaScope, entityType.ClrType);
+                    BinaryExpression typeCheck = CreateRuntimeTypeCheck(context.LambdaScope, entityType.ClrType);
                     rootCondition = Expression.Condition(typeCheck, castToBaseType, rootCondition);
                 }
             }
@@ -100,18 +111,16 @@ public class SelectClauseBuilder : QueryClauseBuilder, ISelectClauseBuilder
         return Expression.MakeBinary(ExpressionType.Equal, getTypeCall, concreteTypeConstant, false, TypeOpEqualityMethod);
     }
 
-    private MemberInitExpression CreateLambdaBodyInitializerForSingleType(FieldSelection selection, ResourceType resourceType, LambdaScope lambdaScope,
+    private MemberInitExpression CreateLambdaBodyInitializerForSingleType(FieldSelection selection, ResourceType resourceType,
         QueryClauseBuilderContext context)
     {
         FieldSelectors fieldSelectors = selection.GetOrCreateSelectors(resourceType);
 
         Dictionary<PropertyInfo, PropertySelector>.ValueCollection propertySelectors =
-            ToPropertySelectors(fieldSelectors, resourceType, lambdaScope.Accessor.Type, context.EntityModel);
+            ToPropertySelectors(fieldSelectors, resourceType, context.LambdaScope.Accessor.Type, context.EntityModel);
 
-        MemberBinding[] propertyAssignments = propertySelectors.Select(selector => CreatePropertyAssignment(selector, lambdaScope, context))
-            .Cast<MemberBinding>().ToArray();
-
-        NewExpression createInstance = _resourceFactory.CreateNewExpression(lambdaScope.Accessor.Type);
+        MemberBinding[] propertyAssignments = propertySelectors.Select(selector => CreatePropertyAssignment(selector, context)).Cast<MemberBinding>().ToArray();
+        NewExpression createInstance = _resourceFactory.CreateNewExpression(context.LambdaScope.Accessor.Type);
         return Expression.MemberInit(createInstance, propertyAssignments);
     }
 
@@ -182,35 +191,40 @@ public class SelectClauseBuilder : QueryClauseBuilder, ISelectClauseBuilder
         }
     }
 
-    private MemberAssignment CreatePropertyAssignment(PropertySelector propertySelector, LambdaScope lambdaScope, QueryClauseBuilderContext context)
+    private MemberAssignment CreatePropertyAssignment(PropertySelector propertySelector, QueryClauseBuilderContext context)
     {
-        bool requiresUpCast = lambdaScope.Accessor.Type != propertySelector.Property.DeclaringType &&
-            lambdaScope.Accessor.Type.IsAssignableFrom(propertySelector.Property.DeclaringType);
+        bool requiresUpCast = context.LambdaScope.Accessor.Type != propertySelector.Property.DeclaringType &&
+            context.LambdaScope.Accessor.Type.IsAssignableFrom(propertySelector.Property.DeclaringType);
 
-        MemberExpression propertyAccess = requiresUpCast
-            ? Expression.MakeMemberAccess(Expression.Convert(lambdaScope.Accessor, propertySelector.Property.DeclaringType!), propertySelector.Property)
-            : Expression.Property(lambdaScope.Accessor, propertySelector.Property);
+        UnaryExpression? derivedAccessor = requiresUpCast ? Expression.Convert(context.LambdaScope.Accessor, propertySelector.Property.DeclaringType!) : null;
+
+        MemberExpression propertyAccess = derivedAccessor != null
+            ? Expression.MakeMemberAccess(derivedAccessor, propertySelector.Property)
+            : Expression.Property(context.LambdaScope.Accessor, propertySelector.Property);
 
         Expression assignmentRightHandSide = propertyAccess;
 
         if (propertySelector.NextLayer != null)
         {
-            assignmentRightHandSide =
-                CreateAssignmentRightHandSideForLayer(propertySelector.NextLayer, lambdaScope, propertyAccess, propertySelector.Property, context);
+            QueryClauseBuilderContext rightHandSideContext =
+                derivedAccessor != null ? context.WithLambdaScope(context.LambdaScope.WithAccessor(derivedAccessor)) : context;
+
+            assignmentRightHandSide = CreateAssignmentRightHandSideForLayer(propertySelector.NextLayer, propertyAccess,
+                propertySelector.Property, rightHandSideContext);
         }
 
         return Expression.Bind(propertySelector.Property, assignmentRightHandSide);
     }
 
-    private Expression CreateAssignmentRightHandSideForLayer(QueryLayer layer, LambdaScope outerLambdaScope, MemberExpression propertyAccess,
-        PropertyInfo selectorPropertyInfo, QueryClauseBuilderContext context)
+    private Expression CreateAssignmentRightHandSideForLayer(QueryLayer layer, MemberExpression propertyAccess, PropertyInfo selectorPropertyInfo,
+        QueryClauseBuilderContext context)
     {
         Type? collectionElementType = CollectionConverter.Instance.FindCollectionElementType(selectorPropertyInfo.PropertyType);
         Type bodyElementType = collectionElementType ?? selectorPropertyInfo.PropertyType;
 
         if (collectionElementType != null)
         {
-            return CreateCollectionInitializer(outerLambdaScope, selectorPropertyInfo, bodyElementType, layer, context);
+            return CreateCollectionInitializer(selectorPropertyInfo, bodyElementType, layer, context);
         }
 
         if (layer.Selection == null || layer.Selection.IsEmpty)
@@ -218,14 +232,15 @@ public class SelectClauseBuilder : QueryClauseBuilder, ISelectClauseBuilder
             return propertyAccess;
         }
 
-        using LambdaScope scope = context.LambdaScopeFactory.CreateScope(bodyElementType, propertyAccess);
-        return CreateLambdaBodyInitializer(layer.Selection, layer.ResourceType, scope, true, context);
+        using LambdaScope initializerScope = context.LambdaScopeFactory.CreateScope(bodyElementType, propertyAccess);
+        QueryClauseBuilderContext initializerContext = context.WithLambdaScope(initializerScope);
+        return CreateLambdaBodyInitializer(layer.Selection, layer.ResourceType, true, initializerContext);
     }
 
-    private static MethodCallExpression CreateCollectionInitializer(LambdaScope lambdaScope, PropertyInfo collectionProperty, Type elementType,
-        QueryLayer layer, QueryClauseBuilderContext context)
+    private static MethodCallExpression CreateCollectionInitializer(PropertyInfo collectionProperty, Type elementType, QueryLayer layer,
+        QueryClauseBuilderContext context)
     {
-        MemberExpression propertyExpression = Expression.Property(lambdaScope.Accessor, collectionProperty);
+        MemberExpression propertyExpression = Expression.Property(context.LambdaScope.Accessor, collectionProperty);
 
         var nestedContext = new QueryableBuilderContext(propertyExpression, elementType, typeof(Enumerable), context.EntityModel, context.LambdaScopeFactory,
             context.State);

--- a/src/JsonApiDotNetCore/Queries/QueryableBuilding/SelectClauseBuilder.cs
+++ b/src/JsonApiDotNetCore/Queries/QueryableBuilding/SelectClauseBuilder.cs
@@ -14,7 +14,6 @@ public class SelectClauseBuilder : QueryClauseBuilder, ISelectClauseBuilder
 {
     private static readonly MethodInfo TypeGetTypeMethod = typeof(object).GetMethod("GetType")!;
     private static readonly MethodInfo TypeOpEqualityMethod = typeof(Type).GetMethod("op_Equality")!;
-    private static readonly CollectionConverter CollectionConverter = new();
     private static readonly ConstantExpression NullConstant = Expression.Constant(null);
 
     private readonly IResourceFactory _resourceFactory;
@@ -206,7 +205,7 @@ public class SelectClauseBuilder : QueryClauseBuilder, ISelectClauseBuilder
     private Expression CreateAssignmentRightHandSideForLayer(QueryLayer layer, LambdaScope outerLambdaScope, MemberExpression propertyAccess,
         PropertyInfo selectorPropertyInfo, QueryClauseBuilderContext context)
     {
-        Type? collectionElementType = CollectionConverter.FindCollectionElementType(selectorPropertyInfo.PropertyType);
+        Type? collectionElementType = CollectionConverter.Instance.FindCollectionElementType(selectorPropertyInfo.PropertyType);
         Type bodyElementType = collectionElementType ?? selectorPropertyInfo.PropertyType;
 
         if (collectionElementType != null)
@@ -233,7 +232,7 @@ public class SelectClauseBuilder : QueryClauseBuilder, ISelectClauseBuilder
 
         Expression layerExpression = context.QueryableBuilder.ApplyQuery(layer, nestedContext);
 
-        string operationName = CollectionConverter.TypeCanContainHashSet(collectionProperty.PropertyType) ? "ToHashSet" : "ToList";
+        string operationName = CollectionConverter.Instance.TypeCanContainHashSet(collectionProperty.PropertyType) ? "ToHashSet" : "ToList";
         return CopyCollectionExtensionMethodCall(layerExpression, operationName, elementType);
     }
 

--- a/src/JsonApiDotNetCore/Queries/QueryableBuilding/WhereClauseBuilder.cs
+++ b/src/JsonApiDotNetCore/Queries/QueryableBuilding/WhereClauseBuilder.cs
@@ -13,7 +13,6 @@ namespace JsonApiDotNetCore.Queries.QueryableBuilding;
 [PublicAPI]
 public class WhereClauseBuilder : QueryClauseBuilder, IWhereClauseBuilder
 {
-    private static readonly CollectionConverter CollectionConverter = new();
     private static readonly ConstantExpression NullConstant = Expression.Constant(null);
 
     public virtual Expression ApplyWhere(FilterExpression filter, QueryClauseBuilderContext context)
@@ -40,7 +39,7 @@ public class WhereClauseBuilder : QueryClauseBuilder, IWhereClauseBuilder
     {
         Expression property = Visit(expression.TargetCollection, context);
 
-        Type? elementType = CollectionConverter.FindCollectionElementType(property.Type);
+        Type? elementType = CollectionConverter.Instance.FindCollectionElementType(property.Type);
 
         if (elementType == null)
         {

--- a/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
+++ b/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
@@ -31,7 +31,6 @@ namespace JsonApiDotNetCore.Repositories;
 public class EntityFrameworkCoreRepository<TResource, TId> : IResourceRepository<TResource, TId>, IRepositorySupportsTransaction
     where TResource : class, IIdentifiable<TId>
 {
-    private readonly CollectionConverter _collectionConverter = new();
     private readonly ITargetedFields _targetedFields;
     private readonly DbContext _dbContext;
     private readonly IResourceGraph _resourceGraph;
@@ -250,7 +249,7 @@ public class EntityFrameworkCoreRepository<TResource, TId> : IResourceRepository
 
         if (relationship is HasManyAttribute hasManyRelationship)
         {
-            HashSet<IIdentifiable> rightResourceIds = _collectionConverter.ExtractResources(rightValue).ToHashSet(IdentifiableComparer.Instance);
+            HashSet<IIdentifiable> rightResourceIds = CollectionConverter.Instance.ExtractResources(rightValue).ToHashSet(IdentifiableComparer.Instance);
 
             await _resourceDefinitionAccessor.OnSetToManyRelationshipAsync(leftResource, hasManyRelationship, rightResourceIds, writeOperation,
                 cancellationToken);
@@ -482,14 +481,14 @@ public class EntityFrameworkCoreRepository<TResource, TId> : IResourceRepository
         object? rightValueStored = relationship.GetValue(leftResource);
 
         // @formatter:wrap_chained_method_calls chop_always
-        // @formatter:wrap_before_first_method_call true
+        // @formatter:wrap_after_property_in_chained_method_calls true
 
-        HashSet<IIdentifiable> rightResourceIdsStored = _collectionConverter
+        HashSet<IIdentifiable> rightResourceIdsStored = CollectionConverter.Instance
             .ExtractResources(rightValueStored)
             .Select(_dbContext.GetTrackedOrAttach)
             .ToHashSet(IdentifiableComparer.Instance);
 
-        // @formatter:wrap_before_first_method_call restore
+        // @formatter:wrap_after_property_in_chained_method_calls restore
         // @formatter:wrap_chained_method_calls restore
 
         if (rightResourceIdsStored.Count > 0)
@@ -531,18 +530,18 @@ public class EntityFrameworkCoreRepository<TResource, TId> : IResourceRepository
             object? rightValueStored = relationship.GetValue(leftResourceTracked);
 
             // @formatter:wrap_chained_method_calls chop_always
-            // @formatter:wrap_before_first_method_call true
+            // @formatter:wrap_after_property_in_chained_method_calls true
 
-            IIdentifiable[] rightResourceIdsStored = _collectionConverter
+            IIdentifiable[] rightResourceIdsStored = CollectionConverter.Instance
                 .ExtractResources(rightValueStored)
                 .Concat(extraResourceIdsToRemove)
                 .Select(_dbContext.GetTrackedOrAttach)
                 .ToArray();
 
-            // @formatter:wrap_before_first_method_call restore
+            // @formatter:wrap_after_property_in_chained_method_calls restore
             // @formatter:wrap_chained_method_calls restore
 
-            rightValueStored = _collectionConverter.CopyToTypedCollection(rightResourceIdsStored, relationship.Property.PropertyType);
+            rightValueStored = CollectionConverter.Instance.CopyToTypedCollection(rightResourceIdsStored, relationship.Property.PropertyType);
             relationship.SetValue(leftResourceTracked, rightValueStored);
 
             MarkRelationshipAsLoaded(leftResourceTracked, relationship);
@@ -624,11 +623,11 @@ public class EntityFrameworkCoreRepository<TResource, TId> : IResourceRepository
             return null;
         }
 
-        IReadOnlyCollection<IIdentifiable> rightResources = _collectionConverter.ExtractResources(rightValue);
+        IReadOnlyCollection<IIdentifiable> rightResources = CollectionConverter.Instance.ExtractResources(rightValue);
         IIdentifiable[] rightResourcesTracked = rightResources.Select(_dbContext.GetTrackedOrAttach).ToArray();
 
         return rightValue is IEnumerable
-            ? _collectionConverter.CopyToTypedCollection(rightResourcesTracked, relationshipPropertyType)
+            ? CollectionConverter.Instance.CopyToTypedCollection(rightResourcesTracked, relationshipPropertyType)
             : rightResourcesTracked.Single();
     }
 

--- a/src/JsonApiDotNetCore/Repositories/IResourceRepositoryAccessor.cs
+++ b/src/JsonApiDotNetCore/Repositories/IResourceRepositoryAccessor.cs
@@ -12,6 +12,11 @@ namespace JsonApiDotNetCore.Repositories;
 public interface IResourceRepositoryAccessor
 {
     /// <summary>
+    /// Uses the <see cref="IResourceGraph" /> to lookup the corresponding <see cref="ResourceType" /> for the specified CLR type.
+    /// </summary>
+    ResourceType LookupResourceType(Type resourceClrType);
+
+    /// <summary>
     /// Invokes <see cref="IResourceReadRepository{TResource,TId}.GetAsync" /> for the specified resource type.
     /// </summary>
     Task<IReadOnlyCollection<TResource>> GetAsync<TResource>(QueryLayer queryLayer, CancellationToken cancellationToken)

--- a/src/JsonApiDotNetCore/Repositories/ResourceRepositoryAccessor.cs
+++ b/src/JsonApiDotNetCore/Repositories/ResourceRepositoryAccessor.cs
@@ -30,6 +30,14 @@ public class ResourceRepositoryAccessor : IResourceRepositoryAccessor
     }
 
     /// <inheritdoc />
+    public ResourceType LookupResourceType(Type resourceClrType)
+    {
+        ArgumentGuard.NotNull(resourceClrType);
+
+        return _resourceGraph.GetResourceType(resourceClrType);
+    }
+
+    /// <inheritdoc />
     public async Task<IReadOnlyCollection<TResource>> GetAsync<TResource>(QueryLayer queryLayer, CancellationToken cancellationToken)
         where TResource : class, IIdentifiable
     {

--- a/src/JsonApiDotNetCore/Resources/OperationContainer.cs
+++ b/src/JsonApiDotNetCore/Resources/OperationContainer.cs
@@ -10,8 +10,6 @@ namespace JsonApiDotNetCore.Resources;
 [PublicAPI]
 public sealed class OperationContainer
 {
-    private static readonly CollectionConverter CollectionConverter = new();
-
     public IIdentifiable Resource { get; }
     public ITargetedFields TargetedFields { get; }
     public IJsonApiRequest Request { get; }
@@ -56,7 +54,7 @@ public sealed class OperationContainer
     private void AddSecondaryResources(RelationshipAttribute relationship, HashSet<IIdentifiable> secondaryResources)
     {
         object? rightValue = relationship.GetValue(Resource);
-        IReadOnlyCollection<IIdentifiable> rightResources = CollectionConverter.ExtractResources(rightValue);
+        IReadOnlyCollection<IIdentifiable> rightResources = CollectionConverter.Instance.ExtractResources(rightValue);
 
         secondaryResources.UnionWith(rightResources);
     }

--- a/src/JsonApiDotNetCore/Serialization/Request/Adapters/RelationshipDataAdapter.cs
+++ b/src/JsonApiDotNetCore/Serialization/Request/Adapters/RelationshipDataAdapter.cs
@@ -9,8 +9,6 @@ namespace JsonApiDotNetCore.Serialization.Request.Adapters;
 /// <inheritdoc cref="IRelationshipDataAdapter" />
 public sealed class RelationshipDataAdapter : BaseAdapter, IRelationshipDataAdapter
 {
-    private static readonly CollectionConverter CollectionConverter = new();
-
     private readonly IResourceIdentifierObjectAdapter _resourceIdentifierObjectAdapter;
 
     public RelationshipDataAdapter(IResourceIdentifierObjectAdapter resourceIdentifierObjectAdapter)
@@ -109,7 +107,7 @@ public sealed class RelationshipDataAdapter : BaseAdapter, IRelationshipDataAdap
 
         if (useToManyElementType)
         {
-            return CollectionConverter.CopyToTypedCollection(rightResources, relationship.Property.PropertyType);
+            return CollectionConverter.Instance.CopyToTypedCollection(rightResources, relationship.Property.PropertyType);
         }
 
         var resourceSet = new HashSet<IIdentifiable>(IdentifiableComparer.Instance);

--- a/src/JsonApiDotNetCore/Serialization/Response/ResponseModelAdapter.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/ResponseModelAdapter.cs
@@ -18,8 +18,6 @@ namespace JsonApiDotNetCore.Serialization.Response;
 [PublicAPI]
 public class ResponseModelAdapter : IResponseModelAdapter
 {
-    private static readonly CollectionConverter CollectionConverter = new();
-
     private readonly IJsonApiRequest _request;
     private readonly IJsonApiOptions _options;
     private readonly ILinkBuilder _linkBuilder;
@@ -304,7 +302,7 @@ public class ResponseModelAdapter : IResponseModelAdapter
         }
 
         object? rightValue = effectiveRelationship.GetValue(leftResource);
-        IReadOnlyCollection<IIdentifiable> rightResources = CollectionConverter.ExtractResources(rightValue);
+        IReadOnlyCollection<IIdentifiable> rightResources = CollectionConverter.Instance.ExtractResources(rightValue);
 
         leftTreeNode.EnsureHasRelationship(effectiveRelationship);
 

--- a/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
@@ -21,7 +21,6 @@ namespace JsonApiDotNetCore.Services;
 public class JsonApiResourceService<TResource, TId> : IResourceService<TResource, TId>
     where TResource : class, IIdentifiable<TId>
 {
-    private readonly CollectionConverter _collectionConverter = new();
     private readonly IResourceRepositoryAccessor _repositoryAccessor;
     private readonly IQueryLayerComposer _queryLayerComposer;
     private readonly IPaginationContext _paginationContext;
@@ -280,7 +279,7 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
             if (!onlyIfTypeHierarchy || relationship.RightType.IsPartOfTypeHierarchy())
             {
                 object? rightValue = relationship.GetValue(primaryResource);
-                HashSet<IIdentifiable> rightResourceIds = _collectionConverter.ExtractResources(rightValue).ToHashSet(IdentifiableComparer.Instance);
+                HashSet<IIdentifiable> rightResourceIds = CollectionConverter.Instance.ExtractResources(rightValue).ToHashSet(IdentifiableComparer.Instance);
 
                 if (rightResourceIds.Count > 0)
                 {
@@ -293,7 +292,7 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
                     // Now that we've fetched them, update the request types so that resource definitions observe the actually stored types.
                     object? newRightValue = relationship is HasOneAttribute
                         ? rightResourceIds.FirstOrDefault()
-                        : _collectionConverter.CopyToTypedCollection(rightResourceIds, relationship.Property.PropertyType);
+                        : CollectionConverter.Instance.CopyToTypedCollection(rightResourceIds, relationship.Property.PropertyType);
 
                     relationship.SetValue(primaryResource, newRightValue);
                 }
@@ -401,7 +400,7 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
         TResource leftResource = await GetForHasManyUpdateAsync(hasManyRelationship, leftId, rightResourceIds, cancellationToken);
 
         object? rightValue = hasManyRelationship.GetValue(leftResource);
-        IReadOnlyCollection<IIdentifiable> existingRightResourceIds = _collectionConverter.ExtractResources(rightValue);
+        IReadOnlyCollection<IIdentifiable> existingRightResourceIds = CollectionConverter.Instance.ExtractResources(rightValue);
 
         rightResourceIds.ExceptWith(existingRightResourceIds);
 
@@ -422,7 +421,7 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
     {
         AssertRelationshipInJsonApiRequestIsNotNull(_request.Relationship);
 
-        HashSet<IIdentifiable> rightResourceIds = _collectionConverter.ExtractResources(rightValue).ToHashSet(IdentifiableComparer.Instance);
+        HashSet<IIdentifiable> rightResourceIds = CollectionConverter.Instance.ExtractResources(rightValue).ToHashSet(IdentifiableComparer.Instance);
         object? newRightValue = rightValue;
 
         if (rightResourceIds.Count > 0)
@@ -436,7 +435,7 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
             // Now that we've fetched them, update the request types so that resource definitions observe the actually stored types.
             newRightValue = _request.Relationship is HasOneAttribute
                 ? rightResourceIds.FirstOrDefault()
-                : _collectionConverter.CopyToTypedCollection(rightResourceIds, _request.Relationship.Property.PropertyType);
+                : CollectionConverter.Instance.CopyToTypedCollection(rightResourceIds, _request.Relationship.Property.PropertyType);
 
             if (missingResources.Count > 0)
             {

--- a/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
@@ -58,9 +58,9 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
     {
         _traceWriter.LogMethodStart();
 
-        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Service - Get resources");
-
         AssertPrimaryResourceTypeInJsonApiRequestIsNotNull(_request.PrimaryResourceType);
+
+        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Service - Get resources");
 
         if (_options.IncludeTotalResourceCount)
         {
@@ -106,11 +106,11 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
             relationshipName
         });
 
-        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Service - Get secondary resource(s)");
-
         ArgumentGuard.NotNull(relationshipName);
         AssertPrimaryResourceTypeInJsonApiRequestIsNotNull(_request.PrimaryResourceType);
         AssertHasRelationship(_request.Relationship, relationshipName);
+
+        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Service - Get secondary resource(s)");
 
         if (_options.IncludeTotalResourceCount && _request.IsCollection)
         {
@@ -146,11 +146,11 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
             relationshipName
         });
 
-        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Service - Get relationship");
-
         ArgumentGuard.NotNull(relationshipName);
         AssertPrimaryResourceTypeInJsonApiRequestIsNotNull(_request.PrimaryResourceType);
         AssertHasRelationship(_request.Relationship, relationshipName);
+
+        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Service - Get relationship");
 
         if (_options.IncludeTotalResourceCount && _request.IsCollection)
         {
@@ -349,11 +349,11 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
             rightResourceIds
         });
 
-        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Service - Add to to-many relationship");
-
         ArgumentGuard.NotNull(relationshipName);
         ArgumentGuard.NotNull(rightResourceIds);
         AssertHasRelationship(_request.Relationship, relationshipName);
+
+        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Service - Add to to-many relationship");
 
         TResource? resourceFromDatabase = null;
 
@@ -499,10 +499,10 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
             rightValue
         });
 
-        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Service - Set relationship");
-
         ArgumentGuard.NotNull(relationshipName);
         AssertHasRelationship(_request.Relationship, relationshipName);
+
+        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Service - Set relationship");
 
         object? effectiveRightValue = _request.Relationship.RightType.IsPartOfTypeHierarchy()
             // Some of the incoming right-side resources may be stored as a derived type. We fetch them, so we'll know
@@ -534,9 +534,9 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
             id
         });
 
-        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Repository - Delete resource");
-
         AssertPrimaryResourceTypeInJsonApiRequestIsNotNull(_request.PrimaryResourceType);
+
+        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Repository - Delete resource");
 
         TResource? resourceFromDatabase = null;
 
@@ -570,11 +570,12 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
             rightResourceIds
         });
 
-        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Repository - Remove from to-many relationship");
-
         ArgumentGuard.NotNull(relationshipName);
         ArgumentGuard.NotNull(rightResourceIds);
         AssertHasRelationship(_request.Relationship, relationshipName);
+
+        using IDisposable _ = CodeTimingSessionManager.Current.Measure("Repository - Remove from to-many relationship");
+
         var hasManyRelationship = (HasManyAttribute)_request.Relationship;
 
         TResource resourceFromDatabase = await GetForHasManyUpdateAsync(hasManyRelationship, leftId, rightResourceIds, cancellationToken);
@@ -599,9 +600,10 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
     private async Task<TResource?> GetPrimaryResourceByIdOrDefaultAsync([DisallowNull] TId id, TopFieldSelection fieldSelection,
         CancellationToken cancellationToken)
     {
-        AssertPrimaryResourceTypeInJsonApiRequestIsNotNull(_request.PrimaryResourceType);
+        // Using the non-accurized resource type, so that includes on sibling derived types can be used at abstract endpoint.
+        ResourceType resourceType = _repositoryAccessor.LookupResourceType(typeof(TResource));
 
-        QueryLayer primaryLayer = _queryLayerComposer.ComposeForGetById(id, _request.PrimaryResourceType, fieldSelection);
+        QueryLayer primaryLayer = _queryLayerComposer.ComposeForGetById(id, resourceType, fieldSelection);
 
         IReadOnlyCollection<TResource> primaryResources = await _repositoryAccessor.GetAsync<TResource>(primaryLayer, cancellationToken);
         return primaryResources.SingleOrDefault();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceWriteTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceInheritance/ResourceInheritanceWriteTests.cs
@@ -108,7 +108,7 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
     }
 
     [Fact]
-    public async Task Can_create_concrete_base_resource_at_abstract_endpoint_with_relationships()
+    public async Task Can_create_concrete_base_resource_at_abstract_endpoint_with_relationships_and_includes()
     {
         // Arrange
         var bikeStore = _testContext.Factory.Services.GetRequiredService<ResourceTypeCaptureStore<Bike, long>>();
@@ -184,7 +184,7 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
             }
         };
 
-        const string route = "/vehicles";
+        const string route = "/vehicles?include=manufacturer,wheels,engine,navigationSystem,features,sleepingArea,cargoBox,lights,foldingDimensions";
 
         // Act
         (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
@@ -238,7 +238,7 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
     }
 
     [Fact]
-    public async Task Can_create_concrete_derived_resource_at_abstract_endpoint_with_relationships()
+    public async Task Can_create_concrete_derived_resource_at_abstract_endpoint_with_relationships_and_includes()
     {
         // Arrange
         var carStore = _testContext.Factory.Services.GetRequiredService<ResourceTypeCaptureStore<Car, long>>();
@@ -325,7 +325,7 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
             }
         };
 
-        const string route = "/vehicles";
+        const string route = "/vehicles?include=manufacturer,wheels,engine,navigationSystem,features,sleepingArea,cargoBox,lights,foldingDimensions";
 
         // Act
         (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
@@ -385,7 +385,7 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
     }
 
     [Fact]
-    public async Task Can_create_concrete_derived_resource_at_concrete_base_endpoint_with_relationships()
+    public async Task Can_create_concrete_derived_resource_at_concrete_base_endpoint_with_relationships_and_includes()
     {
         // Arrange
         var tandemStore = _testContext.Factory.Services.GetRequiredService<ResourceTypeCaptureStore<Tandem, long>>();
@@ -475,7 +475,7 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
             }
         };
 
-        const string route = "/bikes";
+        const string route = "/bikes?include=manufacturer,wheels,cargoBox,lights,foldingDimensions,features";
 
         // Act
         (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody);
@@ -980,7 +980,7 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
     }
 
     [Fact]
-    public async Task Can_update_concrete_base_resource_at_abstract_endpoint_with_relationships()
+    public async Task Can_update_concrete_base_resource_at_abstract_endpoint_with_relationships_and_includes()
     {
         // Arrange
         var bikeStore = _testContext.Factory.Services.GetRequiredService<ResourceTypeCaptureStore<Bike, long>>();
@@ -1059,7 +1059,8 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
             }
         };
 
-        string route = $"/vehicles/{existingBike.StringId}";
+        string route =
+            $"/vehicles/{existingBike.StringId}?include=manufacturer,wheels,engine,navigationSystem,features,sleepingArea,cargoBox,lights,foldingDimensions";
 
         // Act
         (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePatchAsync<string>(route, requestBody);
@@ -1108,7 +1109,7 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
     }
 
     [Fact]
-    public async Task Can_update_concrete_base_resource_stored_as_concrete_derived_at_abstract_endpoint_with_relationships()
+    public async Task Can_update_concrete_base_resource_stored_as_concrete_derived_at_abstract_endpoint_with_relationships_and_includes()
     {
         // Arrange
         var tandemStore = _testContext.Factory.Services.GetRequiredService<ResourceTypeCaptureStore<Tandem, long>>();
@@ -1187,7 +1188,8 @@ public abstract class ResourceInheritanceWriteTests<TDbContext> : IClassFixture<
             }
         };
 
-        string route = $"/vehicles/{existingTandem.StringId}";
+        string route =
+            $"/vehicles/{existingTandem.StringId}?include=manufacturer,wheels,engine,navigationSystem,features,sleepingArea,cargoBox,lights,foldingDimensions";
 
         // Act
         (HttpResponseMessage httpResponse, string responseDocument) = await _testContext.ExecutePatchAsync<string>(route, requestBody);

--- a/test/JsonApiDotNetCoreTests/UnitTests/QueryStringParameters/IncludeParseTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/QueryStringParameters/IncludeParseTests.cs
@@ -93,9 +93,9 @@ public sealed class IncludeParseTests : BaseParseTests
     [InlineData("includes", "posts.comments", "posts.comments")]
     [InlineData("includes", "posts,posts.comments", "posts.comments")]
     [InlineData("includes", "posts,posts.labels,posts.comments", "posts.comments,posts.labels")]
-    [InlineData("includes", "owner.person.children.husband", "owner.person.children.husband")]
+    [InlineData("includes", "owner.person.children.husband", "owner.person.children.husband,owner.person.children.husband")]
     [InlineData("includes", "owner.person.wife,owner.person.husband", "owner.person.husband,owner.person.wife")]
-    [InlineData("includes", "owner.person.father.children.wife", "owner.person.father.children.wife")]
+    [InlineData("includes", "owner.person.father.children.wife", "owner.person.father.children.wife,owner.person.father.children.wife")]
     [InlineData("includes", "owner.person.friends", "owner.person.friends,owner.person.friends")]
     [InlineData("includes", "owner.person.friends.friends",
         "owner.person.friends.friends,owner.person.friends.friends,owner.person.friends.friends,owner.person.friends.friends")]


### PR DESCRIPTION
To render selectors for derived types, a selector for each non-abstract derived type must be available in `QueryLayer.Selection`, which wasn't the case.

Parsing of include chains is changed to include relationships on all concrete derived types.
For example, given an inclusion chain of "wheels" at `/vehicles`, the parser now returns `Car.Wheels` and `Truck.Wheels`. This used to be `Vehicle.Wheels`. There's no point in adding abstract types, because they can't be instantiated in selectors.

`QueryLayerComposer` was fixed to generate selectors for the left-type of these relationships, instead of for the `QueryLayer` resource type (so `Car.Wheels` and `Truck.Wheels` instead of `Vehicle.Wheels`).

`SelectClauseBuilder` was missing a cast to the derived type when descending into relationship selectors, which is fixed now.

Being unable to include relationships of sibling types after a POST/PATCH resource request at a base endpoint was because a `QueryLayer` for fetch-after-post was built against the accurized resource type, and then sent to the original (non-accurized) repository. For example, `POST /vehicles?include=TruckRelationship,CarRelationship` only works if the query executes against the non-accurized table (so `Vehicle` instead of `Car`, because `Car` doesn't contain `TruckRelationship`). The fix is to discard the accurized resource type and use the original `TResource`.

Other improvements:
- During the process of building expression trees, consistency checks have been added to prevent downstream crashes that are difficult to diagnose.
- `SelectClauseBuilder` internally passed along a `LambdaScope` that overruled the one present in context, so care had to be taken to use the right one. To eliminate this pitfall, now a new context is forked which contains the appropriate `LambdaScope`, so the overruling parameter is no longer needed.

Fixes #1639, fixes #1640.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
