### PR TITLE
Bump kiota and NSwag

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -31,7 +31,7 @@
       "rollForward": false
     },
     "microsoft.openapi.kiota": {
-      "version": "1.24.1",
+      "version": "1.24.3",
       "commands": [
         "kiota"
       ],

--- a/package-versions.props
+++ b/package-versions.props
@@ -20,7 +20,7 @@
     <KiotaVersion>1.*</KiotaVersion>
     <MicrosoftApiClientVersion>9.0.*</MicrosoftApiClientVersion>
     <MicrosoftApiServerVersion>9.0.*</MicrosoftApiServerVersion>
-    <NSwagApiClientVersion>14.2.*</NSwagApiClientVersion>
+    <NSwagApiClientVersion>14.3.*</NSwagApiClientVersion>
     <NewtonsoftJsonVersion>13.0.*</NewtonsoftJsonVersion>
     <ScalarAspNetCoreVersion>2.1.*</ScalarAspNetCoreVersion>
     <SwashbuckleVersion>8.*-*</SwashbuckleVersion>


### PR DESCRIPTION
Package updates:
- `microsoft.openapi.kiota` CLI from v1.24.1 to v1.24.3
- `NSwag.ApiDescription.Client` from v14.2.* to v14.3.*

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
