### PR TITLE
Fix invalid expression for total count on inverse relationship filter from resource definition

### DIFF
--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/Constellation.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/Constellation.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
@@ -6,26 +7,15 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]
 [Resource(ControllerNamespace = "JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading")]
-public sealed class Star : Identifiable<int>
+public sealed class Constellation : Identifiable<int>
 {
     [Attr]
     public string Name { get; set; } = null!;
 
     [Attr]
-    public StarKind Kind { get; set; }
-
-    [Attr]
-    public decimal SolarRadius { get; set; }
-
-    [Attr]
-    public decimal SolarMass { get; set; }
-
-    [Attr]
-    public bool IsVisibleFromEarth { get; set; }
+    [Required]
+    public Season? VisibleDuring { get; set; }
 
     [HasMany]
-    public ISet<Planet> Planets { get; set; } = new HashSet<Planet>();
-
-    [HasMany]
-    public ISet<Constellation> IsPartOf { get; set; } = new HashSet<Constellation>();
+    public ISet<Star> Stars { get; set; } = new HashSet<Star>();
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ConstellationDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ConstellationDefinition.cs
@@ -1,11 +1,33 @@
 using JetBrains.Annotations;
 using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Queries.Expressions;
+using JsonApiDotNetCore.Resources.Annotations;
 
 namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading;
 
 [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-public sealed class ConstellationDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter)
-    : HitCountingResourceDefinition<Moon, int>(resourceGraph, hitCounter)
+public sealed class ConstellationDefinition(
+    IResourceGraph resourceGraph, IClientSettingsProvider clientSettingsProvider, ResourceDefinitionHitCounter hitCounter)
+    : HitCountingResourceDefinition<Constellation, int>(resourceGraph, hitCounter)
 {
+    private readonly IClientSettingsProvider _clientSettingsProvider = clientSettingsProvider;
+
     protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.Reading;
+
+    public override FilterExpression? OnApplyFilter(FilterExpression? existingFilter)
+    {
+        FilterExpression? baseFilter = base.OnApplyFilter(existingFilter);
+
+        if (_clientSettingsProvider.AreConstellationsVisibleDuringWinterHidden)
+        {
+            AttrAttribute visibleDuringAttribute = ResourceType.GetAttributeByPropertyName(nameof(Constellation.VisibleDuring));
+            var visibleDuringChain = new ResourceFieldChainExpression(visibleDuringAttribute);
+            var visibleDuringComparison = new ComparisonExpression(ComparisonOperator.Equals, visibleDuringChain, new LiteralConstantExpression(Season.Winter));
+            var notVisibleDuringComparison = new NotExpression(visibleDuringComparison);
+
+            return LogicalExpression.Compose(LogicalOperator.And, baseFilter, notVisibleDuringComparison);
+        }
+
+        return baseFilter;
+    }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ConstellationDefinition.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ConstellationDefinition.cs
@@ -1,0 +1,11 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Configuration;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading;
+
+[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+public sealed class ConstellationDefinition(IResourceGraph resourceGraph, ResourceDefinitionHitCounter hitCounter)
+    : HitCountingResourceDefinition<Moon, int>(resourceGraph, hitCounter)
+{
+    protected override ResourceDefinitionExtensibilityPoints ExtensibilityPointsToTrack => ResourceDefinitionExtensibilityPoints.Reading;
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/IClientSettingsProvider.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/IClientSettingsProvider.cs
@@ -2,6 +2,8 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading;
 
 public interface IClientSettingsProvider
 {
+    bool AreVeryLargeStarsHidden { get; }
+    bool AreConstellationsVisibleDuringWinterHidden { get; }
     bool IsIncludePlanetMoonsBlocked { get; }
     bool ArePlanetsWithPrivateNameHidden { get; }
     bool IsStarGivingLightToMoonAutoIncluded { get; }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ResourceDefinitionReadTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ResourceDefinitionReadTests.cs
@@ -23,6 +23,7 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         testContext.ConfigureServices(services =>
         {
+            services.AddResourceDefinition<ConstellationDefinition>();
             services.AddResourceDefinition<StarDefinition>();
             services.AddResourceDefinition<PlanetDefinition>();
             services.AddResourceDefinition<MoonDefinition>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ResourceDefinitionReadTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ResourceDefinitionReadTests.cs
@@ -324,7 +324,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            await dbContext.ClearTableAsync<Planet>();
             dbContext.Stars.Add(star);
             await dbContext.SaveChangesAsync();
         });
@@ -376,7 +375,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            await dbContext.ClearTableAsync<Planet>();
             dbContext.Stars.Add(star);
             await dbContext.SaveChangesAsync();
         });

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/Season.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/Season.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+
+namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+public enum Season
+{
+    Winter,
+    Spring,
+    Summer,
+    Fall
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/TestClientSettingsProvider.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/TestClientSettingsProvider.cs
@@ -2,15 +2,29 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading;
 
 internal sealed class TestClientSettingsProvider : IClientSettingsProvider
 {
+    public bool AreVeryLargeStarsHidden { get; private set; }
+    public bool AreConstellationsVisibleDuringWinterHidden { get; private set; }
     public bool IsIncludePlanetMoonsBlocked { get; private set; }
     public bool ArePlanetsWithPrivateNameHidden { get; private set; }
     public bool IsStarGivingLightToMoonAutoIncluded { get; private set; }
 
     public void ResetToDefaults()
     {
+        AreVeryLargeStarsHidden = false;
+        AreConstellationsVisibleDuringWinterHidden = false;
         IsIncludePlanetMoonsBlocked = false;
         ArePlanetsWithPrivateNameHidden = false;
         IsStarGivingLightToMoonAutoIncluded = false;
+    }
+
+    public void HideVeryLargeStars()
+    {
+        AreVeryLargeStarsHidden = true;
+    }
+
+    public void HideConstellationsVisibleDuringWinter()
+    {
+        AreConstellationsVisibleDuringWinterHidden = true;
     }
 
     public void BlockIncludePlanetMoons()

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/UniverseDbContext.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/UniverseDbContext.cs
@@ -8,6 +8,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading;
 public sealed class UniverseDbContext(DbContextOptions<UniverseDbContext> options)
     : TestableDbContext(options)
 {
+    public DbSet<Constellation> Constellations => Set<Constellation>();
     public DbSet<Star> Stars => Set<Star>();
     public DbSet<Planet> Planets => Set<Planet>();
     public DbSet<Moon> Moons => Set<Moon>();

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/UniverseFakers.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/UniverseFakers.cs
@@ -8,6 +8,11 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ResourceDefinitions.Reading;
 
 internal sealed class UniverseFakers
 {
+    private readonly Lazy<Faker<Constellation>> _lazyConstellationFaker = new(() => new Faker<Constellation>()
+        .MakeDeterministic()
+        .RuleFor(constellation => constellation.Name, faker => faker.Random.Word())
+        .RuleFor(constellation => constellation.VisibleDuring, faker => faker.PickRandom<Season>()));
+
     private readonly Lazy<Faker<Star>> _lazyStarFaker = new(() => new Faker<Star>()
         .MakeDeterministic()
         .RuleFor(star => star.Name, faker => faker.Random.Word())
@@ -27,6 +32,7 @@ internal sealed class UniverseFakers
         .RuleFor(moon => moon.Name, faker => faker.Random.Word())
         .RuleFor(moon => moon.SolarRadius, faker => faker.Random.Decimal(.01M, 1000M)));
 
+    public Faker<Constellation> Constellation => _lazyConstellationFaker.Value;
     public Faker<Star> Star => _lazyStarFaker.Value;
     public Faker<Planet> Planet => _lazyPlanetFaker.Value;
     public Faker<Moon> Moon => _lazyMoonFaker.Value;


### PR DESCRIPTION
When the total count on a secondary/relationship endpoint is queried, and the primary filter originates from `IResourceDefinition.OnApplyFilter`, the resulting expression is invalid. Since we're using the inverse relationship here, for many-to-many the solution is to move to the proper scope. For many-to-one endpoints, we cannot solve this, so do not return a total instead of crashing.

Fixes #1671.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
