### PR TITLE
Increase .NET 8 compatibility

### DIFF
--- a/package-versions.props
+++ b/package-versions.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Published dependencies (only update on major version change) -->
-    <CodeAnalysisFrozenVersion>4.13.0</CodeAnalysisFrozenVersion>
+    <CodeAnalysisFrozenVersion>4.8.0</CodeAnalysisFrozenVersion>
     <DemystifierFrozenVersion>0.4.1</DemystifierFrozenVersion>
     <HumanizerFrozenVersion>2.14.1</HumanizerFrozenVersion>
     <NewtonsoftJsonFrozenVersion>13.0.4</NewtonsoftJsonFrozenVersion>

--- a/src/JsonApiDotNetCore.SourceGenerators/ControllerSourceGenerator.cs
+++ b/src/JsonApiDotNetCore.SourceGenerators/ControllerSourceGenerator.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
-// To debug in Visual Studio (requires v17.13 or higher):
+// To debug in Visual Studio (requires v17.8 or higher):
 // - Set JsonApiDotNetCore.SourceGenerators as startup project
 // - Add a breakpoint at the start of the Initialize method
 // - Optional: change targetProject in Properties\launchSettings.json


### PR DESCRIPTION
Reduce the required version of our dependency on `Microsoft.CodeAnalysis` to enable building with .NET 8 SDK v8.0.1xx, which is the version installed by the Ubuntu package manager.

See the version table at https://andrewlock.net/supporting-multiple-sdk-versions-in-analyzers-and-source-generators/ and the Ubuntu feed at https://launchpad.net/ubuntu/+source/dotnet8.

Fixes #1821.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
