### PR TITLE
Breaking: rename relaxed form of Atomic Operations extension

### DIFF
--- a/src/JsonApiDotNetCore/Middleware/HeaderConstants.cs
+++ b/src/JsonApiDotNetCore/Middleware/HeaderConstants.cs
@@ -14,5 +14,5 @@ public static class HeaderConstants
     public const string AtomicOperationsMediaType = $"{MediaType}; ext=\"https://jsonapi.org/ext/atomic\"";
 
     [Obsolete($"Use {nameof(JsonApiMediaType)}.{nameof(JsonApiMediaType.RelaxedAtomicOperations)}.ToString() instead.")]
-    public const string RelaxedAtomicOperationsMediaType = $"{MediaType}; ext=atomic-operations";
+    public const string RelaxedAtomicOperationsMediaType = $"{MediaType}; ext=atomic";
 }

--- a/src/JsonApiDotNetCore/Middleware/JsonApiMediaType.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiMediaType.cs
@@ -25,7 +25,7 @@ public sealed class JsonApiMediaType : IEquatable<JsonApiMediaType>
     public static readonly JsonApiMediaType AtomicOperations = new([JsonApiMediaTypeExtension.AtomicOperations]);
 
     /// <summary>
-    /// Gets the JSON:API media type with the "atomic-operations" extension.
+    /// Gets the JSON:API media type with the "atomic" extension.
     /// </summary>
     public static readonly JsonApiMediaType RelaxedAtomicOperations = new([JsonApiMediaTypeExtension.RelaxedAtomicOperations]);
 

--- a/src/JsonApiDotNetCore/Middleware/JsonApiMediaTypeExtension.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiMediaTypeExtension.cs
@@ -9,7 +9,7 @@ namespace JsonApiDotNetCore.Middleware;
 public sealed class JsonApiMediaTypeExtension : IEquatable<JsonApiMediaTypeExtension>
 {
     public static readonly JsonApiMediaTypeExtension AtomicOperations = new("https://jsonapi.org/ext/atomic");
-    public static readonly JsonApiMediaTypeExtension RelaxedAtomicOperations = new("atomic-operations");
+    public static readonly JsonApiMediaTypeExtension RelaxedAtomicOperations = new("atomic");
 
     public string UnescapedValue { get; }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/AcceptHeaderTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/AcceptHeaderTests.cs
@@ -121,7 +121,7 @@ public sealed class AcceptHeaderTests : IClassFixture<IntegrationTestContext<Tes
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default}; profile=some"));
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(JsonApiMediaType.Default.ToString()));
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default}; unknown=unexpected"));
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default};EXT=atomic-operations; q=0.8"));
+            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default};EXT=atomic; q=0.8"));
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default};EXT=\"https://jsonapi.org/ext/atomic\"; q=0.2"));
         };
 
@@ -168,7 +168,7 @@ public sealed class AcceptHeaderTests : IClassFixture<IntegrationTestContext<Tes
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(JsonApiMediaType.Default.ToString()));
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default}; unknown=unexpected"));
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default};EXT=\"https://jsonapi.org/ext/atomic\"; q=0.8"));
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default};EXT=atomic-operations; q=0.2"));
+            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default};EXT=atomic; q=0.2"));
         };
 
         // Act


### PR DESCRIPTION
Breaking: Rename the relaxed form of Atomic Operations extension from "atomic-operations" to "atomic" for consistency. This exists for OpenAPI support in `Content-Type` and `Accept` HTTP headers, which is currently experimental.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
