### PR TITLE
Fixed: build error after adding reference to JADNC.Kiota package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)tests.runsettings</RunSettingsFilePath>
     <VersionPrefix>5.7.1</VersionPrefix>
     <VersionSuffix>pre</VersionSuffix>
-    <OpenApiPreviewNumber>1</OpenApiPreviewNumber>
+    <OpenApiPreviewNumber>2</OpenApiPreviewNumber>
     <NuGetAuditMode>direct</NuGetAuditMode>
   </PropertyGroup>
 

--- a/src/JsonApiDotNetCore.OpenApi.Client.Kiota/Build/JsonApiDotNetCore.OpenApi.Client.Kiota.targets
+++ b/src/JsonApiDotNetCore.OpenApi.Client.Kiota/Build/JsonApiDotNetCore.OpenApi.Client.Kiota.targets
@@ -149,8 +149,8 @@
   </Target>
 
   <!-- Include **/*.cs from output directory afterward, so that MSBuild properly refreshes if .cs files appear/disappear when openapi.json file changed -->
-  <Target Name="_KiotaIncludeGeneratedCode" Condition="'$(DesignTimeBuild)' != 'true' And '$(BuildingProject)' == 'true'" DependsOnTargets="_KiotaRunTool"
-    BeforeTargets="BeforeCompile;CoreCompile">
+  <Target Name="_KiotaIncludeGeneratedCode" Condition="'$(DesignTimeBuild)' != 'true' And '$(BuildingProject)' == 'true' And '@(KiotaReference)' != ''"
+    DependsOnTargets="_KiotaRunTool" BeforeTargets="BeforeCompile;CoreCompile">
     <ItemGroup>
       <_WildcardGroup Include="%2A%2A/%2A.cs">
         <GeneratedCodeDirectory>%(KiotaReference._NonEmptyOutputPath)</GeneratedCodeDirectory>


### PR DESCRIPTION
Fixed: build error after adding reference to `JsonApiDotNetCore.OpenApi.Client.Kiota` package, without any Kiota references in the project file yet.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
