### PR TITLE
Speed up CodeQL by turning off AutoBuild

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'csharp' ]
+        include:
+        - language: csharp
+          build-mode: manual
     steps:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
@@ -34,11 +36,12 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-    - name: Restore .NET tools
-      run: |
-        dotnet tool restore
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+    - name: Restore tools
+      run: dotnet tool restore
+    - name: Restore packages
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:


### PR DESCRIPTION
Attempt to reduce CodeQL build time (14 minutes) by specifying `dotnet build` directly.