### PR TITLE
Remove workaround for kiota bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,6 +423,3 @@ FodyWeavers.xsd
 **/.idea/**/httpRequests/
 **/.idea/**/dataSources/
 !**/.idea/**/codeStyles/*
-
-# Workaround for https://github.com/microsoft/kiota/issues/4228
-kiota-lock.json

--- a/JsonApiDotNetCore.sln.DotSettings
+++ b/JsonApiDotNetCore.sln.DotSettings
@@ -3,6 +3,7 @@
 	<s:Int64 x:Key="/Default/CodeEditing/NullCheckPatterns/PatternTypeNamesToPriority/=JetBrains_002EReSharper_002EFeature_002EServices_002ECSharp_002ENullChecking_002EIfThenThrowPattern/@EntryIndexedValue">2000</s:Int64>
 	<s:Int64 x:Key="/Default/CodeEditing/NullCheckPatterns/PatternTypeNamesToPriority/=JetBrains_002EReSharper_002EFeature_002EServices_002ECSharp_002ENullChecking_002EThrowExpressionNullCheckPattern/@EntryIndexedValue">3000</s:Int64>
 	<s:Boolean x:Key="/Default/CodeInspection/CodeAnnotations/PropagateAnnotations/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=kiota_002Dlock_002Ejson/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=swagger_002Ejson/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/GeneratedFilesAndFolders/=71287D6F_002D6C3B_002D44B4_002D9FCA_002DE78FE3F02289_002Ff_003ASchemaGenerator_002Ecs/@EntryIndexedValue">71287D6F-6C3B-44B4-9FCA-E78FE3F02289/f:SchemaGenerator.cs</s:String>
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/GeneratedFilesAndFolders/=83FF097C_002DC8C6_002D477B_002D9FAB_002DDF99B84978B5_002Ff_003AReadOnlySet_002Ecs/@EntryIndexedValue">83FF097C-C8C6-477B-9FAB-DF99B84978B5/f:ReadOnlySet.cs</s:String>

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/kiota-lock.json
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/kiota-lock.json
@@ -1,0 +1,37 @@
+{
+  "descriptionHash": "FF92B668728B3329C184D28DB2ACE0FC77CE0B49A523B41CF515B5EDB724B64AE2DFDC36CCEE985A1390C2D391C9C5A07F285FC44CA9C2754DC2574B07820EBC",
+  "descriptionLocation": "../../JsonApiDotNetCoreExample/GeneratedSwagger/JsonApiDotNetCoreExample.json",
+  "lockFileVersion": "1.0.0",
+  "kiotaVersion": "1.24.1",
+  "clientClassName": "ExampleApiClient",
+  "typeAccessModifier": "Public",
+  "clientNamespaceName": "OpenApiKiotaClientExample.GeneratedCode",
+  "language": "CSharp",
+  "usesBackingStore": true,
+  "excludeBackwardCompatible": true,
+  "includeAdditionalData": true,
+  "disableSSLValidation": false,
+  "serializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Form.FormSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Multipart.MultipartSerializationWriterFactory"
+  ],
+  "deserializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Text.TextParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Form.FormParseNodeFactory"
+  ],
+  "structuredMimeTypes": [
+    "application/json",
+    "text/plain;q=0.9",
+    "application/x-www-form-urlencoded;q=0.2",
+    "multipart/form-data;q=0.1"
+  ],
+  "includePatterns": [],
+  "excludePatterns": [],
+  "disabledValidationRules": [
+    "KnownAndNotSupportedFormats",
+    "InconsistentTypeFormatPair"
+  ]
+}

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/kiota-lock.json
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/kiota-lock.json
@@ -1,0 +1,37 @@
+{
+  "descriptionHash": "0FA4C6F14F49E8BEF234F16EA0564DE41378229D8F08E306965FA69DFB489811DEE5823A251690D0CAC5346F6879008F2A00E8CAEFC894F705ECB0D5CFD9EB12",
+  "descriptionLocation": "../../../OpenApiTests/AtomicOperations/GeneratedSwagger/swagger.g.json",
+  "lockFileVersion": "1.0.0",
+  "kiotaVersion": "1.24.1",
+  "clientClassName": "AtomicOperationsClient",
+  "typeAccessModifier": "Public",
+  "clientNamespaceName": "OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode",
+  "language": "CSharp",
+  "usesBackingStore": true,
+  "excludeBackwardCompatible": true,
+  "includeAdditionalData": true,
+  "disableSSLValidation": false,
+  "serializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Form.FormSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Multipart.MultipartSerializationWriterFactory"
+  ],
+  "deserializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Text.TextParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Form.FormParseNodeFactory"
+  ],
+  "structuredMimeTypes": [
+    "application/json",
+    "text/plain;q=0.9",
+    "application/x-www-form-urlencoded;q=0.2",
+    "multipart/form-data;q=0.1"
+  ],
+  "includePatterns": [],
+  "excludePatterns": [],
+  "disabledValidationRules": [
+    "KnownAndNotSupportedFormats",
+    "InconsistentTypeFormatPair"
+  ]
+}

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/kiota-lock.json
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/kiota-lock.json
@@ -1,0 +1,37 @@
+{
+  "descriptionHash": "F5B96359ED1889AA581B29688E5D091B20DE900ED46DB6115F29F1A614C43F08AE973C203786BBFB0C989054B8962A6532701FEA2B6815ED9F047AB1A66CFBD8",
+  "descriptionLocation": "../../../OpenApiTests/ClientIdGenerationModes/GeneratedSwagger/swagger.g.json",
+  "lockFileVersion": "1.0.0",
+  "kiotaVersion": "1.24.1",
+  "clientClassName": "ClientIdGenerationModesClient",
+  "typeAccessModifier": "Public",
+  "clientNamespaceName": "OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode",
+  "language": "CSharp",
+  "usesBackingStore": true,
+  "excludeBackwardCompatible": true,
+  "includeAdditionalData": true,
+  "disableSSLValidation": false,
+  "serializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Form.FormSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Multipart.MultipartSerializationWriterFactory"
+  ],
+  "deserializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Text.TextParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Form.FormParseNodeFactory"
+  ],
+  "structuredMimeTypes": [
+    "application/json",
+    "text/plain;q=0.9",
+    "application/x-www-form-urlencoded;q=0.2",
+    "multipart/form-data;q=0.1"
+  ],
+  "includePatterns": [],
+  "excludePatterns": [],
+  "disabledValidationRules": [
+    "KnownAndNotSupportedFormats",
+    "InconsistentTypeFormatPair"
+  ]
+}

--- a/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/kiota-lock.json
+++ b/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/kiota-lock.json
@@ -1,0 +1,37 @@
+{
+  "descriptionHash": "D7A01B5E17A3CAEED3BCAB2B44BA37AC5B89F59B7CCE0A410DF24E142B9D73FFED84441E3C94EF628E346C8DFB2B6A08BA253384132AE8E4C246579CCEF39DE3",
+  "descriptionLocation": "../../../OpenApiTests/Headers/GeneratedSwagger/swagger.g.json",
+  "lockFileVersion": "1.0.0",
+  "kiotaVersion": "1.24.1",
+  "clientClassName": "HeadersClient",
+  "typeAccessModifier": "Public",
+  "clientNamespaceName": "OpenApiKiotaEndToEndTests.Headers.GeneratedCode",
+  "language": "CSharp",
+  "usesBackingStore": true,
+  "excludeBackwardCompatible": true,
+  "includeAdditionalData": true,
+  "disableSSLValidation": false,
+  "serializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Form.FormSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Multipart.MultipartSerializationWriterFactory"
+  ],
+  "deserializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Text.TextParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Form.FormParseNodeFactory"
+  ],
+  "structuredMimeTypes": [
+    "application/json",
+    "text/plain;q=0.9",
+    "application/x-www-form-urlencoded;q=0.2",
+    "multipart/form-data;q=0.1"
+  ],
+  "includePatterns": [],
+  "excludePatterns": [],
+  "disabledValidationRules": [
+    "KnownAndNotSupportedFormats",
+    "InconsistentTypeFormatPair"
+  ]
+}

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/kiota-lock.json
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/kiota-lock.json
@@ -1,0 +1,37 @@
+{
+  "descriptionHash": "883CA2E4CAA6871A31807542112BC2EBF154717C0A52764867EA9E025FB99E0BD78D938F69266AF56A488630855A70CFB4A37BB6602CA8B7A7383DC21CE3229E",
+  "descriptionLocation": "../../../OpenApiTests/Links/Enabled/GeneratedSwagger/swagger.g.json",
+  "lockFileVersion": "1.0.0",
+  "kiotaVersion": "1.24.1",
+  "clientClassName": "LinksClient",
+  "typeAccessModifier": "Public",
+  "clientNamespaceName": "OpenApiKiotaEndToEndTests.Links.GeneratedCode",
+  "language": "CSharp",
+  "usesBackingStore": true,
+  "excludeBackwardCompatible": true,
+  "includeAdditionalData": true,
+  "disableSSLValidation": false,
+  "serializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Form.FormSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Multipart.MultipartSerializationWriterFactory"
+  ],
+  "deserializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Text.TextParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Form.FormParseNodeFactory"
+  ],
+  "structuredMimeTypes": [
+    "application/json",
+    "text/plain;q=0.9",
+    "application/x-www-form-urlencoded;q=0.2",
+    "multipart/form-data;q=0.1"
+  ],
+  "includePatterns": [],
+  "excludePatterns": [],
+  "disabledValidationRules": [
+    "KnownAndNotSupportedFormats",
+    "InconsistentTypeFormatPair"
+  ]
+}

--- a/test/OpenApiKiotaEndToEndTests/ModelStateValidation/GeneratedCode/kiota-lock.json
+++ b/test/OpenApiKiotaEndToEndTests/ModelStateValidation/GeneratedCode/kiota-lock.json
@@ -1,0 +1,37 @@
+{
+  "descriptionHash": "8B885D48B661E47CBB125A626316B4897155677AFC90A8EB6E17A9DFB723CB2BC426B019A5F8343CA58BA7798754AEC5624B2599690EE03156E77AB5439E70DA",
+  "descriptionLocation": "../../../OpenApiTests/ModelStateValidation/GeneratedSwagger/swagger.g.json",
+  "lockFileVersion": "1.0.0",
+  "kiotaVersion": "1.24.1",
+  "clientClassName": "ModelStateValidationClient",
+  "typeAccessModifier": "Public",
+  "clientNamespaceName": "OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode",
+  "language": "CSharp",
+  "usesBackingStore": true,
+  "excludeBackwardCompatible": true,
+  "includeAdditionalData": true,
+  "disableSSLValidation": false,
+  "serializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Form.FormSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Multipart.MultipartSerializationWriterFactory"
+  ],
+  "deserializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Text.TextParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Form.FormParseNodeFactory"
+  ],
+  "structuredMimeTypes": [
+    "application/json",
+    "text/plain;q=0.9",
+    "application/x-www-form-urlencoded;q=0.2",
+    "multipart/form-data;q=0.1"
+  ],
+  "includePatterns": [],
+  "excludePatterns": [],
+  "disabledValidationRules": [
+    "KnownAndNotSupportedFormats",
+    "InconsistentTypeFormatPair"
+  ]
+}

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/kiota-lock.json
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/kiota-lock.json
@@ -1,0 +1,37 @@
+{
+  "descriptionHash": "A97763502718F5062870C53EBD7FF426E267E9D68820C8268297AB50A34C42F34033703FCB6C8EE4DE0967055086726285A30115FC9EAFE45830AFB0ECF5DFE6",
+  "descriptionLocation": "../../../OpenApiTests/QueryStrings/GeneratedSwagger/swagger.g.json",
+  "lockFileVersion": "1.0.0",
+  "kiotaVersion": "1.24.1",
+  "clientClassName": "QueryStringsClient",
+  "typeAccessModifier": "Public",
+  "clientNamespaceName": "OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode",
+  "language": "CSharp",
+  "usesBackingStore": true,
+  "excludeBackwardCompatible": true,
+  "includeAdditionalData": true,
+  "disableSSLValidation": false,
+  "serializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Form.FormSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Multipart.MultipartSerializationWriterFactory"
+  ],
+  "deserializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Text.TextParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Form.FormParseNodeFactory"
+  ],
+  "structuredMimeTypes": [
+    "application/json",
+    "text/plain;q=0.9",
+    "application/x-www-form-urlencoded;q=0.2",
+    "multipart/form-data;q=0.1"
+  ],
+  "includePatterns": [],
+  "excludePatterns": [],
+  "disabledValidationRules": [
+    "KnownAndNotSupportedFormats",
+    "InconsistentTypeFormatPair"
+  ]
+}

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/kiota-lock.json
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/kiota-lock.json
@@ -1,0 +1,37 @@
+{
+  "descriptionHash": "49BCC98A33A4B1D9B4244F06331A0D1B6E275B7F88F388D925C3A2B649687E6366349C0952D0631F4E8E113160ACC5841405707869051A94484DD2A653E40B7F",
+  "descriptionLocation": "../../../OpenApiTests/RestrictedControllers/GeneratedSwagger/swagger.g.json",
+  "lockFileVersion": "1.0.0",
+  "kiotaVersion": "1.24.1",
+  "clientClassName": "RestrictedControllersClient",
+  "typeAccessModifier": "Public",
+  "clientNamespaceName": "OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode",
+  "language": "CSharp",
+  "usesBackingStore": true,
+  "excludeBackwardCompatible": true,
+  "includeAdditionalData": true,
+  "disableSSLValidation": false,
+  "serializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Form.FormSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Multipart.MultipartSerializationWriterFactory"
+  ],
+  "deserializers": [
+    "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Text.TextParseNodeFactory",
+    "Microsoft.Kiota.Serialization.Form.FormParseNodeFactory"
+  ],
+  "structuredMimeTypes": [
+    "application/json",
+    "text/plain;q=0.9",
+    "application/x-www-form-urlencoded;q=0.2",
+    "multipart/form-data;q=0.1"
+  ],
+  "includePatterns": [],
+  "excludePatterns": [],
+  "disabledValidationRules": [
+    "KnownAndNotSupportedFormats",
+    "InconsistentTypeFormatPair"
+  ]
+}


### PR DESCRIPTION
Removes the workaround for kiota bug at https://github.com/microsoft/kiota/issues/4228, which was fixed in https://github.com/microsoft/kiota/pull/4932.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
