### PR TITLE
Replace DOTNET_SKIP_FIRST_TIME_EXPERIENCE with DOTNET_NOLOGO

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -113,6 +113,12 @@ csharp_style_expression_bodied_properties = true:silent
 # IDE0025: Use expression body for properties
 dotnet_diagnostic.IDE0025.severity = silent
 
+# Member preferences (these analyzers are unreliable)
+# IDE0051: Remove unused private member
+dotnet_diagnostic.IDE0051.severity = silent
+# IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0052.severity = silent
+
 # Code-block preferences
 csharp_prefer_braces = true:silent
 # IDE0011: Add braces
@@ -142,11 +148,13 @@ dotnet_diagnostic.IDE0047.severity = silent
 # IDE0048: Add parentheses for clarity
 dotnet_diagnostic.IDE0048.severity = silent
 
+# Switch preferences
 # IDE0010: Add missing cases to switch statement
 dotnet_diagnostic.IDE0010.severity = silent
 # IDE0072: Add missing cases to switch expression
 dotnet_diagnostic.IDE0072.severity = silent
 
+# Null check preferences
 # IDE0029: Null check can be simplified
 dotnet_diagnostic.IDE0029.severity = silent
 # IDE0030: Null check can be simplified

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
       with:
         # Block buggy release from February 11, 2025
         dotnet-version: |
-          8.0.309 
-          9.0.103
+          8.0.*
+          9.0.*
     - name: Show installed versions
       shell: pwsh
       run: |
@@ -166,8 +166,8 @@ jobs:
       with:
         # Block buggy release from February 11, 2025
         dotnet-version: |
-          8.0.309 
-          9.0.103
+          8.0.*
+          9.0.*
     - name: Git checkout
       uses: actions/checkout@v4
     - name: Restore tools
@@ -222,8 +222,8 @@ jobs:
       with:
         # Block buggy release from February 11, 2025
         dotnet-version: |
-          8.0.309 
-          9.0.103
+          8.0.*
+          9.0.*
     - name: Git checkout
       uses: actions/checkout@v4
       with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
       Taking the suggestion TODAY produces List<string>, but the spec doesn't require that, so the compiler may change it over time.
       As a result, callers that cast back to List<string> will face a breaking change.
      -->
-    <UseCollectionExpressionRules>IDE0028;IDE0300;IDE0301;IDE0302;IDE0303;IDE0304;IDE0305</UseCollectionExpressionRules>
+    <UseCollectionExpressionRules>IDE0028;IDE0300;IDE0301;IDE0302;IDE0303;IDE0304;IDE0305;IDE0306</UseCollectionExpressionRules>
     <NoWarn>$(NoWarn);$(UseCollectionExpressionRules)</NoWarn>
 
     <!-- Suppress warning that targeting .NET Standard 1.0 is not recommended, because it requires a breaking change. -->


### PR DESCRIPTION
Replace `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` with `DOTNET_NOLOGO` in GitHub Actions, based on the guidance at https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_skip_first_time_experience:

> This environment variable is no longer supported in .NET Core 3.0 and later. Use [DOTNET_NOLOGO](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_nologo) as a replacement.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
