### PR TITLE
Add trace logging for component schema generation

### DIFF
--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/ISchemaGenerationTraceScope.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/ISchemaGenerationTraceScope.cs
@@ -1,0 +1,6 @@
+namespace JsonApiDotNetCore.OpenApi.Swashbuckle;
+
+internal interface ISchemaGenerationTraceScope : IDisposable
+{
+    void TraceSucceeded(string schemaId);
+}

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerationTracer.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerationTracer.cs
@@ -1,0 +1,153 @@
+using JsonApiDotNetCore.Resources.Annotations;
+using JsonApiDotNetCore.Serialization.Objects;
+using Microsoft.Extensions.Logging;
+
+namespace JsonApiDotNetCore.OpenApi.Swashbuckle;
+
+/// <summary>
+/// Enables to log recursive component schema generation at trace level.
+/// </summary>
+internal sealed partial class SchemaGenerationTracer
+{
+    private readonly ILoggerFactory _loggerFactory;
+
+    public SchemaGenerationTracer(ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        _loggerFactory = loggerFactory;
+    }
+
+    public ISchemaGenerationTraceScope TraceStart(object generator)
+    {
+        ArgumentNullException.ThrowIfNull(generator);
+
+        return InnerTraceStart(generator, () => "(none)");
+    }
+
+    public ISchemaGenerationTraceScope TraceStart(object generator, Type schemaType)
+    {
+        ArgumentNullException.ThrowIfNull(generator);
+        ArgumentNullException.ThrowIfNull(schemaType);
+
+        return InnerTraceStart(generator, () => GetSchemaTypeName(schemaType));
+    }
+
+    public ISchemaGenerationTraceScope TraceStart(object generator, AtomicOperationCode operationCode)
+    {
+        ArgumentNullException.ThrowIfNull(generator);
+
+        return InnerTraceStart(generator, () => $"{nameof(AtomicOperationCode)}.{operationCode}");
+    }
+
+    public ISchemaGenerationTraceScope TraceStart(object generator, RelationshipAttribute relationship)
+    {
+        ArgumentNullException.ThrowIfNull(generator);
+        ArgumentNullException.ThrowIfNull(relationship);
+
+        return InnerTraceStart(generator,
+            () => $"{GetSchemaTypeName(relationship.GetType())}({GetSchemaTypeName(relationship.LeftType.ClrType)}.{relationship.Property.Name})");
+    }
+
+    public ISchemaGenerationTraceScope TraceStart(object generator, Type schemaOpenType, RelationshipAttribute relationship)
+    {
+        ArgumentNullException.ThrowIfNull(generator);
+        ArgumentNullException.ThrowIfNull(schemaOpenType);
+        ArgumentNullException.ThrowIfNull(relationship);
+
+        return InnerTraceStart(generator,
+            () =>
+                $"{GetSchemaTypeName(schemaOpenType)} with {GetSchemaTypeName(relationship.GetType())}({GetSchemaTypeName(relationship.LeftType.ClrType)}.{relationship.Property.Name})");
+    }
+
+    private ISchemaGenerationTraceScope InnerTraceStart(object generator, Func<string> getSchemaTypeName)
+    {
+        ILogger logger = _loggerFactory.CreateLogger(generator.GetType());
+
+        if (logger.IsEnabled(LogLevel.Trace))
+        {
+            string schemaTypeName = getSchemaTypeName();
+            return new SchemaGenerationTraceScope(logger, schemaTypeName);
+        }
+
+        return DisabledSchemaGenerationTraceScope.Instance;
+    }
+
+    private static string GetSchemaTypeName(Type type)
+    {
+        if (type.IsConstructedGenericType)
+        {
+            string typeArguments = string.Join(',', type.GetGenericArguments().Select(GetSchemaTypeName));
+            int arityIndex = type.Name.IndexOf('`');
+            return $"{type.Name[..arityIndex]}<{typeArguments}>";
+        }
+
+        return type.Name;
+    }
+
+    private sealed partial class SchemaGenerationTraceScope : ISchemaGenerationTraceScope
+    {
+        private static readonly AsyncLocal<int> RecursionDepthAsyncLocal = new();
+
+        private readonly ILogger _logger;
+        private readonly string _schemaTypeName;
+        private string? _schemaId;
+
+        public SchemaGenerationTraceScope(ILogger logger, string schemaTypeName)
+        {
+            ArgumentNullException.ThrowIfNull(logger);
+            ArgumentNullException.ThrowIfNull(schemaTypeName);
+
+            _logger = logger;
+            _schemaTypeName = schemaTypeName;
+
+            RecursionDepthAsyncLocal.Value++;
+            LogStarted(RecursionDepthAsyncLocal.Value, _schemaTypeName);
+        }
+
+        public void TraceSucceeded(string schemaId)
+        {
+            _schemaId = schemaId;
+        }
+
+        public void Dispose()
+        {
+            if (_schemaId != null)
+            {
+                LogSucceeded(RecursionDepthAsyncLocal.Value, _schemaTypeName, _schemaId);
+            }
+            else
+            {
+                LogFailed(RecursionDepthAsyncLocal.Value, _schemaTypeName);
+            }
+
+            RecursionDepthAsyncLocal.Value--;
+        }
+
+        [LoggerMessage(Level = LogLevel.Trace, SkipEnabledCheck = true, Message = "({Depth:D2}) Started for {SchemaTypeName}.")]
+        private partial void LogStarted(int depth, string schemaTypeName);
+
+        [LoggerMessage(Level = LogLevel.Trace, SkipEnabledCheck = true, Message = "({Depth:D2}) Generated '{SchemaId}' from {SchemaTypeName}.")]
+        private partial void LogSucceeded(int depth, string schemaTypeName, string schemaId);
+
+        [LoggerMessage(Level = LogLevel.Trace, SkipEnabledCheck = true, Message = "({Depth:D2}) Failed for {SchemaTypeName}.")]
+        private partial void LogFailed(int depth, string schemaTypeName);
+    }
+
+    private sealed class DisabledSchemaGenerationTraceScope : ISchemaGenerationTraceScope
+    {
+        public static DisabledSchemaGenerationTraceScope Instance { get; } = new();
+
+        private DisabledSchemaGenerationTraceScope()
+        {
+        }
+
+        public void TraceSucceeded(string schemaId)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Components/RelationshipIdentifierSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Components/RelationshipIdentifierSchemaGenerator.cs
@@ -8,22 +8,25 @@ namespace JsonApiDotNetCore.OpenApi.Swashbuckle.SchemaGenerators.Components;
 
 internal sealed class RelationshipIdentifierSchemaGenerator
 {
+    private readonly SchemaGenerationTracer _schemaGenerationTracer;
     private readonly SchemaGenerator _defaultSchemaGenerator;
     private readonly ResourceTypeSchemaGenerator _resourceTypeSchemaGenerator;
     private readonly ResourceIdSchemaGenerator _resourceIdSchemaGenerator;
     private readonly RelationshipNameSchemaGenerator _relationshipNameSchemaGenerator;
     private readonly JsonApiSchemaIdSelector _schemaIdSelector;
 
-    public RelationshipIdentifierSchemaGenerator(SchemaGenerator defaultSchemaGenerator, ResourceTypeSchemaGenerator resourceTypeSchemaGenerator,
-        ResourceIdSchemaGenerator resourceIdSchemaGenerator, RelationshipNameSchemaGenerator relationshipNameSchemaGenerator,
-        JsonApiSchemaIdSelector schemaIdSelector)
+    public RelationshipIdentifierSchemaGenerator(SchemaGenerationTracer schemaGenerationTracer, SchemaGenerator defaultSchemaGenerator,
+        ResourceTypeSchemaGenerator resourceTypeSchemaGenerator, ResourceIdSchemaGenerator resourceIdSchemaGenerator,
+        RelationshipNameSchemaGenerator relationshipNameSchemaGenerator, JsonApiSchemaIdSelector schemaIdSelector)
     {
+        ArgumentNullException.ThrowIfNull(schemaGenerationTracer);
         ArgumentNullException.ThrowIfNull(defaultSchemaGenerator);
         ArgumentNullException.ThrowIfNull(resourceTypeSchemaGenerator);
         ArgumentNullException.ThrowIfNull(resourceIdSchemaGenerator);
         ArgumentNullException.ThrowIfNull(relationshipNameSchemaGenerator);
         ArgumentNullException.ThrowIfNull(schemaIdSelector);
 
+        _schemaGenerationTracer = schemaGenerationTracer;
         _defaultSchemaGenerator = defaultSchemaGenerator;
         _resourceTypeSchemaGenerator = resourceTypeSchemaGenerator;
         _resourceIdSchemaGenerator = resourceIdSchemaGenerator;
@@ -50,6 +53,8 @@ internal sealed class RelationshipIdentifierSchemaGenerator
             };
         }
 
+        using ISchemaGenerationTraceScope traceScope = _schemaGenerationTracer.TraceStart(this, relationship);
+
         Type relationshipIdentifierConstructedType = typeof(RelationshipIdentifier<>).MakeGenericType(relationship.LeftType.ClrType);
         ConsistencyGuard.ThrowIf(schemaRepository.TryLookupByType(relationshipIdentifierConstructedType, out _));
 
@@ -65,6 +70,7 @@ internal sealed class RelationshipIdentifierSchemaGenerator
         schemaRepository.ReplaceSchemaId(relationshipIdentifierConstructedType, schemaId);
         referenceSchemaForIdentifier.Reference.Id = schemaId;
 
+        traceScope.TraceSucceeded(schemaId);
         return referenceSchemaForIdentifier;
     }
 

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Components/ResourceIdSchemaGenerator.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/SchemaGenerators/Components/ResourceIdSchemaGenerator.cs
@@ -17,6 +17,8 @@ internal sealed class ResourceIdSchemaGenerator
 
     public OpenApiSchema GenerateSchema(ResourceType resourceType, SchemaRepository schemaRepository)
     {
+        ArgumentNullException.ThrowIfNull(resourceType);
+
         return GenerateSchema(resourceType.IdentityClrType, schemaRepository);
     }
 
@@ -26,6 +28,8 @@ internal sealed class ResourceIdSchemaGenerator
         ArgumentNullException.ThrowIfNull(schemaRepository);
 
         OpenApiSchema idSchema = _defaultSchemaGenerator.GenerateSchema(resourceIdClrType, schemaRepository);
+        ConsistencyGuard.ThrowIf(idSchema.Reference != null);
+
         idSchema.Type = "string";
 
         if (resourceIdClrType != typeof(string))

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/ServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/ServiceCollectionExtensions.cs
@@ -109,5 +109,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<DataContainerSchemaGenerator>();
         services.TryAddSingleton<LinksVisibilitySchemaGenerator>();
         services.TryAddSingleton<GenerationCacheSchemaGenerator>();
+
+        services.TryAddSingleton<SchemaGenerationTracer>();
     }
 }

--- a/test/OpenApiTests/AtomicOperations/OperationsTests.cs
+++ b/test/OpenApiTests/AtomicOperations/OperationsTests.cs
@@ -3,6 +3,7 @@ using JsonApiDotNetCore.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.AtomicOperations;
 
@@ -10,16 +11,17 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
 {
     private readonly OpenApiTestContext<OpenApiStartup<OperationsDbContext>, OperationsDbContext> _testContext;
 
-    public OperationsTests(OpenApiTestContext<OpenApiStartup<OperationsDbContext>, OperationsDbContext> testContext)
+    public OperationsTests(OpenApiTestContext<OpenApiStartup<OperationsDbContext>, OperationsDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<OperationsController>();
 
+        testContext.SetTestOutputHelper(testOutputHelper);
+        testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
+
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
         options.IncludeJsonApiVersion = true;
-
-        testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 
     [Fact]

--- a/test/OpenApiTests/ClientIdGenerationModes/ClientIdGenerationTests.cs
+++ b/test/OpenApiTests/ClientIdGenerationModes/ClientIdGenerationTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.ClientIdGenerationModes;
 
@@ -8,7 +9,8 @@ public sealed class ClientIdGenerationTests : IClassFixture<OpenApiTestContext<O
 {
     private readonly OpenApiTestContext<OpenApiStartup<ClientIdGenerationDbContext>, ClientIdGenerationDbContext> _testContext;
 
-    public ClientIdGenerationTests(OpenApiTestContext<OpenApiStartup<ClientIdGenerationDbContext>, ClientIdGenerationDbContext> testContext)
+    public ClientIdGenerationTests(OpenApiTestContext<OpenApiStartup<ClientIdGenerationDbContext>, ClientIdGenerationDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
@@ -16,6 +18,7 @@ public sealed class ClientIdGenerationTests : IClassFixture<OpenApiTestContext<O
         testContext.UseController<GamesController>();
         testContext.UseController<PlayerGroupsController>();
 
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/Documentation/DocumentationTests.cs
+++ b/test/OpenApiTests/Documentation/DocumentationTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 // @formatter:max_line_length 250
 
@@ -17,7 +18,7 @@ public sealed class DocumentationTests : IClassFixture<OpenApiTestContext<Docume
 
     private readonly OpenApiTestContext<DocumentationStartup<DocumentationDbContext>, DocumentationDbContext> _testContext;
 
-    public DocumentationTests(OpenApiTestContext<DocumentationStartup<DocumentationDbContext>, DocumentationDbContext> testContext)
+    public DocumentationTests(OpenApiTestContext<DocumentationStartup<DocumentationDbContext>, DocumentationDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
@@ -25,6 +26,8 @@ public sealed class DocumentationTests : IClassFixture<OpenApiTestContext<Docume
         testContext.UseController<ElevatorsController>();
         testContext.UseController<SpacesController>();
         testContext.UseController<OperationsController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
     }
 
     [Fact]

--- a/test/OpenApiTests/Documentation/ErrorResponseTests.cs
+++ b/test/OpenApiTests/Documentation/ErrorResponseTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.Documentation;
 
@@ -12,7 +13,8 @@ public sealed class ErrorResponseTests : IClassFixture<OpenApiTestContext<Docume
 
     private readonly OpenApiTestContext<DocumentationStartup<DocumentationDbContext>, DocumentationDbContext> _testContext;
 
-    public ErrorResponseTests(OpenApiTestContext<DocumentationStartup<DocumentationDbContext>, DocumentationDbContext> testContext)
+    public ErrorResponseTests(OpenApiTestContext<DocumentationStartup<DocumentationDbContext>, DocumentationDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
@@ -20,6 +22,8 @@ public sealed class ErrorResponseTests : IClassFixture<OpenApiTestContext<Docume
         testContext.UseController<ElevatorsController>();
         testContext.UseController<SpacesController>();
         testContext.UseController<OperationsController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
     }
 
     [Fact]

--- a/test/OpenApiTests/Headers/HeaderTests.cs
+++ b/test/OpenApiTests/Headers/HeaderTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.Headers;
 
@@ -9,12 +10,13 @@ public sealed class HeaderTests : IClassFixture<OpenApiTestContext<OpenApiStartu
 {
     private readonly OpenApiTestContext<OpenApiStartup<HeaderDbContext>, HeaderDbContext> _testContext;
 
-    public HeaderTests(OpenApiTestContext<OpenApiStartup<HeaderDbContext>, HeaderDbContext> testContext)
+    public HeaderTests(OpenApiTestContext<OpenApiStartup<HeaderDbContext>, HeaderDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<CountriesController>();
 
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/LegacyOpenApi/LegacyTests.cs
+++ b/test/OpenApiTests/LegacyOpenApi/LegacyTests.cs
@@ -4,18 +4,20 @@ using System.Text.Json;
 using FluentAssertions;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.LegacyOpenApi;
 
 public sealed class LegacyTests : OpenApiTestContext<LegacyStartup<LegacyIntegrationDbContext>, LegacyIntegrationDbContext>
 {
-    public LegacyTests()
+    public LegacyTests(ITestOutputHelper testOutputHelper)
     {
         UseController<AirplanesController>();
         UseController<FlightsController>();
         UseController<FlightAttendantsController>();
         UseController<PassengersController>();
 
+        SetTestOutputHelper(testOutputHelper);
         SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/Links/Disabled/LinksDisabledTests.cs
+++ b/test/OpenApiTests/Links/Disabled/LinksDisabledTests.cs
@@ -5,6 +5,7 @@ using JsonApiDotNetCore.Resources.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.Links.Disabled;
 
@@ -12,7 +13,7 @@ public sealed class LinksDisabledTests : IClassFixture<OpenApiTestContext<OpenAp
 {
     private readonly OpenApiTestContext<OpenApiStartup<LinkDbContext>, LinkDbContext> _testContext;
 
-    public LinksDisabledTests(OpenApiTestContext<OpenApiStartup<LinkDbContext>, LinkDbContext> testContext)
+    public LinksDisabledTests(OpenApiTestContext<OpenApiStartup<LinkDbContext>, LinkDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
@@ -20,6 +21,8 @@ public sealed class LinksDisabledTests : IClassFixture<OpenApiTestContext<OpenAp
         testContext.UseController<AccommodationsController>();
         testContext.UseController<TransportsController>();
         testContext.UseController<ExcursionsController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
 
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
         options.TopLevelLinks = LinkTypes.None;

--- a/test/OpenApiTests/Links/Enabled/LinksEnabledTests.cs
+++ b/test/OpenApiTests/Links/Enabled/LinksEnabledTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using JsonApiDotNetCore.Resources.Annotations;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.Links.Enabled;
 
@@ -10,7 +11,7 @@ public sealed class LinksEnabledTests : IClassFixture<OpenApiTestContext<OpenApi
 {
     private readonly OpenApiTestContext<OpenApiStartup<LinkDbContext>, LinkDbContext> _testContext;
 
-    public LinksEnabledTests(OpenApiTestContext<OpenApiStartup<LinkDbContext>, LinkDbContext> testContext)
+    public LinksEnabledTests(OpenApiTestContext<OpenApiStartup<LinkDbContext>, LinkDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
@@ -19,6 +20,7 @@ public sealed class LinksEnabledTests : IClassFixture<OpenApiTestContext<OpenApi
         testContext.UseController<TransportsController>();
         testContext.UseController<ExcursionsController>();
 
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/Links/Mixed/LinksMixedTests.cs
+++ b/test/OpenApiTests/Links/Mixed/LinksMixedTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.Links.Mixed;
 
@@ -13,7 +14,7 @@ public sealed class LinksMixedTests : IClassFixture<OpenApiTestContext<OpenApiSt
 {
     private readonly OpenApiTestContext<OpenApiStartup<LinkDbContext>, LinkDbContext> _testContext;
 
-    public LinksMixedTests(OpenApiTestContext<OpenApiStartup<LinkDbContext>, LinkDbContext> testContext)
+    public LinksMixedTests(OpenApiTestContext<OpenApiStartup<LinkDbContext>, LinkDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
@@ -22,6 +23,7 @@ public sealed class LinksMixedTests : IClassFixture<OpenApiTestContext<OpenApiSt
         testContext.UseController<TransportsController>();
         testContext.UseController<ExcursionsController>();
 
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.ConfigureServices(services => services.AddSingleton(CreateResourceGraph));
 
         var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();

--- a/test/OpenApiTests/ModelStateValidation/ModelStateValidationTests.cs
+++ b/test/OpenApiTests/ModelStateValidation/ModelStateValidationTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.ModelStateValidation;
 
@@ -16,12 +17,14 @@ public sealed class ModelStateValidationTests : IClassFixture<OpenApiTestContext
 
     private readonly OpenApiTestContext<OpenApiStartup<ModelStateValidationDbContext>, ModelStateValidationDbContext> _testContext;
 
-    public ModelStateValidationTests(OpenApiTestContext<OpenApiStartup<ModelStateValidationDbContext>, ModelStateValidationDbContext> testContext)
+    public ModelStateValidationTests(OpenApiTestContext<OpenApiStartup<ModelStateValidationDbContext>, ModelStateValidationDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<SocialMediaAccountsController>();
 
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/NamingConventions/CamelCase/CamelCaseTests.cs
+++ b/test/OpenApiTests/NamingConventions/CamelCase/CamelCaseTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.NamingConventions.CamelCase;
 
@@ -11,7 +12,8 @@ public sealed class CamelCaseTests : IClassFixture<OpenApiTestContext<CamelCaseN
 
     private readonly OpenApiTestContext<CamelCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext> _testContext;
 
-    public CamelCaseTests(OpenApiTestContext<CamelCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext> testContext)
+    public CamelCaseTests(OpenApiTestContext<CamelCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
@@ -19,6 +21,7 @@ public sealed class CamelCaseTests : IClassFixture<OpenApiTestContext<CamelCaseN
         testContext.UseController<StaffMembersController>();
         testContext.UseController<OperationsController>();
 
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/NamingConventions/KebabCase/KebabCaseTests.cs
+++ b/test/OpenApiTests/NamingConventions/KebabCase/KebabCaseTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.NamingConventions.KebabCase;
 
@@ -11,7 +12,8 @@ public sealed class KebabCaseTests : IClassFixture<OpenApiTestContext<KebabCaseN
 
     private readonly OpenApiTestContext<KebabCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext> _testContext;
 
-    public KebabCaseTests(OpenApiTestContext<KebabCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext> testContext)
+    public KebabCaseTests(OpenApiTestContext<KebabCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
@@ -19,6 +21,7 @@ public sealed class KebabCaseTests : IClassFixture<OpenApiTestContext<KebabCaseN
         testContext.UseController<StaffMembersController>();
         testContext.UseController<OperationsController>();
 
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/NamingConventions/PascalCase/PascalCaseTests.cs
+++ b/test/OpenApiTests/NamingConventions/PascalCase/PascalCaseTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.NamingConventions.PascalCase;
 
@@ -11,7 +12,8 @@ public sealed class PascalCaseTests : IClassFixture<OpenApiTestContext<PascalCas
 
     private readonly OpenApiTestContext<PascalCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext> _testContext;
 
-    public PascalCaseTests(OpenApiTestContext<PascalCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext> testContext)
+    public PascalCaseTests(OpenApiTestContext<PascalCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
@@ -19,6 +21,7 @@ public sealed class PascalCaseTests : IClassFixture<OpenApiTestContext<PascalCas
         testContext.UseController<StaffMembersController>();
         testContext.UseController<OperationsController>();
 
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/OpenApiGenerationFailures/MissingFromBody/MissingFromBodyOnPatchMethodTests.cs
+++ b/test/OpenApiTests/OpenApiGenerationFailures/MissingFromBody/MissingFromBodyOnPatchMethodTests.cs
@@ -1,14 +1,17 @@
 using FluentAssertions;
 using JsonApiDotNetCore.Errors;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.OpenApiGenerationFailures.MissingFromBody;
 
 public sealed class MissingFromBodyOnPatchMethodTests : OpenApiTestContext<OpenApiStartup<MissingFromBodyDbContext>, MissingFromBodyDbContext>
 {
-    public MissingFromBodyOnPatchMethodTests()
+    public MissingFromBodyOnPatchMethodTests(ITestOutputHelper testOutputHelper)
     {
         UseController<MissingFromBodyOnPatchController>();
+
+        SetTestOutputHelper(testOutputHelper);
     }
 
     [Fact]

--- a/test/OpenApiTests/OpenApiGenerationFailures/MissingFromBody/MissingFromBodyOnPostMethodTests.cs
+++ b/test/OpenApiTests/OpenApiGenerationFailures/MissingFromBody/MissingFromBodyOnPostMethodTests.cs
@@ -1,14 +1,17 @@
 ﻿using FluentAssertions;
 using JsonApiDotNetCore.Errors;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.OpenApiGenerationFailures.MissingFromBody;
 
 public sealed class MissingFromBodyOnPostMethodTests : OpenApiTestContext<OpenApiStartup<MissingFromBodyDbContext>, MissingFromBodyDbContext>
 {
-    public MissingFromBodyOnPostMethodTests()
+    public MissingFromBodyOnPostMethodTests(ITestOutputHelper testOutputHelper)
     {
         UseController<MissingFromBodyOnPostController>();
+
+        SetTestOutputHelper(testOutputHelper);
     }
 
     [Fact]

--- a/test/OpenApiTests/QueryStrings/IncludeTests.cs
+++ b/test/OpenApiTests/QueryStrings/IncludeTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.QueryStrings;
 
@@ -16,11 +17,13 @@ public sealed class IncludeTests : IClassFixture<OpenApiTestContext<OpenApiStart
 {
     private readonly OpenApiTestContext<OpenApiStartup<QueryStringDbContext>, QueryStringDbContext> _testContext;
 
-    public IncludeTests(OpenApiTestContext<OpenApiStartup<QueryStringDbContext>, QueryStringDbContext> testContext)
+    public IncludeTests(OpenApiTestContext<OpenApiStartup<QueryStringDbContext>, QueryStringDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<OnlyGetSingleNodeController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
     }
 
     [Fact]

--- a/test/OpenApiTests/QueryStrings/QueryStringTests.cs
+++ b/test/OpenApiTests/QueryStrings/QueryStringTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.QueryStrings;
 
@@ -9,13 +10,14 @@ public sealed class QueryStringTests : IClassFixture<OpenApiTestContext<OpenApiS
 {
     private readonly OpenApiTestContext<OpenApiStartup<QueryStringDbContext>, QueryStringDbContext> _testContext;
 
-    public QueryStringTests(OpenApiTestContext<OpenApiStartup<QueryStringDbContext>, QueryStringDbContext> testContext)
+    public QueryStringTests(OpenApiTestContext<OpenApiStartup<QueryStringDbContext>, QueryStringDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<NodesController>();
         testContext.UseController<NameValuePairsController>();
 
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/NullabilityTests.cs
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/NullabilityTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.ResourceFieldValidation.NullableReferenceTypesOff.ModelStateValidationOff;
 
@@ -9,11 +10,13 @@ public sealed class NullabilityTests : IClassFixture<OpenApiTestContext<MsvOffSt
 {
     private readonly OpenApiTestContext<MsvOffStartup<NrtOffDbContext>, NrtOffDbContext> _testContext;
 
-    public NullabilityTests(OpenApiTestContext<MsvOffStartup<NrtOffDbContext>, NrtOffDbContext> testContext)
+    public NullabilityTests(OpenApiTestContext<MsvOffStartup<NrtOffDbContext>, NrtOffDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<NrtOffResourcesController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/RequiredTests.cs
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/RequiredTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.ResourceFieldValidation.NullableReferenceTypesOff.ModelStateValidationOff;
 
@@ -8,11 +9,13 @@ public sealed class RequiredTests : IClassFixture<OpenApiTestContext<MsvOffStart
 {
     private readonly OpenApiTestContext<MsvOffStartup<NrtOffDbContext>, NrtOffDbContext> _testContext;
 
-    public RequiredTests(OpenApiTestContext<MsvOffStartup<NrtOffDbContext>, NrtOffDbContext> testContext)
+    public RequiredTests(OpenApiTestContext<MsvOffStartup<NrtOffDbContext>, NrtOffDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<NrtOffResourcesController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
     }
 
     [Theory]

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/NullabilityTests.cs
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/NullabilityTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.ResourceFieldValidation.NullableReferenceTypesOff.ModelStateValidationOn;
 
@@ -9,11 +10,13 @@ public sealed class NullabilityTests : IClassFixture<OpenApiTestContext<OpenApiS
 {
     private readonly OpenApiTestContext<OpenApiStartup<NrtOffDbContext>, NrtOffDbContext> _testContext;
 
-    public NullabilityTests(OpenApiTestContext<OpenApiStartup<NrtOffDbContext>, NrtOffDbContext> testContext)
+    public NullabilityTests(OpenApiTestContext<OpenApiStartup<NrtOffDbContext>, NrtOffDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<NrtOffResourcesController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/RequiredTests.cs
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/RequiredTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.ResourceFieldValidation.NullableReferenceTypesOff.ModelStateValidationOn;
 
@@ -8,11 +9,13 @@ public sealed class RequiredTests : IClassFixture<OpenApiTestContext<OpenApiStar
 {
     private readonly OpenApiTestContext<OpenApiStartup<NrtOffDbContext>, NrtOffDbContext> _testContext;
 
-    public RequiredTests(OpenApiTestContext<OpenApiStartup<NrtOffDbContext>, NrtOffDbContext> testContext)
+    public RequiredTests(OpenApiTestContext<OpenApiStartup<NrtOffDbContext>, NrtOffDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<NrtOffResourcesController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
     }
 
     [Theory]

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/NullabilityTests.cs
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/NullabilityTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.ResourceFieldValidation.NullableReferenceTypesOn.ModelStateValidationOff;
 
@@ -9,11 +10,13 @@ public sealed class NullabilityTests : IClassFixture<OpenApiTestContext<MsvOffSt
 {
     private readonly OpenApiTestContext<MsvOffStartup<NrtOnDbContext>, NrtOnDbContext> _testContext;
 
-    public NullabilityTests(OpenApiTestContext<MsvOffStartup<NrtOnDbContext>, NrtOnDbContext> testContext)
+    public NullabilityTests(OpenApiTestContext<MsvOffStartup<NrtOnDbContext>, NrtOnDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<NrtOnResourcesController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/RequiredTests.cs
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/RequiredTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.ResourceFieldValidation.NullableReferenceTypesOn.ModelStateValidationOff;
 
@@ -8,11 +9,13 @@ public sealed class RequiredTests : IClassFixture<OpenApiTestContext<MsvOffStart
 {
     private readonly OpenApiTestContext<MsvOffStartup<NrtOnDbContext>, NrtOnDbContext> _testContext;
 
-    public RequiredTests(OpenApiTestContext<MsvOffStartup<NrtOnDbContext>, NrtOnDbContext> testContext)
+    public RequiredTests(OpenApiTestContext<MsvOffStartup<NrtOnDbContext>, NrtOnDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<NrtOnResourcesController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
     }
 
     [Theory]

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/NullabilityTests.cs
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/NullabilityTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentAssertions;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.ResourceFieldValidation.NullableReferenceTypesOn.ModelStateValidationOn;
 
@@ -9,11 +10,13 @@ public sealed class NullabilityTests : IClassFixture<OpenApiTestContext<OpenApiS
 {
     private readonly OpenApiTestContext<OpenApiStartup<NrtOnDbContext>, NrtOnDbContext> _testContext;
 
-    public NullabilityTests(OpenApiTestContext<OpenApiStartup<NrtOnDbContext>, NrtOnDbContext> testContext)
+    public NullabilityTests(OpenApiTestContext<OpenApiStartup<NrtOnDbContext>, NrtOnDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<NrtOnResourcesController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/RequiredTests.cs
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/RequiredTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.ResourceFieldValidation.NullableReferenceTypesOn.ModelStateValidationOn;
 
@@ -8,11 +9,13 @@ public sealed class RequiredTests : IClassFixture<OpenApiTestContext<OpenApiStar
 {
     private readonly OpenApiTestContext<OpenApiStartup<NrtOnDbContext>, NrtOnDbContext> _testContext;
 
-    public RequiredTests(OpenApiTestContext<OpenApiStartup<NrtOnDbContext>, NrtOnDbContext> testContext)
+    public RequiredTests(OpenApiTestContext<OpenApiStartup<NrtOnDbContext>, NrtOnDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
         testContext.UseController<NrtOnResourcesController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
     }
 
     [Theory]

--- a/test/OpenApiTests/ResourceInheritance/Everything/EverythingInheritanceTests.cs
+++ b/test/OpenApiTests/ResourceInheritance/Everything/EverythingInheritanceTests.cs
@@ -1,13 +1,15 @@
 using JsonApiDotNetCore.Controllers;
 using OpenApiTests.ResourceInheritance.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 #pragma warning disable format
 
 namespace OpenApiTests.ResourceInheritance.Everything;
 
-public sealed class EverythingInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext)
-    : ResourceInheritanceTests(testContext, true, false)
+public sealed class EverythingInheritanceTests(
+    OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext, ITestOutputHelper testOutputHelper)
+    : ResourceInheritanceTests(testContext, testOutputHelper, true, false)
 {
     [Theory]
     [InlineData(typeof(District), JsonApiEndpoints.All)]

--- a/test/OpenApiTests/ResourceInheritance/NoOperations/NoOperationsInheritanceTests.cs
+++ b/test/OpenApiTests/ResourceInheritance/NoOperations/NoOperationsInheritanceTests.cs
@@ -4,6 +4,7 @@ using JsonApiDotNetCore.Middleware;
 using Microsoft.Extensions.DependencyInjection;
 using OpenApiTests.ResourceInheritance.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 #pragma warning disable format
 
@@ -11,8 +12,9 @@ namespace OpenApiTests.ResourceInheritance.NoOperations;
 
 public sealed class NoOperationsInheritanceTests : ResourceInheritanceTests
 {
-    public NoOperationsInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext)
-        : base(testContext, true, true)
+    public NoOperationsInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
+        : base(testContext, testOutputHelper, true, true)
     {
         testContext.ConfigureServices(services =>
         {

--- a/test/OpenApiTests/ResourceInheritance/OnlyAbstract/OnlyAbstractInheritanceTests.cs
+++ b/test/OpenApiTests/ResourceInheritance/OnlyAbstract/OnlyAbstractInheritanceTests.cs
@@ -4,6 +4,7 @@ using JsonApiDotNetCore.Middleware;
 using Microsoft.Extensions.DependencyInjection;
 using OpenApiTests.ResourceInheritance.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 #pragma warning disable format
 
@@ -11,8 +12,9 @@ namespace OpenApiTests.ResourceInheritance.OnlyAbstract;
 
 public sealed class OnlyAbstractInheritanceTests : ResourceInheritanceTests
 {
-    public OnlyAbstractInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext)
-        : base(testContext, true, false)
+    public OnlyAbstractInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
+        : base(testContext, testOutputHelper, true, false)
     {
         testContext.ConfigureServices(services =>
         {

--- a/test/OpenApiTests/ResourceInheritance/OnlyConcrete/OnlyConcreteInheritanceTests.cs
+++ b/test/OpenApiTests/ResourceInheritance/OnlyConcrete/OnlyConcreteInheritanceTests.cs
@@ -4,6 +4,7 @@ using JsonApiDotNetCore.Middleware;
 using Microsoft.Extensions.DependencyInjection;
 using OpenApiTests.ResourceInheritance.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 #pragma warning disable format
 
@@ -11,8 +12,9 @@ namespace OpenApiTests.ResourceInheritance.OnlyConcrete;
 
 public sealed class OnlyConcreteInheritanceTests : ResourceInheritanceTests
 {
-    public OnlyConcreteInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext)
-        : base(testContext, true, false)
+    public OnlyConcreteInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
+        : base(testContext, testOutputHelper, true, false)
     {
         testContext.ConfigureServices(services =>
         {

--- a/test/OpenApiTests/ResourceInheritance/OnlyOperations/OnlyOperationsInheritanceTests.cs
+++ b/test/OpenApiTests/ResourceInheritance/OnlyOperations/OnlyOperationsInheritanceTests.cs
@@ -4,6 +4,7 @@ using JsonApiDotNetCore.Middleware;
 using Microsoft.Extensions.DependencyInjection;
 using OpenApiTests.ResourceInheritance.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 #pragma warning disable format
 
@@ -11,8 +12,9 @@ namespace OpenApiTests.ResourceInheritance.OnlyOperations;
 
 public sealed class OnlyOperationsInheritanceTests : ResourceInheritanceTests
 {
-    public OnlyOperationsInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext)
-        : base(testContext, true, false)
+    public OnlyOperationsInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
+        : base(testContext, testOutputHelper, true, false)
     {
         testContext.ConfigureServices(services =>
         {

--- a/test/OpenApiTests/ResourceInheritance/OnlyRelationships/OnlyRelationshipsInheritanceTests.cs
+++ b/test/OpenApiTests/ResourceInheritance/OnlyRelationships/OnlyRelationshipsInheritanceTests.cs
@@ -4,6 +4,7 @@ using JsonApiDotNetCore.Middleware;
 using Microsoft.Extensions.DependencyInjection;
 using OpenApiTests.ResourceInheritance.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 #pragma warning disable format
 
@@ -14,8 +15,9 @@ public sealed class OnlyRelationshipsInheritanceTests : ResourceInheritanceTests
     private const JsonApiEndpoints OnlyRelationshipEndpoints = JsonApiEndpoints.GetRelationship | JsonApiEndpoints.PostRelationship |
         JsonApiEndpoints.PatchRelationship | JsonApiEndpoints.DeleteRelationship;
 
-    public OnlyRelationshipsInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext)
-        : base(testContext, true, true)
+    public OnlyRelationshipsInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
+        : base(testContext, testOutputHelper, true, true)
     {
         testContext.ConfigureServices(services =>
         {

--- a/test/OpenApiTests/ResourceInheritance/ResourceInheritanceTests.cs
+++ b/test/OpenApiTests/ResourceInheritance/ResourceInheritanceTests.cs
@@ -6,6 +6,7 @@ using JsonApiDotNetCore.Controllers;
 using Microsoft.Extensions.DependencyInjection;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 #pragma warning disable AV1755 // Name of async method should end with Async or TaskAsync
 
@@ -16,11 +17,12 @@ public abstract class ResourceInheritanceTests : IClassFixture<OpenApiTestContex
     private readonly OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> _testContext;
 
     protected ResourceInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext,
-        bool hasOperationsController, bool writeToDisk)
+        ITestOutputHelper testOutputHelper, bool hasOperationsController, bool writeToDisk)
     {
         _testContext = testContext;
 
         testContext.UseInheritanceControllers(hasOperationsController);
+        testContext.SetTestOutputHelper(testOutputHelper);
 
         if (writeToDisk)
         {

--- a/test/OpenApiTests/ResourceInheritance/SubsetOfOperations/SubsetOfOperationsInheritanceTests.cs
+++ b/test/OpenApiTests/ResourceInheritance/SubsetOfOperations/SubsetOfOperationsInheritanceTests.cs
@@ -4,6 +4,7 @@ using JsonApiDotNetCore.Middleware;
 using Microsoft.Extensions.DependencyInjection;
 using OpenApiTests.ResourceInheritance.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 #pragma warning disable format
 
@@ -11,8 +12,9 @@ namespace OpenApiTests.ResourceInheritance.SubsetOfOperations;
 
 public sealed class SubsetOfOperationsInheritanceTests : ResourceInheritanceTests
 {
-    public SubsetOfOperationsInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext)
-        : base(testContext, true, true)
+    public SubsetOfOperationsInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
+        : base(testContext, testOutputHelper, true, true)
     {
         testContext.ConfigureServices(services =>
         {

--- a/test/OpenApiTests/ResourceInheritance/SubsetOfVarious/SubsetOfVariousInheritanceTests.cs
+++ b/test/OpenApiTests/ResourceInheritance/SubsetOfVarious/SubsetOfVariousInheritanceTests.cs
@@ -4,13 +4,15 @@ using JsonApiDotNetCore.Middleware;
 using Microsoft.Extensions.DependencyInjection;
 using OpenApiTests.ResourceInheritance.Models;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.ResourceInheritance.SubsetOfVarious;
 
 public sealed class SubsetOfVariousInheritanceTests : ResourceInheritanceTests
 {
-    public SubsetOfVariousInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext)
-        : base(testContext, false, true)
+    public SubsetOfVariousInheritanceTests(OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext> testContext,
+        ITestOutputHelper testOutputHelper)
+        : base(testContext, testOutputHelper, false, true)
     {
         testContext.ConfigureServices(services =>
         {

--- a/test/OpenApiTests/RestrictedControllers/RestrictionTests.cs
+++ b/test/OpenApiTests/RestrictedControllers/RestrictionTests.cs
@@ -5,6 +5,7 @@ using JsonApiDotNetCore.Controllers;
 using Microsoft.Extensions.DependencyInjection;
 using TestBuildingBlocks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenApiTests.RestrictedControllers;
 
@@ -12,7 +13,7 @@ public sealed class RestrictionTests : IClassFixture<OpenApiTestContext<OpenApiS
 {
     private readonly OpenApiTestContext<OpenApiStartup<RestrictionDbContext>, RestrictionDbContext> _testContext;
 
-    public RestrictionTests(OpenApiTestContext<OpenApiStartup<RestrictionDbContext>, RestrictionDbContext> testContext)
+    public RestrictionTests(OpenApiTestContext<OpenApiStartup<RestrictionDbContext>, RestrictionDbContext> testContext, ITestOutputHelper testOutputHelper)
     {
         _testContext = testContext;
 
@@ -22,6 +23,7 @@ public sealed class RestrictionTests : IClassFixture<OpenApiTestContext<OpenApiS
         testContext.UseController<RelationshipChannelsController>();
         testContext.UseController<ReadOnlyResourceChannelsController>();
 
+        testContext.SetTestOutputHelper(testOutputHelper);
         testContext.SwaggerDocumentOutputDirectory = $"{GetType().Namespace!.Replace('.', '/')}/GeneratedSwagger";
     }
 


### PR DESCRIPTION
Turned off by default, but is turned on in OpenApiTests.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated

Fixes #1626.
