### PR TITLE
Use temporary alternate versionspec to workaround Swashbuckle dev feed broken version

### DIFF
--- a/package-versions.props
+++ b/package-versions.props
@@ -27,7 +27,7 @@
     <PolyfillVersion>9.3.*</PolyfillVersion>
     <ReadableExpressionsVersion>4.1.*</ReadableExpressionsVersion>
     <ScalarAspNetCoreVersion>2.11.*</ScalarAspNetCoreVersion>
-    <SwashbuckleVersion>$(SwashbuckleFrozenVersion)</SwashbuckleVersion>
+    <SwashbuckleVersion>[10.0.*-*,10.0.2)</SwashbuckleVersion>
     <SystemTextJsonVersion>10.0.*</SystemTextJsonVersion>
     <TestSdkVersion>18.0.*</TestSdkVersion>
     <XunitVersion>2.9.*</XunitVersion>


### PR DESCRIPTION
Related to https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3683.