### PR TITLE
Optimize NuGet package restore

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="Swashbuckle MyGet" value="https://www.myget.org/F/domaindrivendev/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="SwashbuckleMyGet" value="https://www.myget.org/F/domaindrivendev/api/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="SwashbuckleMyGet">
+      <package pattern="Swashbuckle.*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Optimize NuGet package restore: only check for _Swashbuckle_ packages on MyGet feed (instead of searching for _all_ packages on MyGet feed).

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
