### PR TITLE
Throw when AddOpenApiForJsonApi is called before AddJsonApi

### DIFF
--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/ServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Errors;
 using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiMetadata;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.SchemaGenerators;
@@ -23,6 +24,7 @@ public static class ServiceCollectionExtensions
     public static void AddOpenApiForJsonApi(this IServiceCollection services, Action<SwaggerGenOptions>? configureSwaggerGenOptions = null)
     {
         ArgumentNullException.ThrowIfNull(services);
+        AssertHasJsonApi(services);
 
         AddCustomApiExplorer(services);
         AddCustomSwaggerComponents(services);
@@ -36,6 +38,14 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IJsonApiContentNegotiator, OpenApiContentNegotiator>();
         services.TryAddSingleton<IJsonApiRequestAccessor, JsonApiRequestAccessor>();
         services.Replace(ServiceDescriptor.Singleton<IJsonApiApplicationBuilderEvents, OpenApiApplicationBuilderEvents>());
+    }
+
+    private static void AssertHasJsonApi(IServiceCollection services)
+    {
+        if (services.FirstOrDefault(descriptor => descriptor.ServiceType == typeof(IJsonApiOptions)) == null)
+        {
+            throw new InvalidConfigurationException("Call 'services.AddJsonApi()' before calling 'services.AddOpenApiForJsonApi()'.");
+        }
     }
 
     private static void AddCustomApiExplorer(IServiceCollection services)

--- a/test/OpenApiTests/OpenApiGenerationFailures/IncorrectSetupOrder/RegistrationTests.cs
+++ b/test/OpenApiTests/OpenApiGenerationFailures/IncorrectSetupOrder/RegistrationTests.cs
@@ -1,0 +1,24 @@
+using FluentAssertions;
+using JsonApiDotNetCore.Errors;
+using JsonApiDotNetCore.OpenApi.Swashbuckle;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace OpenApiTests.OpenApiGenerationFailures.IncorrectSetupOrder;
+
+public sealed class RegistrationTests
+{
+    [Fact]
+    public void Fails_when_OpenAPI_registered_without_JsonApi()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        Action action = () => services.AddOpenApiForJsonApi();
+
+        // Arrange
+        action.Should().ThrowExactly<InvalidConfigurationException>()
+            .WithMessage("Call 'services.AddJsonApi()' before calling 'services.AddOpenApiForJsonApi()'.");
+    }
+}


### PR DESCRIPTION
Fixes #1734.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
