### PR TITLE
Improve code coverage by skipping unreachable code

### DIFF
--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/ConsistencyGuard.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/ConsistencyGuard.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace JsonApiDotNetCore.OpenApi.Swashbuckle;
+
+#pragma warning disable AV1008 // Class should not be static
+
+internal static class ConsistencyGuard
+{
+    [ExcludeFromCodeCoverage]
+    public static void ThrowIf([DoesNotReturnIf(true)] bool condition)
+    {
+        if (condition)
+        {
+            throw new UnreachableException();
+        }
+    }
+}

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiActionDescriptorCollectionProvider.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiActionDescriptorCollectionProvider.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using JsonApiDotNetCore.Errors;
 using JsonApiDotNetCore.Middleware;
@@ -115,18 +114,20 @@ internal sealed class JsonApiActionDescriptorCollectionProvider : IActionDescrip
 
     private static void UpdateProducesResponseTypeAttribute(ActionDescriptor endpoint, Type responseDocumentType)
     {
+        ProducesResponseTypeAttribute? attribute = null;
+
         if (ProducesJsonApiResponseDocument(endpoint))
         {
             var producesResponse = endpoint.GetFilterMetadata<ProducesResponseTypeAttribute>();
 
             if (producesResponse != null)
             {
-                producesResponse.Type = responseDocumentType;
-                return;
+                attribute = producesResponse;
             }
         }
 
-        throw new UnreachableException();
+        ConsistencyGuard.ThrowIf(attribute == null);
+        attribute.Type = responseDocumentType;
     }
 
     private static bool ProducesJsonApiResponseDocument(ActionDescriptor endpoint)

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiMetadata/JsonApiEndpointMetadataProvider.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiMetadata/JsonApiEndpointMetadataProvider.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Controllers;
@@ -43,11 +42,7 @@ internal sealed class JsonApiEndpointMetadataProvider
         }
 
         ResourceType? primaryResourceType = _controllerResourceMapping.GetResourceTypeForController(controllerAction.ReflectedType);
-
-        if (primaryResourceType == null)
-        {
-            throw new UnreachableException();
-        }
+        ConsistencyGuard.ThrowIf(primaryResourceType == null);
 
         IJsonApiRequestMetadata? requestMetadata = GetRequestMetadata(endpoint, primaryResourceType);
         IJsonApiResponseMetadata? responseMetadata = GetResponseMetadata(endpoint, primaryResourceType);

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiOperationIdSelector.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiOperationIdSelector.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json;
 using Humanizer;
@@ -64,23 +63,14 @@ internal sealed class OpenApiOperationIdSelector
     private static string GetTemplate(ApiDescription endpoint)
     {
         Type bodyType = GetBodyType(endpoint);
-
-        if (!SchemaOpenTypeToOpenApiOperationIdTemplateMap.TryGetValue(bodyType, out string? template))
-        {
-            throw new UnreachableException();
-        }
-
+        ConsistencyGuard.ThrowIf(!SchemaOpenTypeToOpenApiOperationIdTemplateMap.TryGetValue(bodyType, out string? template));
         return template;
     }
 
     private static Type GetBodyType(ApiDescription endpoint)
     {
         var producesResponseTypeAttribute = endpoint.ActionDescriptor.GetFilterMetadata<ProducesResponseTypeAttribute>();
-
-        if (producesResponseTypeAttribute == null)
-        {
-            throw new UnreachableException();
-        }
+        ConsistencyGuard.ThrowIf(producesResponseTypeAttribute == null);
 
         ControllerParameterDescriptor? requestBodyDescriptor = endpoint.ActionDescriptor.GetBodyParameterDescriptor();
         Type bodyType = (requestBodyDescriptor?.ParameterType ?? producesResponseTypeAttribute.Type).ConstructedToOpenType();
@@ -95,10 +85,8 @@ internal sealed class OpenApiOperationIdSelector
 
     private string ApplyTemplate(string openApiOperationIdTemplate, ResourceType? resourceType, ApiDescription endpoint)
     {
-        if (endpoint.RelativePath == null || endpoint.HttpMethod == null)
-        {
-            throw new UnreachableException();
-        }
+        ConsistencyGuard.ThrowIf(endpoint.RelativePath == null);
+        ConsistencyGuard.ThrowIf(endpoint.HttpMethod == null);
 
         string method = endpoint.HttpMethod.ToLowerInvariant();
         string relationshipName = openApiOperationIdTemplate.Contains("[RelationshipName]") ? endpoint.RelativePath.Split('/').Last() : string.Empty;

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiSchemaExtensions.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiSchemaExtensions.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace JsonApiDotNetCore.OpenApi.Swashbuckle;
@@ -20,10 +19,7 @@ internal static class OpenApiSchemaExtensions
             }
         }
 
-        if (fullSchema.Properties.Count != propertiesInOrder.Count)
-        {
-            throw new UnreachableException();
-        }
+        ConsistencyGuard.ThrowIf(fullSchema.Properties.Count != propertiesInOrder.Count);
 
         fullSchema.Properties = propertiesInOrder;
     }

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Components/DataContainerSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Components/DataContainerSchemaGenerator.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiObjects.ResourceObjects;
@@ -64,11 +63,7 @@ internal sealed class DataContainerSchemaGenerator
     private static Type GetElementTypeOfDataProperty(Type dataContainerConstructedType, ResourceType resourceType)
     {
         PropertyInfo? dataProperty = dataContainerConstructedType.GetProperty("Data");
-
-        if (dataProperty == null)
-        {
-            throw new UnreachableException();
-        }
+        ConsistencyGuard.ThrowIf(dataProperty == null);
 
         Type innerPropertyType = dataProperty.PropertyType.ConstructedToOpenType().IsAssignableTo(typeof(ICollection<>))
             ? dataProperty.PropertyType.GenericTypeArguments[0]
@@ -79,10 +74,7 @@ internal sealed class DataContainerSchemaGenerator
             return typeof(DataInResponse<>).MakeGenericType(resourceType.ClrType);
         }
 
-        if (!innerPropertyType.IsGenericType)
-        {
-            throw new UnreachableException();
-        }
+        ConsistencyGuard.ThrowIf(!innerPropertyType.IsGenericType);
 
         return innerPropertyType;
     }

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Components/DataSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Components/DataSchemaGenerator.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiMetadata;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiObjects.ResourceObjects;
@@ -144,62 +144,55 @@ internal sealed class DataSchemaGenerator
 
     private static Type? GetCommonSchemaType(Type schemaOpenType)
     {
+        StrongBox<Type?>? boxedSchemaType = null;
+
         if (schemaOpenType == typeof(IdentifierInRequest<>))
         {
-            return typeof(IdentifierInRequest);
+            boxedSchemaType = new StrongBox<Type?>(typeof(IdentifierInRequest));
         }
-
-        if (schemaOpenType == typeof(DataInCreateRequest<>))
+        else if (schemaOpenType == typeof(DataInCreateRequest<>))
         {
-            return typeof(ResourceInCreateRequest);
+            boxedSchemaType = new StrongBox<Type?>(typeof(ResourceInCreateRequest));
         }
-
-        if (schemaOpenType == typeof(AttributesInCreateRequest<>))
+        else if (schemaOpenType == typeof(AttributesInCreateRequest<>))
         {
-            return typeof(AttributesInCreateRequest);
+            boxedSchemaType = new StrongBox<Type?>(typeof(AttributesInCreateRequest));
         }
-
-        if (schemaOpenType == typeof(RelationshipsInCreateRequest<>))
+        else if (schemaOpenType == typeof(RelationshipsInCreateRequest<>))
         {
-            return typeof(RelationshipsInCreateRequest);
+            boxedSchemaType = new StrongBox<Type?>(typeof(RelationshipsInCreateRequest));
         }
-
-        if (schemaOpenType == typeof(DataInUpdateRequest<>))
+        else if (schemaOpenType == typeof(DataInUpdateRequest<>))
         {
-            return typeof(ResourceInUpdateRequest);
+            boxedSchemaType = new StrongBox<Type?>(typeof(ResourceInUpdateRequest));
         }
-
-        if (schemaOpenType == typeof(AttributesInUpdateRequest<>))
+        else if (schemaOpenType == typeof(AttributesInUpdateRequest<>))
         {
-            return typeof(AttributesInUpdateRequest);
+            boxedSchemaType = new StrongBox<Type?>(typeof(AttributesInUpdateRequest));
         }
-
-        if (schemaOpenType == typeof(RelationshipsInUpdateRequest<>))
+        else if (schemaOpenType == typeof(RelationshipsInUpdateRequest<>))
         {
-            return typeof(RelationshipsInUpdateRequest);
+            boxedSchemaType = new StrongBox<Type?>(typeof(RelationshipsInUpdateRequest));
         }
-
-        if (schemaOpenType == typeof(IdentifierInResponse<>))
+        else if (schemaOpenType == typeof(IdentifierInResponse<>))
         {
-            return null;
+            boxedSchemaType = new StrongBox<Type?>(null);
         }
-
-        if (schemaOpenType == typeof(DataInResponse<>))
+        else if (schemaOpenType == typeof(DataInResponse<>))
         {
-            return typeof(ResourceInResponse);
+            boxedSchemaType = new StrongBox<Type?>(typeof(ResourceInResponse));
         }
-
-        if (schemaOpenType == typeof(AttributesInResponse<>))
+        else if (schemaOpenType == typeof(AttributesInResponse<>))
         {
-            return typeof(AttributesInResponse);
+            boxedSchemaType = new StrongBox<Type?>(typeof(AttributesInResponse));
         }
-
-        if (schemaOpenType == typeof(RelationshipsInResponse<>))
+        else if (schemaOpenType == typeof(RelationshipsInResponse<>))
         {
-            return typeof(RelationshipsInResponse);
+            boxedSchemaType = new StrongBox<Type?>(typeof(RelationshipsInResponse));
         }
 
-        throw new UnreachableException();
+        ConsistencyGuard.ThrowIf(boxedSchemaType == null);
+        return boxedSchemaType.Value;
     }
 
     public OpenApiSchema GenerateSchemaForCommonData(Type commonDataSchemaType, SchemaRepository schemaRepository)

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Components/DataSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Components/DataSchemaGenerator.cs
@@ -390,11 +390,7 @@ internal sealed class DataSchemaGenerator
                 GetResourceSchemaTypeForFieldsProperty(resourceSchemaTypeForData, forAttributes ? "Attributes" : "Relationships");
 
             Type? commonFieldsSchemaType = GetCommonSchemaType(resourceSchemaTypeForFields.SchemaOpenType);
-
-            if (commonFieldsSchemaType == null)
-            {
-                throw new UnreachableException();
-            }
+            ConsistencyGuard.ThrowIf(commonFieldsSchemaType == null);
 
             _ = GenerateSchemaForCommonFields(commonFieldsSchemaType, schemaRepository);
 
@@ -432,11 +428,7 @@ internal sealed class DataSchemaGenerator
     private ResourceSchemaType GetResourceSchemaTypeForFieldsProperty(ResourceSchemaType resourceSchemaTypeForData, string propertyName)
     {
         PropertyInfo? fieldsProperty = resourceSchemaTypeForData.SchemaConstructedType.GetProperty(propertyName);
-
-        if (fieldsProperty == null)
-        {
-            throw new UnreachableException();
-        }
+        ConsistencyGuard.ThrowIf(fieldsProperty == null);
 
         Type fieldsConstructedType = fieldsProperty.PropertyType;
         return ResourceSchemaType.Create(fieldsConstructedType, _resourceGraph);

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Components/RelationshipIdentifierSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Components/RelationshipIdentifierSchemaGenerator.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiObjects.ResourceObjects;
 using JsonApiDotNetCore.Resources.Annotations;
@@ -52,11 +51,7 @@ internal sealed class RelationshipIdentifierSchemaGenerator
         }
 
         Type relationshipIdentifierConstructedType = typeof(RelationshipIdentifier<>).MakeGenericType(relationship.LeftType.ClrType);
-
-        if (schemaRepository.TryLookupByType(relationshipIdentifierConstructedType, out _))
-        {
-            throw new UnreachableException();
-        }
+        ConsistencyGuard.ThrowIf(schemaRepository.TryLookupByType(relationshipIdentifierConstructedType, out _));
 
         OpenApiSchema referenceSchemaForIdentifier = _defaultSchemaGenerator.GenerateSchema(relationshipIdentifierConstructedType, schemaRepository);
         OpenApiSchema fullSchemaForIdentifier = schemaRepository.Schemas[referenceSchemaForIdentifier.Reference.Id];

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Documents/AtomicOperationsDocumentSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Documents/AtomicOperationsDocumentSchemaGenerator.cs
@@ -336,11 +336,7 @@ internal sealed class AtomicOperationsDocumentSchemaGenerator : DocumentSchemaGe
             RemoveProperties(inlineSchemaForOperation);
 
             string baseRelationshipSchemaId = _schemaIdSelector.GetRelationshipAtomicOperationSchemaId(relationshipInAnyBaseResourceType, operationCode);
-
-            if (!schemaRepository.Schemas.ContainsKey(baseRelationshipSchemaId))
-            {
-                throw new UnreachableException();
-            }
+            ConsistencyGuard.ThrowIf(!schemaRepository.Schemas.ContainsKey(baseRelationshipSchemaId));
 
             fullSchemaForOperation.AllOf[0] = new OpenApiSchema
             {

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Documents/AtomicOperationsDocumentSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Documents/AtomicOperationsDocumentSchemaGenerator.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using JsonApiDotNetCore.AtomicOperations;
 using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Middleware;
@@ -158,13 +157,7 @@ internal sealed class AtomicOperationsDocumentSchemaGenerator : DocumentSchemaGe
     private void GenerateSchemaForResourceOperation(Type operationOpenType, ResourceType resourceType, AtomicOperationCode operationCode,
         SchemaRepository schemaRepository)
     {
-        WriteOperationKind writeOperation = operationCode switch
-        {
-            AtomicOperationCode.Add => WriteOperationKind.CreateResource,
-            AtomicOperationCode.Update => WriteOperationKind.UpdateResource,
-            AtomicOperationCode.Remove => WriteOperationKind.DeleteResource,
-            _ => throw new UnreachableException()
-        };
+        WriteOperationKind writeOperation = GetKindOfResourceOperation(operationCode);
 
         if (IsResourceTypeEnabled(resourceType, writeOperation))
         {
@@ -210,6 +203,27 @@ internal sealed class AtomicOperationsDocumentSchemaGenerator : DocumentSchemaGe
         {
             GenerateSchemaForResourceOperation(operationOpenType, derivedType, operationCode, schemaRepository);
         }
+    }
+
+    private static WriteOperationKind GetKindOfResourceOperation(AtomicOperationCode operationCode)
+    {
+        WriteOperationKind? writeOperation = null;
+
+        if (operationCode == AtomicOperationCode.Add)
+        {
+            writeOperation = WriteOperationKind.CreateResource;
+        }
+        else if (operationCode == AtomicOperationCode.Update)
+        {
+            writeOperation = WriteOperationKind.UpdateResource;
+        }
+        else if (operationCode == AtomicOperationCode.Remove)
+        {
+            writeOperation = WriteOperationKind.DeleteResource;
+        }
+
+        ConsistencyGuard.ThrowIf(writeOperation == null);
+        return writeOperation.Value;
     }
 
     private bool IsResourceTypeEnabled(ResourceType resourceType, WriteOperationKind writeOperation)
@@ -277,13 +291,7 @@ internal sealed class AtomicOperationsDocumentSchemaGenerator : DocumentSchemaGe
     private void GenerateSchemaForRelationshipOperation(Type operationOpenType, RelationshipAttribute relationship, AtomicOperationCode operationCode,
         SchemaRepository schemaRepository)
     {
-        WriteOperationKind writeOperation = operationCode switch
-        {
-            AtomicOperationCode.Add => WriteOperationKind.AddToRelationship,
-            AtomicOperationCode.Update => WriteOperationKind.SetRelationship,
-            AtomicOperationCode.Remove => WriteOperationKind.RemoveFromRelationship,
-            _ => throw new UnreachableException()
-        };
+        WriteOperationKind writeOperation = GetKindOfRelationshipOperation(operationCode);
 
         if (!IsRelationshipEnabled(relationship, writeOperation))
         {
@@ -352,6 +360,27 @@ internal sealed class AtomicOperationsDocumentSchemaGenerator : DocumentSchemaGe
         MapInDiscriminator(referenceSchemaForOperation, discriminatorValue, schemaRepository);
     }
 
+    private static WriteOperationKind GetKindOfRelationshipOperation(AtomicOperationCode operationCode)
+    {
+        WriteOperationKind? writeOperation = null;
+
+        if (operationCode == AtomicOperationCode.Add)
+        {
+            writeOperation = WriteOperationKind.AddToRelationship;
+        }
+        else if (operationCode == AtomicOperationCode.Update)
+        {
+            writeOperation = WriteOperationKind.SetRelationship;
+        }
+        else if (operationCode == AtomicOperationCode.Remove)
+        {
+            writeOperation = WriteOperationKind.RemoveFromRelationship;
+        }
+
+        ConsistencyGuard.ThrowIf(writeOperation == null);
+        return writeOperation.Value;
+    }
+
     private bool IsRelationshipEnabled(RelationshipAttribute relationship, WriteOperationKind writeOperation)
     {
         if (!_atomicOperationFilter.IsEnabled(relationship.LeftType, writeOperation))
@@ -374,22 +403,36 @@ internal sealed class AtomicOperationsDocumentSchemaGenerator : DocumentSchemaGe
 
     private static bool IsToOneRelationshipEnabled(HasOneAttribute relationship, WriteOperationKind writeOperation)
     {
-        return writeOperation switch
+        bool? isEnabled = null;
+
+        if (writeOperation == WriteOperationKind.SetRelationship)
         {
-            WriteOperationKind.SetRelationship => relationship.Capabilities.HasFlag(HasOneCapabilities.AllowSet),
-            _ => throw new UnreachableException()
-        };
+            isEnabled = relationship.Capabilities.HasFlag(HasOneCapabilities.AllowSet);
+        }
+
+        ConsistencyGuard.ThrowIf(isEnabled == null);
+        return isEnabled.Value;
     }
 
     private static bool IsToManyRelationshipEnabled(HasManyAttribute relationship, WriteOperationKind writeOperation)
     {
-        return writeOperation switch
+        bool? isEnabled = null;
+
+        if (writeOperation == WriteOperationKind.SetRelationship)
         {
-            WriteOperationKind.SetRelationship => relationship.Capabilities.HasFlag(HasManyCapabilities.AllowSet),
-            WriteOperationKind.AddToRelationship => relationship.Capabilities.HasFlag(HasManyCapabilities.AllowAdd),
-            WriteOperationKind.RemoveFromRelationship => relationship.Capabilities.HasFlag(HasManyCapabilities.AllowRemove),
-            _ => throw new UnreachableException()
-        };
+            isEnabled = relationship.Capabilities.HasFlag(HasManyCapabilities.AllowSet);
+        }
+        else if (writeOperation == WriteOperationKind.AddToRelationship)
+        {
+            isEnabled = relationship.Capabilities.HasFlag(HasManyCapabilities.AllowAdd);
+        }
+        else if (writeOperation == WriteOperationKind.RemoveFromRelationship)
+        {
+            isEnabled = relationship.Capabilities.HasFlag(HasManyCapabilities.AllowRemove);
+        }
+
+        ConsistencyGuard.ThrowIf(isEnabled == null);
+        return isEnabled.Value;
     }
 
     private RelationshipAttribute? GetRelationshipEnabledInAnyBase(RelationshipAttribute relationship, WriteOperationKind writeOperation)

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/JsonApiSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/JsonApiSchemaGenerator.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using JsonApiDotNetCore.Controllers;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.SchemaGenerators.Components;
@@ -54,14 +53,18 @@ internal sealed class JsonApiSchemaGenerator : ISchemaGenerator
 
     private DocumentSchemaGenerator GetDocumentSchemaGenerator(Type schemaType)
     {
+        DocumentSchemaGenerator? generator = null;
+
         foreach (DocumentSchemaGenerator documentSchemaGenerator in _documentSchemaGenerators)
         {
             if (documentSchemaGenerator.CanGenerate(schemaType))
             {
-                return documentSchemaGenerator;
+                generator = documentSchemaGenerator;
+                break;
             }
         }
 
-        throw new UnreachableException();
+        ConsistencyGuard.ThrowIf(generator == null);
+        return generator;
     }
 }

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SwaggerComponents/DocumentationOpenApiOperationFilter.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SwaggerComponents/DocumentationOpenApiOperationFilter.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Net;
 using System.Reflection;
 using Humanizer;
@@ -439,10 +438,7 @@ internal sealed class DocumentationOpenApiOperationFilter : IOperationFilter
 
     private static RelationshipAttribute GetRelationshipFromRoute(ApiDescription apiDescription, ResourceType resourceType)
     {
-        if (apiDescription.RelativePath == null)
-        {
-            throw new UnreachableException();
-        }
+        ConsistencyGuard.ThrowIf(apiDescription.RelativePath == null);
 
         string relationshipName = apiDescription.RelativePath.Split('/').Last();
         return resourceType.GetRelationshipByPublicName(relationshipName);

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SwaggerComponents/ResourceFieldSchemaBuilder.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SwaggerComponents/ResourceFieldSchemaBuilder.cs
@@ -221,9 +221,6 @@ internal sealed class ResourceFieldSchemaBuilder
 
     private static void AssertHasNoProperties(OpenApiSchema fullSchema)
     {
-        if (fullSchema.Properties.Count > 0)
-        {
-            throw new UnreachableException();
-        }
+        ConsistencyGuard.ThrowIf(fullSchema.Properties.Count > 0);
     }
 }

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SwaggerComponents/ResourceFieldSchemaBuilder.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SwaggerComponents/ResourceFieldSchemaBuilder.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiMetadata;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiObjects.ResourceObjects;
@@ -108,9 +107,23 @@ internal sealed class ResourceFieldSchemaBuilder
 
     private static AttrCapabilities GetRequiredCapabilityForAttributes(Type resourceDataOpenType)
     {
-        return resourceDataOpenType == typeof(DataInResponse<>) ? AttrCapabilities.AllowView :
-            resourceDataOpenType == typeof(DataInCreateRequest<>) ? AttrCapabilities.AllowCreate :
-            resourceDataOpenType == typeof(DataInUpdateRequest<>) ? AttrCapabilities.AllowChange : throw new UnreachableException();
+        AttrCapabilities? capabilities = null;
+
+        if (resourceDataOpenType == typeof(DataInResponse<>))
+        {
+            capabilities = AttrCapabilities.AllowView;
+        }
+        else if (resourceDataOpenType == typeof(DataInCreateRequest<>))
+        {
+            capabilities = AttrCapabilities.AllowCreate;
+        }
+        else if (resourceDataOpenType == typeof(DataInUpdateRequest<>))
+        {
+            capabilities = AttrCapabilities.AllowChange;
+        }
+
+        ConsistencyGuard.ThrowIf(capabilities == null);
+        return capabilities.Value;
     }
 
     private void EnsureAttributeSchemaIsExposed(OpenApiSchema referenceSchemaForAttribute, AttrAttribute attribute, SchemaRepository schemaRepository)

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SwaggerComponents/StringEnumOrderingFilter.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SwaggerComponents/StringEnumOrderingFilter.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
@@ -47,11 +46,7 @@ internal sealed class StringEnumOrderingFilter : IDocumentFilter
         private static void OrderEnumMembers(OpenApiSchema schema)
         {
             List<IOpenApiAny> ordered = schema.Enum.OfType<OpenApiString>().OrderBy(openApiString => openApiString.Value).Cast<IOpenApiAny>().ToList();
-
-            if (ordered.Count != schema.Enum.Count)
-            {
-                throw new UnreachableException();
-            }
+            ConsistencyGuard.ThrowIf(ordered.Count != schema.Enum.Count);
 
             schema.Enum = ordered;
         }


### PR DESCRIPTION
Replace occurrences of:
```c#
throw new UnreachableException();
```
which gets flagged as non-covered by tests, with an extension method that is marked with `[ExcludeFromCodeCoverage]`.
It works similarly to `Debug.Assert`, taking a boolean condition.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
