### PR TITLE
Documentation: Clarify comments and cleanup in namespace list

### DIFF
--- a/src/JsonApiDotNetCore/Middleware/IAsyncConvertEmptyActionResultFilter.cs
+++ b/src/JsonApiDotNetCore/Middleware/IAsyncConvertEmptyActionResultFilter.cs
@@ -5,13 +5,18 @@ namespace JsonApiDotNetCore.Middleware;
 
 /// <summary>
 /// Converts action result without parameters into action result with null parameter.
-/// <example>
-/// <code><![CDATA[
-/// return NotFound() -> return NotFound(null)
-/// ]]></code>
-/// </example>
-/// This ensures our formatter is invoked, where we'll build a JSON:API compliant response. For details, see:
-/// https://github.com/dotnet/aspnetcore/issues/16969
 /// </summary>
+/// <remarks>
+/// This basically turns calls such as
+/// <c>
+/// return NotFound()
+/// </c>
+/// into
+/// <c>
+/// return NotFound(null)
+/// </c>
+/// , so that our formatter is invoked, where we'll build a JSON:API compliant response. For details, see:
+/// https://github.com/dotnet/aspnetcore/issues/16969
+/// </remarks>
 [PublicAPI]
 public interface IAsyncConvertEmptyActionResultFilter : IAsyncAlwaysRunResultFilter;


### PR DESCRIPTION
Clarify comments and move to remarks section to keep the namespace list clean.

Before:
<img width="970" height="395" alt="{717E7E26-0767-4D1D-9424-9F0B5599BD5F}" src="https://github.com/user-attachments/assets/14f03677-46ab-4b16-83df-cce682e23cbd" />

After:
<img width="830" height="256" alt="{62869851-0529-4081-9C5F-026EC6282EA4}" src="https://github.com/user-attachments/assets/de943f96-52ab-4027-8b89-8de58bf9ecf5" />

Before:
<img width="879" height="620" alt="{B3532753-2B77-4045-99B2-62F56D6AAF40}" src="https://github.com/user-attachments/assets/e767680b-a28a-46f0-baf4-b09c77e78178" />

After:
<img width="1032" height="592" alt="{119BCD8D-8757-4FB3-9374-8BC79EC46DD0}" src="https://github.com/user-attachments/assets/aab4245f-ef4c-43a0-9240-c35d9168ecdb" />

#### QUALITY CHECKLIST
- [ ] N/A: Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [x] Documentation updated
