### PR TITLE
Combined updates from Dependabot: Resharper and ReportGenerator

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.4.11",
+      "version": "5.4.12",
       "commands": [
         "reportgenerator"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2025.1.5",
+      "version": "2025.2.0",
       "commands": [
         "jb"
       ],


### PR DESCRIPTION
Because Dependabot creates insanely long branch names (`dependabot-nuget-dot-config-dotnet-reportgenerator-globaltool-5.4.12` and `dependabot-nuget-dot-config-jetbrains.resharper.globaltools-2025.2.0`), the PR builds fail with:

> Error: /Users/runner/.dotnet/sdk/9.0.304/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets(221,5): error NU5123: Warning As Error: The file 'package/services/metadata/core-properties/27dfef446f6043e3a174e1942aa22383.psmdcp' path, name, or both are too long. Your package might not work without long file path support. Please shorten the file path or file name. [/Users/runner/work/JsonApiDotNetCore/JsonApiDotNetCore/src/JsonApiDotNetCore.OpenApi.Client.NSwag/JsonApiDotNetCore.OpenApi.Client.NSwag.csproj]
Error: /Users/runner/.dotnet/sdk/9.0.304/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets(221,5): error NU5123: Warning As Error: The file 'package/services/metadata/core-properties/576f133caa684374a95b9df1e19e3221.psmdcp' path, name, or both are too long. Your package might not work without long file path support. Please shorten the file path or file name. [/Users/runner/work/JsonApiDotNetCore/JsonApiDotNetCore/src/JsonApiDotNetCore.OpenApi.Client.Kiota/JsonApiDotNetCore.OpenApi.Client.Kiota.csproj]

This PR combines the changes from #1761 and #1764.

#### QUALITY CHECKLIST
- [ ] Changes implemented in code
- [ ] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] Adapted tests
- [ ] Documentation updated
