### PR TITLE
Truncate long branch names created by Dependabot, causing build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,8 +85,8 @@ jobs:
             # Get the version suffix from the auto-incrementing build number. For example: '123' => 'master-00123'
             $revision = "{0:D5}" -f [convert]::ToInt32($env:GITHUB_RUN_NUMBER, 10)
             $branchName = ![string]::IsNullOrEmpty($env:GITHUB_HEAD_REF) ? $env:GITHUB_HEAD_REF : $env:GITHUB_REF_NAME
-            $safeName = $branchName.Replace('/', '-').Replace('_', '-')
-            $versionSuffix = "$safeName-$revision"
+            $safeBranchName = $($branchName -Replace '[^a-zA-Z0-9-]', '-')[0..40] -Join ""
+            $versionSuffix = "$safeBranchName-$revision"
         }
         Write-Output "Using version suffix: $versionSuffix"
         Write-Output "PACKAGE_VERSION_SUFFIX=$versionSuffix" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append


### PR DESCRIPTION
Fixes #1784.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
