### PR TITLE
Partially revert changes for CA1873 (expensive logging)

### DIFF
--- a/src/JsonApiDotNetCore/QueryStrings/QueryStringReader.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/QueryStringReader.cs
@@ -47,11 +47,7 @@ public sealed partial class QueryStringReader : IQueryStringReader
 
             if (reader != null)
             {
-                if (_logger.IsEnabled(LogLevel.Debug))
-                {
-                    string readerType = reader.GetType().Name;
-                    LogParameterAccepted(parameterName, parameterValue, readerType);
-                }
+                LogParameterAccepted(parameterName, parameterValue, reader.GetType().Name);
 
                 if (!reader.AllowEmptyValue && string.IsNullOrEmpty(parameterValue))
                 {
@@ -78,8 +74,7 @@ public sealed partial class QueryStringReader : IQueryStringReader
         }
     }
 
-    [LoggerMessage(Level = LogLevel.Debug, SkipEnabledCheck = true,
-        Message = "Query string parameter '{ParameterName}' with value '{ParameterValue}' was accepted by {ReaderType}.")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Query string parameter '{ParameterName}' with value '{ParameterValue}' was accepted by {ReaderType}.")]
     private partial void LogParameterAccepted(string parameterName, StringValues parameterValue, string readerType);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Query string parameter '{ParameterName}' was successfully read.")]


### PR DESCRIPTION
Partially revert changes for [CA1873](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1873) ("Evaluation of this argument may be expensive and unnecessary if logging is disabled"), now that it's [not so rigid anymore](https://github.com/dotnet/sdk/pull/51839) since .NET 10 SDK v10.0.102.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
