### PR TITLE
Reduce complexity of QueryLayer after composition

### DIFF
--- a/src/JsonApiDotNetCore/Queries/QueryLayer.cs
+++ b/src/JsonApiDotNetCore/Queries/QueryLayer.cs
@@ -11,6 +11,8 @@ namespace JsonApiDotNetCore.Queries;
 [PublicAPI]
 public sealed class QueryLayer
 {
+    internal bool IsEmpty => Filter == null && Sort == null && Pagination?.PageSize == null && (Selection == null || Selection.IsEmpty);
+
     public ResourceType ResourceType { get; }
 
     public IncludeExpression? Include { get; set; }

--- a/test/DapperTests/IntegrationTests/QueryStrings/FilterTests.cs
+++ b/test/DapperTests/IntegrationTests/QueryStrings/FilterTests.cs
@@ -78,7 +78,6 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
                 FROM "Tags" AS t1
                 LEFT JOIN "RgbColors" AS t2 ON t1."Id" = t2."TagId"
                 WHERE t2."Id" = @p1
-                ORDER BY t1."Id"
                 """));
 
             command.Parameters.Should().HaveCount(1);
@@ -144,7 +143,6 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
                 FROM "Tags" AS t1
                 LEFT JOIN "RgbColors" AS t2 ON t1."Id" = t2."TagId"
                 WHERE t2."Id" IN (@p1, @p2)
-                ORDER BY t1."Id"
                 """));
 
             command.Parameters.Should().HaveCount(2);
@@ -662,7 +660,6 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
                 SELECT t1."Id", t1."FirstName", t1."LastName"
                 FROM "People" AS t1
                 WHERE (NOT (t1."FirstName" = @p1)) OR (t1."FirstName" IS NULL)
-                ORDER BY t1."Id"
                 """));
 
             command.Parameters.Should().HaveCount(1);
@@ -867,7 +864,6 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
                 SELECT t1."Id", t1."Name"
                 FROM "Tags" AS t1
                 WHERE (t1."Name" LIKE '%A\%%' ESCAPE '\') OR (t1."Name" LIKE '%A\_%' ESCAPE '\') OR (t1."Name" LIKE '%A\\%' ESCAPE '\') OR (t1."Name" LIKE '%A''%') OR (t1."Name" LIKE '%\%\_\\''%' ESCAPE '\')
-                ORDER BY t1."Id"
                 """));
 
             command.Parameters.Should().BeEmpty();
@@ -1177,7 +1173,6 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
                     LEFT JOIN "People" AS t3 ON t2."AssigneeId" = t3."Id"
                     WHERE (t1."Id" = t2."OwnerId") AND (NOT (t3."Id" IS NULL)) AND (t3."FirstName" IS NULL)
                 )
-                ORDER BY t1."Id"
                 """));
 
             command.Parameters.Should().BeEmpty();

--- a/test/DapperTests/IntegrationTests/QueryStrings/IncludeTests.cs
+++ b/test/DapperTests/IntegrationTests/QueryStrings/IncludeTests.cs
@@ -165,7 +165,7 @@ public sealed class IncludeTests : IClassFixture<DapperTestContext>
                 INNER JOIN "People" AS t3 ON t1."OwnerId" = t3."Id"
                 LEFT JOIN "TodoItems" AS t4 ON t3."Id" = t4."AssigneeId"
                 LEFT JOIN "Tags" AS t5 ON t1."Id" = t5."TodoItemId"
-                ORDER BY t1."Priority", t1."LastModifiedAt" DESC, t4."Priority", t4."LastModifiedAt" DESC, t5."Id"
+                ORDER BY t1."Priority", t1."LastModifiedAt" DESC, t4."Priority", t4."LastModifiedAt" DESC
                 """));
 
             command.Parameters.Should().BeEmpty();
@@ -231,7 +231,7 @@ public sealed class IncludeTests : IClassFixture<DapperTestContext>
                 FROM "TodoItems" AS t1
                 LEFT JOIN "Tags" AS t2 ON t1."Id" = t2."TodoItemId"
                 LEFT JOIN "RgbColors" AS t3 ON t2."Id" = t3."TagId"
-                ORDER BY t1."Priority", t1."LastModifiedAt" DESC, t2."Id"
+                ORDER BY t1."Priority", t1."LastModifiedAt" DESC
                 """));
 
             command.Parameters.Should().BeEmpty();

--- a/test/DapperTests/IntegrationTests/QueryStrings/SortTests.cs
+++ b/test/DapperTests/IntegrationTests/QueryStrings/SortTests.cs
@@ -349,7 +349,7 @@ public sealed class SortTests : IClassFixture<DapperTestContext>
                     SELECT COUNT(*)
                     FROM "Tags" AS t3
                     WHERE t2."Id" = t3."TodoItemId"
-                ) DESC, t2."Id", t4."Id"
+                ) DESC, t2."Id"
                 """));
 
             command.Parameters.Should().HaveCount(1);
@@ -415,7 +415,7 @@ public sealed class SortTests : IClassFixture<DapperTestContext>
                 SELECT t1."Id", t1."FirstName", t1."LastName", t2."Id", t2."CreatedAt", t2."Description", t2."DurationInHours", t2."LastModifiedAt", t2."Priority"
                 FROM "People" AS t1
                 LEFT JOIN "TodoItems" AS t2 ON t1."Id" = t2."OwnerId"
-                ORDER BY t1."Id", (
+                ORDER BY (
                     SELECT COUNT(*)
                     FROM "Tags" AS t3
                     WHERE t2."Id" = t3."TodoItemId"

--- a/test/DapperTests/IntegrationTests/QueryStrings/SparseFieldSets.cs
+++ b/test/DapperTests/IntegrationTests/QueryStrings/SparseFieldSets.cs
@@ -215,7 +215,6 @@ public sealed class SparseFieldSets : IClassFixture<DapperTestContext>
                 FROM "TodoItems" AS t1
                 LEFT JOIN "Tags" AS t2 ON t1."Id" = t2."TodoItemId"
                 WHERE t1."Id" = @p1
-                ORDER BY t2."Id"
                 """));
 
             command.Parameters.Should().HaveCount(1);
@@ -400,7 +399,6 @@ public sealed class SparseFieldSets : IClassFixture<DapperTestContext>
                 FROM "TodoItems" AS t1
                 LEFT JOIN "Tags" AS t2 ON t1."Id" = t2."TodoItemId"
                 WHERE t1."Id" = @p1
-                ORDER BY t2."Id"
                 """));
 
             command.Parameters.Should().HaveCount(1);

--- a/test/DapperTests/IntegrationTests/ReadWrite/Relationships/FetchRelationshipTests.cs
+++ b/test/DapperTests/IntegrationTests/ReadWrite/Relationships/FetchRelationshipTests.cs
@@ -168,7 +168,6 @@ public sealed class FetchRelationshipTests : IClassFixture<DapperTestContext>
                 FROM "TodoItems" AS t1
                 LEFT JOIN "Tags" AS t2 ON t1."Id" = t2."TodoItemId"
                 WHERE t1."Id" = @p1
-                ORDER BY t2."Id"
                 """));
 
             command.Parameters.Should().HaveCount(1);

--- a/test/DapperTests/IntegrationTests/ReadWrite/Resources/FetchResourceTests.cs
+++ b/test/DapperTests/IntegrationTests/ReadWrite/Resources/FetchResourceTests.cs
@@ -246,7 +246,6 @@ public sealed class FetchResourceTests : IClassFixture<DapperTestContext>
                 FROM "TodoItems" AS t1
                 LEFT JOIN "Tags" AS t2 ON t1."Id" = t2."TodoItemId"
                 WHERE t1."Id" = @p1
-                ORDER BY t2."Id"
                 """));
 
             command.Parameters.Should().HaveCount(1);

--- a/test/DapperTests/IntegrationTests/Sql/SubQueryInJoinTests.cs
+++ b/test/DapperTests/IntegrationTests/Sql/SubQueryInJoinTests.cs
@@ -62,7 +62,6 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
                 SELECT t1."Id", t1."FirstName", t1."LastName", t2."Id", t2."LastUsedAt", t2."UserName"
                 FROM "People" AS t1
                 LEFT JOIN "LoginAccounts" AS t2 ON t1."AccountId" = t2."Id"
-                ORDER BY t1."Id"
                 """));
 
             command.Parameters.Should().BeEmpty();
@@ -111,7 +110,7 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
                 SELECT t1."Id", t1."FirstName", t1."LastName", t2."Id", t2."CreatedAt", t2."Description", t2."DurationInHours", t2."LastModifiedAt", t2."Priority"
                 FROM "People" AS t1
                 LEFT JOIN "TodoItems" AS t2 ON t1."Id" = t2."OwnerId"
-                ORDER BY t1."Id", t2."Priority", t2."LastModifiedAt" DESC
+                ORDER BY t2."Priority", t2."LastModifiedAt" DESC
                 """));
 
             command.Parameters.Should().BeEmpty();
@@ -160,7 +159,7 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
                 SELECT t1."Id", t1."FirstName", t1."LastName", t2."Id", t2."CreatedAt", t2."Description", t2."DurationInHours", t2."LastModifiedAt", t2."Priority"
                 FROM "People" AS t1
                 LEFT JOIN "TodoItems" AS t2 ON t1."Id" = t2."OwnerId"
-                ORDER BY t1."Id", t2."Description"
+                ORDER BY t2."Description"
                 """));
 
             command.Parameters.Should().BeEmpty();
@@ -209,7 +208,7 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
                 SELECT t1."Id", t1."FirstName", t1."LastName", t2."Id", t2."CreatedAt", t2."Description", t2."DurationInHours", t2."LastModifiedAt", t2."Priority"
                 FROM "People" AS t1
                 LEFT JOIN "TodoItems" AS t2 ON t1."Id" = t2."OwnerId"
-                ORDER BY t1."Id", (
+                ORDER BY (
                     SELECT COUNT(*)
                     FROM "Tags" AS t3
                     WHERE t2."Id" = t3."TodoItemId"
@@ -263,7 +262,7 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
                 FROM "People" AS t1
                 LEFT JOIN "TodoItems" AS t2 ON t1."Id" = t2."OwnerId"
                 LEFT JOIN "Tags" AS t4 ON t2."Id" = t4."TodoItemId"
-                ORDER BY t1."Id", (
+                ORDER BY (
                     SELECT COUNT(*)
                     FROM "Tags" AS t3
                     WHERE t2."Id" = t3."TodoItemId"
@@ -326,11 +325,11 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
                     SELECT COUNT(*)
                     FROM "Tags" AS t4
                     WHERE t3."Id" = t4."TodoItemId"
-                ), t5."Id", (
+                ), (
                     SELECT COUNT(*)
                     FROM "Tags" AS t7
                     WHERE t6."Id" = t7."TodoItemId"
-                ), t8."Id"
+                )
                 """));
 
             command.Parameters.Should().BeEmpty();
@@ -383,7 +382,7 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
                     FROM "TodoItems" AS t2
                     WHERE t2."Description" = @p1
                 ) AS t3 ON t1."Id" = t3."OwnerId"
-                ORDER BY t1."Id", t3."Priority", t3."LastModifiedAt" DESC
+                ORDER BY t3."Priority", t3."LastModifiedAt" DESC
                 """));
 
             command.Parameters.Should().HaveCount(1);
@@ -441,7 +440,7 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
                         WHERE t2."Id" = t3."TodoItemId"
                     )
                 ) AS t4 ON t1."Id" = t4."OwnerId"
-                ORDER BY t1."Id", t4."Priority", t4."LastModifiedAt" DESC
+                ORDER BY t4."Priority", t4."LastModifiedAt" DESC
                 """));
 
             command.Parameters.Should().BeEmpty();
@@ -498,7 +497,7 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
                         WHERE t2."Id" = t3."TodoItemId"
                     ) > @p1
                 ) AS t4 ON t1."Id" = t4."OwnerId"
-                ORDER BY t1."Id", t4."Priority", t4."LastModifiedAt" DESC
+                ORDER BY t4."Priority", t4."LastModifiedAt" DESC
                 """));
 
             command.Parameters.Should().HaveCount(1);
@@ -554,7 +553,7 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
                     LEFT JOIN "Tags" AS t4 ON t2."Id" = t4."TodoItemId"
                     WHERE t2."Description" = @p1
                 ) AS t5 ON t1."Id" = t5."OwnerId"
-                ORDER BY t1."Id", (
+                ORDER BY (
                     SELECT COUNT(*)
                     FROM "Tags" AS t3
                     WHERE t5."Id" = t3."TodoItemId"
@@ -620,7 +619,7 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
                     ) AS t6 ON t2."Id" = t6."TodoItemId"
                     WHERE NOT (t2."Description" = @p1)
                 ) AS t7 ON t1."Id" = t7."OwnerId"
-                ORDER BY t1."Id", (
+                ORDER BY (
                     SELECT COUNT(*)
                     FROM "Tags" AS t3
                     WHERE t7."Id" = t3."TodoItemId"


### PR DESCRIPTION
Attempts to address the slow query performance reported in #1731.

The reported issue involves a type hierarchy that includes two nested includes for each type in the hierarchy. The number of rows in the type hierarchy is high (various kinds of products), whereas the two nested includes (unit group and unit) are small. Because pagination is applied at every level by default, the SQL query becomes very complex. This can be fixed by disabling pagination in the two nested includes via resource definitions.

This PR simplifies the query using the following changes:
- If pagination is turned off at some depth in the inclusion chain, do not add sort-by-ID at that depth when no sorting is provided.
- If filter/sort/page/fields is not specified at some depth in the inclusion chain, remove the explicit selector that selects everything.

This reduces the query for `/PriceGroup?include=products.unitGroup.units` from:
```c#
Expression tree: [Microsoft.EntityFrameworkCore.Query.EntityQueryRootExpression]
    .AsNoTrackingWithIdentityResolution()
    .Include("Products.UnitGroup.Units")
    .OrderBy(priceGroup => priceGroup.Id)
    .Take(value)
    .Select(
        priceGroup => new PriceGroup
        {
            Id = priceGroup.Id,
            CreatedAt = priceGroup.CreatedAt,
            CreatedById = priceGroup.CreatedById,
            Description = priceGroup.Description,
            IsDeleted = priceGroup.IsDeleted,
            Name = priceGroup.Name,
            UpdatedAt = priceGroup.UpdatedAt,
            UpdatedById = priceGroup.UpdatedById,
            Products = priceGroup.Products
                .OrderBy(commonProduct => commonProduct.Id)
                .Take(value)
                .Select(
                    commonProduct => (commonProduct.GetType() == value)
                        ? (CommonProduct)new ProductAddon
                        {
                            Id = commonProduct.Id,
                            AllowOrder = commonProduct.AllowOrder,
                            CopyProductId = commonProduct.CopyProductId,
                            CreatedAt = commonProduct.CreatedAt,
                            CreatedById = commonProduct.CreatedById,
                            Discriminator = commonProduct.Discriminator,
                            FullDescription = commonProduct.FullDescription,
                            IsEnabled = commonProduct.IsEnabled,
                            IsNew = commonProduct.IsNew,
                            Name = commonProduct.Name,
                            PriceGroupId = commonProduct.PriceGroupId,
                            ScreenshotLinkEnabled = commonProduct.ScreenshotLinkEnabled,
                            ShortDescription = commonProduct.ShortDescription,
                            SupportOptions = commonProduct.SupportOptions,
                            UnitGroupId = commonProduct.UnitGroupId,
                            UpdatedAt = commonProduct.UpdatedAt,
                            UpdatedById = commonProduct.UpdatedById,
                            IsTaxable = commonProduct.IsTaxable,
                            ProductGroupId = commonProduct.ProductGroupId,
                            UniqueCode = commonProduct.UniqueCode,
                            AllowsCustomEndDate = ((StandaloneProduct)commonProduct).AllowsCustomEndDate,
                            TrialDuration = ((StandaloneProduct)commonProduct).TrialDuration,
                            TrialNo = ((StandaloneProduct)commonProduct).TrialNo,
                            UnitGroup = (commonProduct.UnitGroup == null)
                                ? (UnitGroup)null
                                : new UnitGroup
                                {
                                    Id = commonProduct.UnitGroup.Id,
                                    CreatedAt = commonProduct.UnitGroup.CreatedAt,
                                    CreatedById = commonProduct.UnitGroup.CreatedById,
                                    Description = commonProduct.UnitGroup.Description,
                                    IsActive = commonProduct.UnitGroup.IsActive,
                                    Name = commonProduct.UnitGroup.Name,
                                    UpdatedAt = commonProduct.UnitGroup.UpdatedAt,
                                    UpdatedById = commonProduct.UnitGroup.UpdatedById,
                                    Units = commonProduct.UnitGroup.Units
                                        .OrderBy(unit => unit.Id)
                                        .ToHashSet()
                                }
                        }
                        : (commonProduct.GetType() == value)
                            ? (CommonProduct)new Product
                            {
                                Id = commonProduct.Id,
                                AllowOrder = commonProduct.AllowOrder,
                                CopyProductId = commonProduct.CopyProductId,
                                CreatedAt = commonProduct.CreatedAt,
                                CreatedById = commonProduct.CreatedById,
                                Discriminator = commonProduct.Discriminator,
                                FullDescription = commonProduct.FullDescription,
                                IsEnabled = commonProduct.IsEnabled,
                                IsNew = commonProduct.IsNew,
                                Name = commonProduct.Name,
                                PriceGroupId = commonProduct.PriceGroupId,
                                ScreenshotLinkEnabled = commonProduct.ScreenshotLinkEnabled,
                                ShortDescription = commonProduct.ShortDescription,
                                SupportOptions = commonProduct.SupportOptions,
                                UnitGroupId = commonProduct.UnitGroupId,
                                UpdatedAt = commonProduct.UpdatedAt,
                                UpdatedById = commonProduct.UpdatedById,
                                IsTaxable = commonProduct.IsTaxable,
                                ProductGroupId = commonProduct.ProductGroupId,
                                UniqueCode = commonProduct.UniqueCode,
                                AllowsCustomEndDate = ((StandaloneProduct)commonProduct).AllowsCustomEndDate,
                                TrialDuration = ((StandaloneProduct)commonProduct).TrialDuration,
                                TrialNo = ((StandaloneProduct)commonProduct).TrialNo,
                                SupportsMonthlyBillingFrequency = ((Product)commonProduct).SupportsMonthlyBillingFrequency,
                                UnitGroup = (commonProduct.UnitGroup == null)
                                    ? (UnitGroup)null
                                    : new UnitGroup
                                    {
                                        Id = commonProduct.UnitGroup.Id,
                                        CreatedAt = commonProduct.UnitGroup.CreatedAt,
                                        CreatedById = commonProduct.UnitGroup.CreatedById,
                                        Description = commonProduct.UnitGroup.Description,
                                        IsActive = commonProduct.UnitGroup.IsActive,
                                        Name = commonProduct.UnitGroup.Name,
                                        UpdatedAt = commonProduct.UnitGroup.UpdatedAt,
                                        UpdatedById = commonProduct.UnitGroup.UpdatedById,
                                        Units = commonProduct.UnitGroup.Units
                                            .OrderBy(unit => unit.Id)
                                            .ToHashSet()
                                    }
                            }
                            : (commonProduct.GetType() == value)
                                ? (CommonProduct)new ProductBundle
                                {
                                    Id = commonProduct.Id,
                                    AllowOrder = commonProduct.AllowOrder,
                                    CopyProductId = commonProduct.CopyProductId,
                                    CreatedAt = commonProduct.CreatedAt,
                                    CreatedById = commonProduct.CreatedById,
                                    Discriminator = commonProduct.Discriminator,
                                    FullDescription = commonProduct.FullDescription,
                                    IsEnabled = commonProduct.IsEnabled,
                                    IsNew = commonProduct.IsNew,
                                    Name = commonProduct.Name,
                                    PriceGroupId = commonProduct.PriceGroupId,
                                    ScreenshotLinkEnabled = commonProduct.ScreenshotLinkEnabled,
                                    ShortDescription = commonProduct.ShortDescription,
                                    SupportOptions = commonProduct.SupportOptions,
                                    UnitGroupId = commonProduct.UnitGroupId,
                                    UpdatedAt = commonProduct.UpdatedAt,
                                    UpdatedById = commonProduct.UpdatedById,
                                    IsTaxable = commonProduct.IsTaxable,
                                    ProductGroupId = commonProduct.ProductGroupId,
                                    UniqueCode = commonProduct.UniqueCode,
                                    UnitGroup = (commonProduct.UnitGroup == null)
                                        ? (UnitGroup)null
                                        : new UnitGroup
                                        {
                                            Id = commonProduct.UnitGroup.Id,
                                            CreatedAt = commonProduct.UnitGroup.CreatedAt,
                                            CreatedById = commonProduct.UnitGroup.CreatedById,
                                            Description = commonProduct.UnitGroup.Description,
                                            IsActive = commonProduct.UnitGroup.IsActive,
                                            Name = commonProduct.UnitGroup.Name,
                                            UpdatedAt = commonProduct.UnitGroup.UpdatedAt,
                                            UpdatedById = commonProduct.UnitGroup.UpdatedById,
                                            Units = commonProduct.UnitGroup.Units
                                                .OrderBy(unit => unit.Id)
                                                .ToHashSet()
                                        }
                                }
                                : commonProduct)
                .ToHashSet()
        })
```
to:
```c#
Expression tree: [Microsoft.EntityFrameworkCore.Query.EntityQueryRootExpression]
    .AsNoTrackingWithIdentityResolution()
    .Include("Products.UnitGroup.Units")
    .OrderBy(priceGroup => priceGroup.Id)
    .Take(value)
    .Select(
        priceGroup => new PriceGroup
        {
            Id = priceGroup.Id,
            CreatedAt = priceGroup.CreatedAt,
            CreatedById = priceGroup.CreatedById,
            Description = priceGroup.Description,
            IsDeleted = priceGroup.IsDeleted,
            Name = priceGroup.Name,
            UpdatedAt = priceGroup.UpdatedAt,
            UpdatedById = priceGroup.UpdatedById,
            Products = priceGroup.Products
                .OrderBy(commonProduct => commonProduct.Id)
                .Take(value)
                .ToHashSet()
        })
```

However, this doesn't entirely solve all problems. But so far, I think it's the best we can offer. Because it's _not possible_ to express a selector at a base level.

For example, using the following model:
```c#
abstract class Abstract;
class ConcreteBase : Abstract;
sealed class Derived1 : ConcreteBase;
sealed class Derived2 : ConcreteBase;

sealed class Root
{
    [HasMany] ISet<Abstract> Items { get; set; }
}
```

The following query is produced without any parameters (so all pagination turned off):

```c#
var query = source
    .Include(root => root.Items);
```

But when a parameter is specified somewhere in the type hierarchy (for example, `fields` for `Derived1`), we MUST always select the actual type:

```c#
var query = source
    .Include(root => root.Items);
    .Select(
        root =>
            root.GetType() == typeof(Derived1)
                ? new Derived1()
                {
                    ... // select subset of fields
                }
                :
            root // matches anything else in the type hierarchy
    );
```

It is _not possible_ to apply this on a base type (for example, `fields` for `ConcreteBase`):

```c#
var query = source
    .Include(root => root.Items);
    .Select(
        root =>
            root.GetType() == typeof(ConcreteBase)
                ? new ConcreteBase() // create instance of base type
                {
                    ... // select subset of fields -- PROBLEM: properties on Derived1 and Derived2 are unavailable
                }
                :
            root // matches anything else in the type hierarchy
    );
```

Thus, the _only way_ to make that work is to expand into separate selectors for `ConcreteBase` and all of its derived types in the type hierarchy:

```c#
var query = source
    .Include(root => root.Items);
    .Select(
        root =>
            root.GetType() == typeof(ConcreteBase)
                ? new ConcreteBase()
                {
                    ... // select subset of fields
                }
                :
            root.GetType() == typeof(Derived1)
                ? new Derived1()
                {
                    ... // select subset of fields (identical to above)
                }
                :
            root.GetType() == typeof(Derived2)
                ? new Derived2()
                {
                     ... // select subset of fields (identical to above)
                }
                :
            root // matches nothing in this case
    );
```

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] Documentation updated
