### PR TITLE
Log QueryLayer and Expression at Debug level

### DIFF
--- a/package-versions.props
+++ b/package-versions.props
@@ -22,6 +22,7 @@
     <MicrosoftApiServerVersion>9.0.*</MicrosoftApiServerVersion>
     <NSwagApiClientVersion>14.4.*</NSwagApiClientVersion>
     <NewtonsoftJsonVersion>13.0.*</NewtonsoftJsonVersion>
+    <ReadableExpressionsVersion>4.1.*</ReadableExpressionsVersion>
     <ScalarAspNetCoreVersion>2.3.*</ScalarAspNetCoreVersion>
     <SwashbuckleVersion>8.*-*</SwashbuckleVersion>
     <SystemTextJsonVersion>9.0.*</SystemTextJsonVersion>

--- a/src/JsonApiDotNetCore/Queries/QueryableBuilding/ExpressionTreeFormatter.cs
+++ b/src/JsonApiDotNetCore/Queries/QueryableBuilding/ExpressionTreeFormatter.cs
@@ -1,0 +1,53 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace JsonApiDotNetCore.Queries.QueryableBuilding;
+
+/// <summary>
+/// Converts a <see cref="Expression" /> to readable text, if the AgileObjects.ReadableExpressions NuGet package is referenced.
+/// </summary>
+internal sealed class ExpressionTreeFormatter
+{
+    private static readonly Lazy<MethodInvoker?> LazyToReadableStringMethod = new(GetToReadableStringMethod, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public static ExpressionTreeFormatter Instance { get; } = new();
+
+    private ExpressionTreeFormatter()
+    {
+    }
+
+    private static MethodInvoker? GetToReadableStringMethod()
+    {
+        Assembly? assembly = TryLoadAssembly();
+        Type? type = assembly?.GetType("AgileObjects.ReadableExpressions.ExpressionExtensions", false);
+        MethodInfo? method = type?.GetMethods(BindingFlags.Public | BindingFlags.Static).FirstOrDefault(method => method.Name == "ToReadableString");
+        return method != null ? MethodInvoker.Create(method) : null;
+    }
+
+    private static Assembly? TryLoadAssembly()
+    {
+        try
+        {
+            return Assembly.Load("AgileObjects.ReadableExpressions");
+        }
+        catch (Exception exception) when (exception is ArgumentException or IOException or BadImageFormatException)
+        {
+        }
+
+        return null;
+    }
+
+    public string? GetText(Expression expression)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+
+        try
+        {
+            return LazyToReadableStringMethod.Value?.Invoke(null, expression, null) as string;
+        }
+        catch (Exception exception) when (exception is TargetException or InvalidOperationException or TargetParameterCountException or NotSupportedException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
+++ b/src/JsonApiDotNetCore/Repositories/EntityFrameworkCoreRepository.cs
@@ -122,6 +122,8 @@ public class EntityFrameworkCoreRepository<TResource, TId> : IResourceRepository
 
         ArgumentNullException.ThrowIfNull(queryLayer);
 
+        _traceWriter.LogDebug(queryLayer);
+
         using (CodeTimingSessionManager.Current.Measure("Convert QueryLayer to System.Expression"))
         {
             IQueryable<TResource> source = GetAll();
@@ -150,6 +152,8 @@ public class EntityFrameworkCoreRepository<TResource, TId> : IResourceRepository
 
             var context = QueryableBuilderContext.CreateRoot(source, typeof(Queryable), _dbContext.Model, null);
             Expression expression = builder.ApplyQuery(queryLayer, context);
+
+            _traceWriter.LogDebug(expression);
 
             using (CodeTimingSessionManager.Current.Measure("Convert System.Expression to IQueryable"))
             {

--- a/test/DiscoveryTests/DiscoveryTests.csproj
+++ b/test/DiscoveryTests/DiscoveryTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
@@ -15,5 +15,6 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="$(GitHubActionsTestLoggerVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Condition="'$(TargetFramework)' != 'net8.0'" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EntityFrameworkCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/test/DiscoveryTests/LoggingTests.cs
+++ b/test/DiscoveryTests/LoggingTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Queries;
+using JsonApiDotNetCore.Repositories;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using TestBuildingBlocks;
+using Xunit;
+
+namespace DiscoveryTests;
+
+public sealed class LoggingTests
+{
+    [Fact]
+    public async Task Logs_message_to_add_NuGet_reference()
+    {
+        // Arrange
+        using var loggerProvider =
+            new CapturingLoggerProvider((category, _) => category.StartsWith("JsonApiDotNetCore.Repositories", StringComparison.Ordinal));
+
+        WebApplicationBuilder builder = WebApplication.CreateEmptyBuilder(new WebApplicationOptions());
+        builder.Logging.AddProvider(loggerProvider);
+        builder.Logging.SetMinimumLevel(LogLevel.Debug);
+        builder.Services.AddDbContext<TestDbContext>(options => options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        builder.Services.AddJsonApi<TestDbContext>();
+        builder.WebHost.UseTestServer();
+        await using WebApplication app = builder.Build();
+
+        var resourceGraph = app.Services.GetRequiredService<IResourceGraph>();
+        ResourceType resourceType = resourceGraph.GetResourceType<PrivateResource>();
+
+        var repository = app.Services.GetRequiredService<IResourceRepository<PrivateResource, int>>();
+
+        // Act
+        _ = await repository.GetAsync(new QueryLayer(resourceType), CancellationToken.None);
+
+        // Assert
+        IReadOnlyList<string> logLines = loggerProvider.GetLines();
+
+        logLines.Should().Contain(
+            "[DEBUG] Failed to load assembly. To log expression trees, add a NuGet reference to 'AgileObjects.ReadableExpressions' in your project.");
+    }
+
+    private sealed class TestDbContext(DbContextOptions options)
+        : DbContext(options)
+    {
+        public DbSet<PrivateResource> PrivateResources => Set<PrivateResource>();
+    }
+}

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicTraceLoggingTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/AtomicOperations/Mixed/AtomicTraceLoggingTests.cs
@@ -22,7 +22,7 @@ public sealed class AtomicTraceLoggingTests : IClassFixture<IntegrationTestConte
         testContext.ConfigureLogging(options =>
         {
             var loggerProvider = new CapturingLoggerProvider((category, level) =>
-                level >= LogLevel.Trace && category.StartsWith("JsonApiDotNetCore.", StringComparison.Ordinal));
+                level == LogLevel.Trace && category.StartsWith("JsonApiDotNetCore.", StringComparison.Ordinal));
 
             options.AddProvider(loggerProvider);
             options.SetMinimumLevel(LogLevel.Trace);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Logging/Fruit.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Logging/Fruit.cs
@@ -10,4 +10,7 @@ public abstract class Fruit : Identifiable<long>
 {
     [Attr]
     public abstract string Color { get; }
+
+    [Attr]
+    public double WeightInKilograms { get; set; }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/Logging/LoggingFakers.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/Logging/LoggingFakers.cs
@@ -15,10 +15,12 @@ internal sealed class LoggingFakers
 
     private readonly Lazy<Faker<Banana>> _lazyBananaFaker = new(() => new Faker<Banana>()
         .MakeDeterministic()
+        .RuleFor(banana => banana.WeightInKilograms, faker => faker.Random.Double(.2, .3))
         .RuleFor(banana => banana.LengthInCentimeters, faker => faker.Random.Double(10, 25)));
 
     private readonly Lazy<Faker<Peach>> _lazyPeachFaker = new(() => new Faker<Peach>()
         .MakeDeterministic()
+        .RuleFor(peach => peach.WeightInKilograms, faker => faker.Random.Double(.2, .3))
         .RuleFor(peach => peach.DiameterInCentimeters, faker => faker.Random.Double(6, 7.5)));
 
     public Faker<AuditEntry> AuditEntry => _lazyAuditEntryFaker.Value;

--- a/test/JsonApiDotNetCoreTests/JsonApiDotNetCoreTests.csproj
+++ b/test/JsonApiDotNetCoreTests/JsonApiDotNetCoreTests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AgileObjects.ReadableExpressions" Version="$(ReadableExpressionsVersion)" />
     <PackageReference Include="coverlet.collector" Version="$(CoverletVersion)" PrivateAssets="All" />
     <PackageReference Include="GitHubActionsTestLogger" Version="$(GitHubActionsTestLoggerVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />


### PR DESCRIPTION
The LINQ expression is logged using the `AgileObjects.ReadableExpressions` NuGet package. This is a light-up dependency, so it needs to be added explicitly to your project.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
