### PR TITLE
Improve detection of collection element type

### DIFF
--- a/src/JsonApiDotNetCore.Annotations/CollectionConverter.cs
+++ b/src/JsonApiDotNetCore.Annotations/CollectionConverter.cs
@@ -104,15 +104,24 @@ internal sealed class CollectionConverter
     /// </summary>
     public Type? FindCollectionElementType(Type? type)
     {
-        if (type is { IsGenericType: true, GenericTypeArguments.Length: 1 })
+        if (type != null)
         {
-            if (type.IsOrImplementsInterface<IEnumerable>())
+            Type? enumerableClosedType = IsEnumerableClosedType(type) ? type : null;
+            enumerableClosedType ??= type.GetInterfaces().FirstOrDefault(IsEnumerableClosedType);
+
+            if (enumerableClosedType != null)
             {
-                return type.GenericTypeArguments[0];
+                return enumerableClosedType.GenericTypeArguments[0];
             }
         }
 
         return null;
+    }
+
+    private static bool IsEnumerableClosedType(Type type)
+    {
+        bool isClosedType = type is { IsGenericType: true, ContainsGenericParameters: false };
+        return isClosedType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>);
     }
 
     /// <summary>

--- a/src/JsonApiDotNetCore/Configuration/ResourceGraphBuilder.cs
+++ b/src/JsonApiDotNetCore/Configuration/ResourceGraphBuilder.cs
@@ -396,8 +396,8 @@ public partial class ResourceGraphBuilder
                 continue;
             }
 
-            Type innerType = TypeOrElementType(property.PropertyType);
-            eagerLoad.Children = GetEagerLoads(innerType, recursionDepth + 1);
+            Type rightType = CollectionConverter.Instance.FindCollectionElementType(property.PropertyType) ?? property.PropertyType;
+            eagerLoad.Children = GetEagerLoads(rightType, recursionDepth + 1);
             eagerLoad.Property = property;
 
             eagerLoads.Add(eagerLoad);
@@ -457,14 +457,6 @@ public partial class ResourceGraphBuilder
         {
             throw new InvalidOperationException("Infinite recursion detected in eager-load chain.");
         }
-    }
-
-    private Type TypeOrElementType(Type type)
-    {
-        Type[] interfaces = type.GetInterfaces().Where(@interface => @interface.IsGenericType && @interface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
-            .ToArray();
-
-        return interfaces.Length == 1 ? interfaces.Single().GenericTypeArguments[0] : type;
     }
 
     private string FormatResourceName(Type resourceClrType)

--- a/test/JsonApiDotNetCoreTests/UnitTests/TypeConversion/CollectionConverterTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/TypeConversion/CollectionConverterTests.cs
@@ -1,0 +1,104 @@
+using FluentAssertions;
+using JsonApiDotNetCore;
+using Xunit;
+
+namespace JsonApiDotNetCoreTests.UnitTests.TypeConversion;
+
+public sealed class CollectionConverterTests
+{
+    [Fact]
+    public void Finds_element_type_for_generic_list()
+    {
+        // Arrange
+        Type sourceType = typeof(List<string>);
+
+        // Act
+        Type? elementType = CollectionConverter.Instance.FindCollectionElementType(sourceType);
+
+        // Assert
+        elementType.Should().Be<string>();
+    }
+
+    [Fact]
+    public void Finds_element_type_for_generic_enumerable()
+    {
+        // Arrange
+        Type sourceType = typeof(IEnumerable<string>);
+
+        // Act
+        Type? elementType = CollectionConverter.Instance.FindCollectionElementType(sourceType);
+
+        // Assert
+        elementType.Should().Be<string>();
+    }
+
+    [Fact]
+    public void Finds_element_type_for_custom_generic_collection_with_multiple_type_parameters()
+    {
+        // Arrange
+        Type sourceType = typeof(CustomCollection<int, string>);
+
+        // Act
+        Type? elementType = CollectionConverter.Instance.FindCollectionElementType(sourceType);
+
+        // Assert
+        elementType.Should().Be<string>();
+    }
+
+    [Fact]
+    public void Finds_element_type_for_custom_non_generic_collection()
+    {
+        // Arrange
+        Type sourceType = typeof(CustomCollectionOfIntString);
+
+        // Act
+        Type? elementType = CollectionConverter.Instance.FindCollectionElementType(sourceType);
+
+        // Assert
+        elementType.Should().Be<string>();
+    }
+
+    [Fact]
+    public void Finds_no_element_type_for_non_generic_type()
+    {
+        // Arrange
+        Type sourceType = typeof(int);
+
+        // Act
+        Type? elementType = CollectionConverter.Instance.FindCollectionElementType(sourceType);
+
+        // Assert
+        elementType.Should().BeNull();
+    }
+
+    [Fact]
+    public void Finds_no_element_type_for_non_collection_generic_type()
+    {
+        // Arrange
+        Type sourceType = typeof(Tuple<int, string>);
+
+        // Act
+        Type? elementType = CollectionConverter.Instance.FindCollectionElementType(sourceType);
+
+        // Assert
+        elementType.Should().BeNull();
+    }
+
+    [Fact]
+    public void Finds_no_element_type_for_unbound_generic_type()
+    {
+        // Arrange
+        Type sourceType = typeof(List<>);
+
+        // Act
+        Type? elementType = CollectionConverter.Instance.FindCollectionElementType(sourceType);
+
+        // Assert
+        elementType.Should().BeNull();
+    }
+
+    // ReSharper disable once UnusedTypeParameter
+    private class CustomCollection<TOther, TElement> : List<TElement>;
+
+    private sealed class CustomCollectionOfIntString : CustomCollection<int, string>;
+}


### PR DESCRIPTION
With this PR, the collection element type for custom collection types that have no or multiple type parameters is now correctly detected.

JADNC v5.7.0 added internal assertions on the `IQueryable<T>` element type `T` to make it easier to track errors/bugs. It uses `CollectionConverter.FindCollectionElementType` to determine the element type, but that works only with types that have exactly one generic type parameter. MongoDB uses an internal type `MongoQuery<TDocument, TOutput> : IQueryable<TOutput>`, which causes assertion failures. This PR fixes that by properly walking up the interface hierarchy to infer that `TOutput` is the element type.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
