### PR TITLE
IJsonApiEndpointFilter: remove controller action methods at runtime

### DIFF
--- a/src/JsonApiDotNetCore.Annotations/Configuration/ResourceType.cs
+++ b/src/JsonApiDotNetCore.Annotations/Configuration/ResourceType.cs
@@ -217,7 +217,7 @@ public sealed class ResourceType
     }
 
     /// <summary>
-    /// Returns all directly and indirectly non-abstract resource types that derive from this resource type.
+    /// Returns all non-abstract resource types that directly or indirectly derive from this resource type.
     /// </summary>
     public IReadOnlySet<ResourceType> GetAllConcreteDerivedTypes()
     {

--- a/src/JsonApiDotNetCore/AtomicOperations/IAtomicOperationFilter.cs
+++ b/src/JsonApiDotNetCore/AtomicOperations/IAtomicOperationFilter.cs
@@ -6,7 +6,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 namespace JsonApiDotNetCore.AtomicOperations;
 
 /// <summary>
-/// Determines whether an operation in an atomic:operations request can be used.
+/// Determines whether an operation in an atomic:operations request can be used. For non-operations requests, see <see cref="IJsonApiEndpointFilter" />.
 /// </summary>
 /// <remarks>
 /// The default implementation relies on the usage of <see cref="ResourceAttribute.GenerateControllerEndpoints" />. If you're using explicit

--- a/src/JsonApiDotNetCore/Configuration/JsonApiApplicationBuilder.cs
+++ b/src/JsonApiDotNetCore/Configuration/JsonApiApplicationBuilder.cs
@@ -184,6 +184,7 @@ internal sealed class JsonApiApplicationBuilder : IJsonApiApplicationBuilder
         _services.TryAddSingleton<IJsonApiOutputFormatter, JsonApiOutputFormatter>();
         _services.TryAddSingleton<IJsonApiRoutingConvention, JsonApiRoutingConvention>();
         _services.TryAddSingleton<IControllerResourceMapping>(provider => provider.GetRequiredService<IJsonApiRoutingConvention>());
+        _services.TryAddSingleton<IJsonApiEndpointFilter, AlwaysEnabledJsonApiEndpointFilter>();
         _services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
         _services.TryAddSingleton<IJsonApiContentNegotiator, JsonApiContentNegotiator>();
         _services.TryAddScoped<IJsonApiRequest, JsonApiRequest>();

--- a/src/JsonApiDotNetCore/Controllers/BaseJsonApiOperationsController.cs
+++ b/src/JsonApiDotNetCore/Controllers/BaseJsonApiOperationsController.cs
@@ -136,11 +136,11 @@ public abstract class BaseJsonApiOperationsController : CoreJsonApiController
         for (int operationIndex = 0; operationIndex < operations.Count; operationIndex++)
         {
             IJsonApiRequest operationRequest = operations[operationIndex].Request;
-            WriteOperationKind operationKind = operationRequest.WriteOperation!.Value;
+            WriteOperationKind writeOperation = operationRequest.WriteOperation!.Value;
 
-            if (operationRequest.Relationship != null && !_operationFilter.IsEnabled(operationRequest.Relationship.LeftType, operationKind))
+            if (operationRequest.Relationship != null && !_operationFilter.IsEnabled(operationRequest.Relationship.LeftType, writeOperation))
             {
-                string operationCode = GetOperationCodeText(operationKind);
+                string operationCode = GetOperationCodeText(writeOperation);
 
                 errors.Add(new ErrorObject(HttpStatusCode.Forbidden)
                 {
@@ -153,9 +153,9 @@ public abstract class BaseJsonApiOperationsController : CoreJsonApiController
                     }
                 });
             }
-            else if (operationRequest.PrimaryResourceType != null && !_operationFilter.IsEnabled(operationRequest.PrimaryResourceType, operationKind))
+            else if (operationRequest.PrimaryResourceType != null && !_operationFilter.IsEnabled(operationRequest.PrimaryResourceType, writeOperation))
             {
-                string operationCode = GetOperationCodeText(operationKind);
+                string operationCode = GetOperationCodeText(writeOperation);
 
                 errors.Add(new ErrorObject(HttpStatusCode.Forbidden)
                 {
@@ -175,9 +175,9 @@ public abstract class BaseJsonApiOperationsController : CoreJsonApiController
         }
     }
 
-    private static string GetOperationCodeText(WriteOperationKind operationKind)
+    private static string GetOperationCodeText(WriteOperationKind writeOperation)
     {
-        AtomicOperationCode operationCode = operationKind switch
+        AtomicOperationCode operationCode = writeOperation switch
         {
             WriteOperationKind.CreateResource => AtomicOperationCode.Add,
             WriteOperationKind.UpdateResource => AtomicOperationCode.Update,
@@ -185,7 +185,7 @@ public abstract class BaseJsonApiOperationsController : CoreJsonApiController
             WriteOperationKind.AddToRelationship => AtomicOperationCode.Add,
             WriteOperationKind.SetRelationship => AtomicOperationCode.Update,
             WriteOperationKind.RemoveFromRelationship => AtomicOperationCode.Remove,
-            _ => throw new NotSupportedException($"Unknown operation kind '{operationKind}'.")
+            _ => throw new NotSupportedException($"Unknown operation kind '{writeOperation}'.")
         };
 
         return operationCode.ToString().ToLowerInvariant();

--- a/src/JsonApiDotNetCore/Middleware/AlwaysEnabledJsonApiEndpointFilter.cs
+++ b/src/JsonApiDotNetCore/Middleware/AlwaysEnabledJsonApiEndpointFilter.cs
@@ -1,0 +1,13 @@
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Controllers;
+
+namespace JsonApiDotNetCore.Middleware;
+
+internal sealed class AlwaysEnabledJsonApiEndpointFilter : IJsonApiEndpointFilter
+{
+    /// <inheritdoc />
+    public bool IsEnabled(ResourceType resourceType, JsonApiEndpoints endpoint)
+    {
+        return true;
+    }
+}

--- a/src/JsonApiDotNetCore/Middleware/HttpMethodAttributeExtensions.cs
+++ b/src/JsonApiDotNetCore/Middleware/HttpMethodAttributeExtensions.cs
@@ -1,0 +1,56 @@
+using JsonApiDotNetCore.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+
+namespace JsonApiDotNetCore.Middleware;
+
+internal static class HttpMethodAttributeExtensions
+{
+    private const string IdTemplate = "{id}";
+    private const string RelationshipNameTemplate = "{relationshipName}";
+    private const string SecondaryEndpointTemplate = $"{IdTemplate}/{RelationshipNameTemplate}";
+    private const string RelationshipEndpointTemplate = $"{IdTemplate}/relationships/{RelationshipNameTemplate}";
+
+    public static JsonApiEndpoints GetJsonApiEndpoint(this IEnumerable<HttpMethodAttribute> httpMethods)
+    {
+        ArgumentGuard.NotNull(httpMethods);
+
+        HttpMethodAttribute[] nonHeadAttributes = httpMethods.Where(attribute => attribute is not HttpHeadAttribute).ToArray();
+
+        return nonHeadAttributes.Length == 1 ? ResolveJsonApiEndpoint(nonHeadAttributes[0]) : JsonApiEndpoints.None;
+    }
+
+    private static JsonApiEndpoints ResolveJsonApiEndpoint(HttpMethodAttribute httpMethod)
+    {
+        return httpMethod switch
+        {
+            HttpGetAttribute httpGet => httpGet.Template switch
+            {
+                null => JsonApiEndpoints.GetCollection,
+                IdTemplate => JsonApiEndpoints.GetSingle,
+                SecondaryEndpointTemplate => JsonApiEndpoints.GetSecondary,
+                RelationshipEndpointTemplate => JsonApiEndpoints.GetRelationship,
+                _ => JsonApiEndpoints.None
+            },
+            HttpPostAttribute httpPost => httpPost.Template switch
+            {
+                null => JsonApiEndpoints.Post,
+                RelationshipEndpointTemplate => JsonApiEndpoints.PostRelationship,
+                _ => JsonApiEndpoints.None
+            },
+            HttpPatchAttribute httpPatch => httpPatch.Template switch
+            {
+                IdTemplate => JsonApiEndpoints.Patch,
+                RelationshipEndpointTemplate => JsonApiEndpoints.PatchRelationship,
+                _ => JsonApiEndpoints.None
+            },
+            HttpDeleteAttribute httpDelete => httpDelete.Template switch
+            {
+                IdTemplate => JsonApiEndpoints.Delete,
+                RelationshipEndpointTemplate => JsonApiEndpoints.DeleteRelationship,
+                _ => JsonApiEndpoints.None
+            },
+            _ => JsonApiEndpoints.None
+        };
+    }
+}

--- a/src/JsonApiDotNetCore/Middleware/IJsonApiEndpointFilter.cs
+++ b/src/JsonApiDotNetCore/Middleware/IJsonApiEndpointFilter.cs
@@ -1,0 +1,24 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.AtomicOperations;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Controllers;
+
+namespace JsonApiDotNetCore.Middleware;
+
+/// <summary>
+/// Enables to remove JSON:API controller action methods at startup. For atomic:operation requests, see <see cref="IAtomicOperationFilter" />.
+/// </summary>
+[PublicAPI]
+public interface IJsonApiEndpointFilter
+{
+    /// <summary>
+    /// Determines whether to remove the associated controller action method.
+    /// </summary>
+    /// <param name="resourceType">
+    /// The primary resource type of the endpoint.
+    /// </param>
+    /// <param name="endpoint">
+    /// The JSON:API endpoint. Despite <see cref="JsonApiEndpoints" /> being a <see cref="FlagsAttribute" /> enum, a single value is always passed here.
+    /// </param>
+    bool IsEnabled(ResourceType resourceType, JsonApiEndpoints endpoint);
+}

--- a/src/JsonApiDotNetCore/Middleware/JsonApiRoutingConvention.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiRoutingConvention.cs
@@ -7,43 +7,48 @@ using JsonApiDotNetCore.Errors;
 using JsonApiDotNetCore.Resources;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.Logging;
 
 namespace JsonApiDotNetCore.Middleware;
 
 /// <summary>
-/// The default routing convention registers the name of the resource as the route using the serializer naming convention. The default for this is a
-/// camel case formatter. If the controller directly inherits from <see cref="CoreJsonApiController" /> and there is no resource directly associated, it
-/// uses the name of the controller instead of the name of the type.
+/// Registers routes based on the JSON:API resource name, which defaults to camel-case pluralized form of the resource CLR type name. If unavailable (for
+/// example, when a controller directly inherits from <see cref="CoreJsonApiController" />), the serializer naming convention is applied on the
+/// controller type name (camel-case by default).
 /// </summary>
 /// <example><![CDATA[
-/// public class SomeResourceController : JsonApiController<SomeResource> { } // => /someResources/relationship/relatedResource
+/// // controller name is ignored when resource type is available:
+/// public class RandomNameController<SomeResource> : JsonApiController<SomeResource> { } // => /someResources
 /// 
-/// public class RandomNameController<SomeResource> : JsonApiController<SomeResource> { } // => /someResources/relationship/relatedResource
+/// // when using kebab-case naming convention in options:
+/// public class RandomNameController<SomeResource> : JsonApiController<SomeResource> { } // => /some-resources
 /// 
-/// // when using kebab-case naming convention:
-/// public class SomeResourceController<SomeResource> : JsonApiController<SomeResource> { } // => /some-resources/relationship/related-resource
-/// 
-/// public class SomeVeryCustomController<SomeResource> : CoreJsonApiController { } // => /someVeryCustoms/relationship/relatedResource
+/// // unable to determine resource type:
+/// public class SomeVeryCustomController<SomeResource> : CoreJsonApiController { } // => /someVeryCustom
 /// ]]></example>
 [PublicAPI]
 public sealed partial class JsonApiRoutingConvention : IJsonApiRoutingConvention
 {
     private readonly IJsonApiOptions _options;
     private readonly IResourceGraph _resourceGraph;
+    private readonly IJsonApiEndpointFilter _jsonApiEndpointFilter;
     private readonly ILogger<JsonApiRoutingConvention> _logger;
     private readonly Dictionary<string, string> _registeredControllerNameByTemplate = [];
     private readonly Dictionary<Type, ResourceType> _resourceTypePerControllerTypeMap = [];
     private readonly Dictionary<ResourceType, ControllerModel> _controllerPerResourceTypeMap = [];
 
-    public JsonApiRoutingConvention(IJsonApiOptions options, IResourceGraph resourceGraph, ILogger<JsonApiRoutingConvention> logger)
+    public JsonApiRoutingConvention(IJsonApiOptions options, IResourceGraph resourceGraph, IJsonApiEndpointFilter jsonApiEndpointFilter,
+        ILogger<JsonApiRoutingConvention> logger)
     {
         ArgumentGuard.NotNull(options);
         ArgumentGuard.NotNull(resourceGraph);
+        ArgumentGuard.NotNull(jsonApiEndpointFilter);
         ArgumentGuard.NotNull(logger);
 
         _options = options;
         _resourceGraph = resourceGraph;
+        _jsonApiEndpointFilter = jsonApiEndpointFilter;
         _logger = logger;
     }
 
@@ -106,6 +111,8 @@ public sealed partial class JsonApiRoutingConvention : IJsonApiRoutingConvention
                             $"Multiple controllers found for resource type '{resourceType}': '{existingModel.ControllerType}' and '{controller.ControllerType}'.");
                     }
 
+                    RemoveDisabledActionMethods(controller, resourceType);
+
                     _resourceTypePerControllerTypeMap.Add(controller.ControllerType, resourceType);
                     _controllerPerResourceTypeMap.Add(resourceType, controller);
                 }
@@ -148,34 +155,10 @@ public sealed partial class JsonApiRoutingConvention : IJsonApiRoutingConvention
         return controller.ControllerType.GetCustomAttribute<ApiControllerAttribute>() != null;
     }
 
-    private static bool IsRoutingConventionDisabled(ControllerModel controller)
+    private static bool IsOperationsController(Type type)
     {
-        return controller.ControllerType.GetCustomAttribute<DisableRoutingConventionAttribute>(true) != null;
-    }
-
-    /// <summary>
-    /// Derives a template from the resource type, and checks if this template was already registered.
-    /// </summary>
-    private string? TemplateFromResource(ControllerModel model)
-    {
-        if (_resourceTypePerControllerTypeMap.TryGetValue(model.ControllerType, out ResourceType? resourceType))
-        {
-            return $"{_options.Namespace}/{resourceType.PublicName}";
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Derives a template from the controller name, and checks if this template was already registered.
-    /// </summary>
-    private string TemplateFromController(ControllerModel model)
-    {
-        string controllerName = _options.SerializerOptions.PropertyNamingPolicy == null
-            ? model.ControllerName
-            : _options.SerializerOptions.PropertyNamingPolicy.ConvertName(model.ControllerName);
-
-        return $"{_options.Namespace}/{controllerName}";
+        Type baseControllerType = typeof(BaseJsonApiOperationsController);
+        return baseControllerType.IsAssignableFrom(type);
     }
 
     /// <summary>
@@ -213,10 +196,47 @@ public sealed partial class JsonApiRoutingConvention : IJsonApiRoutingConvention
         return currentType?.GetGenericArguments().First();
     }
 
-    private static bool IsOperationsController(Type type)
+    private void RemoveDisabledActionMethods(ControllerModel controller, ResourceType resourceType)
     {
-        Type baseControllerType = typeof(BaseJsonApiOperationsController);
-        return baseControllerType.IsAssignableFrom(type);
+        foreach (ActionModel actionModel in controller.Actions.ToArray())
+        {
+            JsonApiEndpoints endpoint = actionModel.Attributes.OfType<HttpMethodAttribute>().GetJsonApiEndpoint();
+
+            if (endpoint != JsonApiEndpoints.None && !_jsonApiEndpointFilter.IsEnabled(resourceType, endpoint))
+            {
+                controller.Actions.Remove(actionModel);
+            }
+        }
+    }
+
+    private static bool IsRoutingConventionDisabled(ControllerModel controller)
+    {
+        return controller.ControllerType.GetCustomAttribute<DisableRoutingConventionAttribute>(true) != null;
+    }
+
+    /// <summary>
+    /// Derives a template from the resource type, and checks if this template was already registered.
+    /// </summary>
+    private string? TemplateFromResource(ControllerModel model)
+    {
+        if (_resourceTypePerControllerTypeMap.TryGetValue(model.ControllerType, out ResourceType? resourceType))
+        {
+            return $"{_options.Namespace}/{resourceType.PublicName}";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Derives a template from the controller name, and checks if this template was already registered.
+    /// </summary>
+    private string TemplateFromController(ControllerModel model)
+    {
+        string controllerName = _options.SerializerOptions.PropertyNamingPolicy == null
+            ? model.ControllerName
+            : _options.SerializerOptions.PropertyNamingPolicy.ConvertName(model.ControllerName);
+
+        return $"{_options.Namespace}/{controllerName}";
     }
 
     [LoggerMessage(Level = LogLevel.Warning,

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/IdObfuscation/ObfuscatedIdentifiableController.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/IdObfuscation/ObfuscatedIdentifiableController.cs
@@ -18,12 +18,14 @@ public abstract class ObfuscatedIdentifiableController<TResource>(
     private readonly HexadecimalCodec _codec = new();
 
     [HttpGet]
+    [HttpHead]
     public override Task<IActionResult> GetAsync(CancellationToken cancellationToken)
     {
         return base.GetAsync(cancellationToken);
     }
 
     [HttpGet("{id}")]
+    [HttpHead("{id}")]
     public Task<IActionResult> GetAsync([Required] string id, CancellationToken cancellationToken)
     {
         int idValue = _codec.Decode(id);
@@ -31,6 +33,7 @@ public abstract class ObfuscatedIdentifiableController<TResource>(
     }
 
     [HttpGet("{id}/{relationshipName}")]
+    [HttpHead("{id}/{relationshipName}")]
     public Task<IActionResult> GetSecondaryAsync([Required] string id, [Required] [PreserveEmptyString] string relationshipName,
         CancellationToken cancellationToken)
     {
@@ -39,6 +42,7 @@ public abstract class ObfuscatedIdentifiableController<TResource>(
     }
 
     [HttpGet("{id}/relationships/{relationshipName}")]
+    [HttpHead("{id}/relationships/{relationshipName}")]
     public Task<IActionResult> GetRelationshipAsync([Required] string id, [Required] [PreserveEmptyString] string relationshipName,
         CancellationToken cancellationToken)
     {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/EndpointFilterTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/RestrictedControllers/EndpointFilterTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Middleware;
+using Microsoft.Extensions.DependencyInjection;
+using TestBuildingBlocks;
+using Xunit;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.RestrictedControllers;
+
+public sealed class EndpointFilterTests : IClassFixture<IntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext>>
+{
+    private readonly IntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext> _testContext;
+    private readonly RestrictionFakers _fakers = new();
+
+    public EndpointFilterTests(IntegrationTestContext<TestableStartup<RestrictionDbContext>, RestrictionDbContext> testContext)
+    {
+        _testContext = testContext;
+
+        testContext.UseController<BedsController>();
+
+        testContext.ConfigureServices(services => services.AddSingleton<IJsonApiEndpointFilter, NoRelationshipsAtBedJsonApiEndpointFilter>());
+    }
+
+    [Fact]
+    public async Task Cannot_get_relationship()
+    {
+        // Arrange
+        Bed bed = _fakers.Bed.GenerateOne();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            dbContext.Beds.Add(bed);
+            await dbContext.SaveChangesAsync();
+        });
+
+        string route = $"/beds/{bed.StringId}/relationships/pillows";
+
+        // Act
+        (HttpResponseMessage httpResponse, _) = await _testContext.ExecuteGetAsync<string>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.NotFound);
+    }
+
+    private sealed class NoRelationshipsAtBedJsonApiEndpointFilter : IJsonApiEndpointFilter
+    {
+        public bool IsEnabled(ResourceType resourceType, JsonApiEndpoints endpoint)
+        {
+            return !IsGetRelationshipAtBed(endpoint, resourceType);
+        }
+
+        private static bool IsGetRelationshipAtBed(JsonApiEndpoints endpoint, ResourceType resourceType)
+        {
+            bool isRelationshipEndpoint = endpoint is JsonApiEndpoints.GetRelationship or JsonApiEndpoints.PostRelationship or
+                JsonApiEndpoints.PatchRelationship or JsonApiEndpoints.DeleteRelationship;
+
+            return isRelationshipEndpoint && resourceType.ClrType == typeof(Bed);
+        }
+    }
+}

--- a/test/JsonApiDotNetCoreTests/UnitTests/Controllers/GetJsonApiEndpointTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Controllers/GetJsonApiEndpointTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Middleware;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Xunit;
+
+namespace JsonApiDotNetCoreTests.UnitTests.Controllers;
+
+public sealed class GetJsonApiEndpointTests
+{
+    [Theory]
+    [InlineData("GET", null, JsonApiEndpoints.GetCollection)]
+    [InlineData("GET", "{id}", JsonApiEndpoints.GetSingle)]
+    [InlineData("GET", "{id}/{relationshipName}", JsonApiEndpoints.GetSecondary)]
+    [InlineData("GET", "{id}/relationships/{relationshipName}", JsonApiEndpoints.GetRelationship)]
+    [InlineData("POST", null, JsonApiEndpoints.Post)]
+    [InlineData("POST", "{id}/relationships/{relationshipName}", JsonApiEndpoints.PostRelationship)]
+    [InlineData("PATCH", "{id}", JsonApiEndpoints.Patch)]
+    [InlineData("PATCH", "{id}/relationships/{relationshipName}", JsonApiEndpoints.PatchRelationship)]
+    [InlineData("DELETE", "{id}", JsonApiEndpoints.Delete)]
+    [InlineData("DELETE", "{id}/relationships/{relationshipName}", JsonApiEndpoints.DeleteRelationship)]
+    [InlineData("PUT", null, JsonApiEndpoints.None)]
+    public void Can_identify_endpoint_from_http_method_and_route_template(string httpMethod, string? routeTemplate, JsonApiEndpoints expected)
+    {
+        // Arrange
+        HttpMethodAttribute attribute = httpMethod switch
+        {
+            "GET" => routeTemplate == null ? new HttpGetAttribute() : new HttpGetAttribute(routeTemplate),
+            "POST" => routeTemplate == null ? new HttpPostAttribute() : new HttpPostAttribute(routeTemplate),
+            "PATCH" => routeTemplate == null ? new HttpPatchAttribute() : new HttpPatchAttribute(routeTemplate),
+            "DELETE" => routeTemplate == null ? new HttpDeleteAttribute() : new HttpDeleteAttribute(routeTemplate),
+            "PUT" => routeTemplate == null ? new HttpPutAttribute() : new HttpPutAttribute(routeTemplate),
+            _ => throw new ArgumentOutOfRangeException(nameof(httpMethod), httpMethod, null)
+        };
+
+        // Act
+        JsonApiEndpoints endpoint = HttpMethodAttributeExtensions.GetJsonApiEndpoint([attribute]);
+
+        // Assert
+        endpoint.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
This PR adds `IJsonApiEndpointFilter`, which enables to remove controller action methods at runtime. This comes in handy in tests, where variation is needed without relying on declarative `GenerateControllerEndpoints` usage.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
