### PR TITLE
Revert package update of JetBrains.Annotations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,7 +54,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2025.2.*" PrivateAssets="All" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.*" PrivateAssets="All" />
     <PackageReference Include="CSharpGuidelinesAnalyzer" Version="3.8.*" PrivateAssets="All" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)CSharpGuidelinesAnalyzer.config" Visible="False" />
   </ItemGroup>


### PR DESCRIPTION
A bug in the latest `JetBrains.Annotations` package results in a runtime failure when using the newest version of JsonApiDotNetCore from nuget.org. Therefore, we're rolling back to the previous version.

Updating this package has always been harmless... until now! The bug is tracked at https://youtrack.jetbrains.com/issue/RSRP-501383/Could-not-load-file-or-assembly-JetBrains.Annotations-for-2025.2.0-version.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
