### PR TITLE
Optimization: skip COUNT query when pagination is disabled

### DIFF
--- a/src/JsonApiDotNetCore.Annotations/CollectionConverter.cs
+++ b/src/JsonApiDotNetCore.Annotations/CollectionConverter.cs
@@ -60,6 +60,8 @@ internal sealed class CollectionConverter
     /// </summary>
     private Type ToConcreteCollectionType(Type collectionType)
     {
+        ArgumentNullException.ThrowIfNull(collectionType);
+
         if (collectionType is { IsInterface: true, IsGenericType: true })
         {
             Type openCollectionType = collectionType.GetGenericTypeDefinition();
@@ -91,6 +93,23 @@ internal sealed class CollectionConverter
             IEnumerable<IIdentifiable> resources => resources.ToArray().AsReadOnly(),
             IIdentifiable resource => [resource],
             _ => Array.Empty<IIdentifiable>()
+        };
+    }
+
+    /// <summary>
+    /// Returns the number of elements in a collection of resources.
+    /// </summary>
+    public int GetCount(IEnumerable source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        return source switch
+        {
+            List<IIdentifiable> resourceList => resourceList.Count,
+            HashSet<IIdentifiable> resourceSet => resourceSet.Count,
+            IReadOnlyCollection<IIdentifiable> resourceCollection => resourceCollection.Count,
+            IEnumerable<IIdentifiable> resources => resources.Count(),
+            _ => source.Cast<object>().Count()
         };
     }
 

--- a/src/JsonApiDotNetCore/Queries/IQueryLayerComposer.cs
+++ b/src/JsonApiDotNetCore/Queries/IQueryLayerComposer.cs
@@ -14,6 +14,8 @@ public interface IQueryLayerComposer
     /// <summary>
     /// Builds a filter from constraints, used to determine total resource count on a primary collection endpoint.
     /// </summary>
+    [Obsolete("This method is no longer used and will be removed in a future version.")]
+    // ReSharper disable once UnusedMemberInSuper.Global
     FilterExpression? GetPrimaryFilterFromConstraints(ResourceType primaryResourceType);
 
     /// <summary>

--- a/src/JsonApiDotNetCore/Queries/QueryLayerComposer.cs
+++ b/src/JsonApiDotNetCore/Queries/QueryLayerComposer.cs
@@ -44,6 +44,7 @@ public class QueryLayerComposer : IQueryLayerComposer
     }
 
     /// <inheritdoc />
+    [Obsolete("This method is no longer used and will be removed in a future version.")]
     public FilterExpression? GetPrimaryFilterFromConstraints(ResourceType primaryResourceType)
     {
         // @formatter:wrap_chained_method_calls chop_always

--- a/test/DapperTests/IntegrationTests/DapperTestContext.cs
+++ b/test/DapperTests/IntegrationTests/DapperTestContext.cs
@@ -81,11 +81,7 @@ public sealed class DapperTestContext : IntegrationTest
             builder.ConfigureServices(services =>
             {
                 services.Replace(ServiceDescriptor.Singleton<TimeProvider>(new FrozenTimeProvider(FrozenTime)));
-
-                ServiceDescriptor scopedCaptureStore = services.Single(descriptor => descriptor.ImplementationType == typeof(SqlCaptureStore));
-                services.Remove(scopedCaptureStore);
-
-                services.AddSingleton<SqlCaptureStore>();
+                services.Replace(ServiceDescriptor.Singleton<SqlCaptureStore, SqlCaptureStore>());
             });
         });
     }

--- a/test/DapperTests/IntegrationTests/QueryStrings/FilterTests.cs
+++ b/test/DapperTests/IntegrationTests/QueryStrings/FilterTests.cs
@@ -56,22 +56,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "Tags" AS t1
-                LEFT JOIN "RgbColors" AS t2 ON t1."Id" = t2."TagId"
-                WHERE t2."Id" = @p1
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", 0x00FF00);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."Name"
@@ -120,23 +107,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "Tags" AS t1
-                LEFT JOIN "RgbColors" AS t2 ON t1."Id" = t2."TagId"
-                WHERE t2."Id" IN (@p1, @p2)
-                """));
-
-            command.Parameters.Should().HaveCount(2);
-            command.Parameters.Should().Contain("@p1", 0x00FF00);
-            command.Parameters.Should().Contain("@p2", 0x11EE11);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."Name"
@@ -182,23 +155,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                INNER JOIN "People" AS t2 ON t1."OwnerId" = t2."Id"
-                LEFT JOIN "People" AS t3 ON t1."AssigneeId" = t3."Id"
-                WHERE (t2."Id" = @p1) AND (t3."Id" IS NULL)
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", person.Id);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t4."Id", t4."CreatedAt", t4."Description", t4."DurationInHours", t4."LastModifiedAt", t4."Priority"
@@ -249,22 +208,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                INNER JOIN "People" AS t2 ON t1."OwnerId" = t2."Id"
-                WHERE (t2."Id" = @p1) AND (t1."DurationInHours" IS NULL)
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", person.Id);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t3."Id", t3."CreatedAt", t3."Description", t3."DurationInHours", t3."LastModifiedAt", t3."Priority"
@@ -317,21 +263,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                WHERE t1."Priority" = @p1
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", todoItems[1].Priority);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority"
@@ -379,23 +313,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                LEFT JOIN "People" AS t2 ON t1."AssigneeId" = t2."Id"
-                WHERE (t2."Id" = @p1) AND (t1."Description" = @p2)
-                """));
-
-            command.Parameters.Should().HaveCount(2);
-            command.Parameters.Should().Contain("@p1", person.Id);
-            command.Parameters.Should().Contain("@p2", person.AssignedTodoItems.ElementAt(1).Description);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t3."Id", t3."CreatedAt", t3."Description", t3."DurationInHours", t3."LastModifiedAt", t3."Priority"
@@ -449,21 +369,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                LEFT JOIN "People" AS t2 ON t1."AssigneeId" = t2."Id"
-                WHERE t2."LastName" = t2."FirstName"
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority"
@@ -510,23 +418,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                INNER JOIN "People" AS t2 ON t1."OwnerId" = t2."Id"
-                WHERE (t2."Id" = @p1) AND (t1."Priority" = @p2)
-                """));
-
-            command.Parameters.Should().HaveCount(2);
-            command.Parameters.Should().Contain("@p1", person.Id);
-            command.Parameters.Should().Contain("@p2", TodoItemPriority.Medium);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t3."Id", t3."CreatedAt", t3."Description", t3."DurationInHours", t3."LastModifiedAt", t3."Priority"
@@ -578,21 +472,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                WHERE t1."Description" = @p1
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", "X");
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority"
@@ -640,21 +522,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(2);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                WHERE (NOT (t1."FirstName" = @p1)) OR (t1."FirstName" IS NULL)
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", "X");
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName"
@@ -702,23 +572,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                LEFT JOIN "People" AS t2 ON t1."AssigneeId" = t2."Id"
-                WHERE (NOT ((t2."FirstName" = @p1) AND (t2."LastName" = @p2))) OR (t2."FirstName" IS NULL) OR (t2."LastName" IS NULL)
-                """));
-
-            command.Parameters.Should().HaveCount(2);
-            command.Parameters.Should().Contain("@p1", "X");
-            command.Parameters.Should().Contain("@p2", "Y");
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority"
@@ -771,24 +627,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                INNER JOIN "People" AS t2 ON t1."OwnerId" = t2."Id"
-                WHERE (t1."Description" LIKE 'T%') AND (NOT (t1."Description" IN (@p1, @p2))) AND (t2."FirstName" = @p3) AND (t1."Description" LIKE '%o%')
-                """));
-
-            command.Parameters.Should().HaveCount(3);
-            command.Parameters.Should().Contain("@p1", "Four");
-            command.Parameters.Should().Contain("@p2", "Three");
-            command.Parameters.Should().Contain("@p3", "Jack");
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority"
@@ -845,20 +686,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(5);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "Tags" AS t1
-                WHERE (t1."Name" LIKE '%A\%%' ESCAPE '\') OR (t1."Name" LIKE '%A\_%' ESCAPE '\') OR (t1."Name" LIKE '%A\\%' ESCAPE '\') OR (t1."Name" LIKE '%A''%') OR (t1."Name" LIKE '%\%\_\\''%' ESCAPE '\')
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."Name"
@@ -906,22 +736,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(2);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                WHERE (t1."DurationInHours" > @p1) OR (t1."DurationInHours" <= @p2)
-                """));
-
-            command.Parameters.Should().HaveCount(2);
-            command.Parameters.Should().Contain("@p1", 250);
-            command.Parameters.Should().Contain("@p2", 100);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority"
@@ -970,27 +787,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                INNER JOIN "People" AS t4 ON t1."OwnerId" = t4."Id"
-                WHERE ((
-                    SELECT COUNT(*)
-                    FROM "People" AS t2
-                    LEFT JOIN "TodoItems" AS t3 ON t2."Id" = t3."AssigneeId"
-                    WHERE t1."OwnerId" = t2."Id"
-                ) > @p1) AND (NOT (t4."Id" IS NULL))
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", 1);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority"
@@ -1054,33 +853,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                WHERE EXISTS (
-                    SELECT 1
-                    FROM "People" AS t2
-                    LEFT JOIN "TodoItems" AS t3 ON t2."Id" = t3."AssigneeId"
-                    INNER JOIN "People" AS t5 ON t3."OwnerId" = t5."Id"
-                    WHERE (t1."OwnerId" = t2."Id") AND (EXISTS (
-                        SELECT 1
-                        FROM "Tags" AS t4
-                        WHERE (t3."Id" = t4."TodoItemId") AND (t4."Name" = @p1)
-                    )) AND (t5."LastName" = @p2) AND (t3."Description" = @p3)
-                )
-                """));
-
-            command.Parameters.Should().HaveCount(3);
-            command.Parameters.Should().Contain("@p1", "Personal");
-            command.Parameters.Should().Contain("@p2", "Smith");
-            command.Parameters.Should().Contain("@p3", "Homework");
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority"
@@ -1144,25 +919,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(1);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                WHERE EXISTS (
-                    SELECT 1
-                    FROM "TodoItems" AS t2
-                    LEFT JOIN "People" AS t3 ON t2."AssigneeId" = t3."Id"
-                    WHERE (t1."Id" = t2."OwnerId") AND (NOT (t3."Id" IS NULL)) AND (t3."FirstName" IS NULL)
-                )
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName"
@@ -1232,23 +991,9 @@ public sealed class FilterTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(3);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                WHERE (t1."Description" = @p1) AND ((t1."Priority" = @p2) OR (t1."DurationInHours" = @p3))
-                """));
-
-            command.Parameters.Should().HaveCount(3);
-            command.Parameters.Should().Contain("@p1", "1");
-            command.Parameters.Should().Contain("@p2", TodoItemPriority.High);
-            command.Parameters.Should().Contain("@p3", 1);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority"

--- a/test/DapperTests/IntegrationTests/QueryStrings/IncludeTests.cs
+++ b/test/DapperTests/IntegrationTests/QueryStrings/IncludeTests.cs
@@ -144,19 +144,9 @@ public sealed class IncludeTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(2);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority", t2."Id", t2."FirstName", t2."LastName", t3."Id", t3."FirstName", t3."LastName", t4."Id", t4."CreatedAt", t4."Description", t4."DurationInHours", t4."LastModifiedAt", t4."Priority", t5."Id", t5."Name"
@@ -212,19 +202,9 @@ public sealed class IncludeTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(25);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority", t2."Id", t2."Name", t3."Id"

--- a/test/DapperTests/IntegrationTests/QueryStrings/SortTests.cs
+++ b/test/DapperTests/IntegrationTests/QueryStrings/SortTests.cs
@@ -56,19 +56,9 @@ public sealed class SortTests : IClassFixture<DapperTestContext>
         responseDocument.Data.ManyValue[1].Id.Should().Be(todoItems[0].StringId);
         responseDocument.Data.ManyValue[2].Id.Should().Be(todoItems[1].StringId);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority"
@@ -124,22 +114,9 @@ public sealed class SortTests : IClassFixture<DapperTestContext>
         responseDocument.Included[0].Id.Should().Be(person.OwnedTodoItems.ElementAt(1).Tags.ElementAt(1).StringId);
         responseDocument.Included[1].Id.Should().Be(person.OwnedTodoItems.ElementAt(1).Tags.ElementAt(0).StringId);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                INNER JOIN "People" AS t2 ON t1."OwnerId" = t2."Id"
-                WHERE t2."Id" = @p1
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", person.Id);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t2."Id", t2."CreatedAt", t2."Description", t2."DurationInHours", t2."LastModifiedAt", t2."Priority", t3."Id", t3."Name"
@@ -190,19 +167,9 @@ public sealed class SortTests : IClassFixture<DapperTestContext>
         responseDocument.Data.ManyValue[1].Id.Should().Be(todoItems[0].StringId);
         responseDocument.Data.ManyValue[2].Id.Should().Be(todoItems[1].StringId);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority"
@@ -253,22 +220,9 @@ public sealed class SortTests : IClassFixture<DapperTestContext>
         responseDocument.Data.ManyValue[1].Id.Should().Be(person.OwnedTodoItems.ElementAt(0).StringId);
         responseDocument.Data.ManyValue[2].Id.Should().Be(person.OwnedTodoItems.ElementAt(1).StringId);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                INNER JOIN "People" AS t2 ON t1."OwnerId" = t2."Id"
-                WHERE t2."Id" = @p1
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", person.Id);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t2."Id", t2."CreatedAt", t2."Description", t2."DurationInHours", t2."LastModifiedAt", t2."Priority"
@@ -322,22 +276,9 @@ public sealed class SortTests : IClassFixture<DapperTestContext>
         responseDocument.Data.ManyValue[1].Id.Should().Be(person.OwnedTodoItems.ElementAt(0).StringId);
         responseDocument.Data.ManyValue[2].Id.Should().Be(person.OwnedTodoItems.ElementAt(1).StringId);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                INNER JOIN "People" AS t2 ON t1."OwnerId" = t2."Id"
-                WHERE t2."Id" = @p1
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", person.Id);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t2."Id", t2."CreatedAt", t2."Description", t2."DurationInHours", t2."LastModifiedAt", t2."Priority", t4."Id", t4."Name"
@@ -397,19 +338,9 @@ public sealed class SortTests : IClassFixture<DapperTestContext>
         responseDocument.Included[2].Id.Should().Be(person.OwnedTodoItems.ElementAt(1).StringId);
         responseDocument.Included[3].Id.Should().Be(person.OwnedTodoItems.ElementAt(3).StringId);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName", t2."Id", t2."CreatedAt", t2."Description", t2."DurationInHours", t2."LastModifiedAt", t2."Priority"

--- a/test/DapperTests/IntegrationTests/QueryStrings/SparseFieldSets.cs
+++ b/test/DapperTests/IntegrationTests/QueryStrings/SparseFieldSets.cs
@@ -84,19 +84,9 @@ public sealed class SparseFieldSets : IClassFixture<DapperTestContext>
         responseDocument.Included[1].Attributes.Should().ContainKey("lastName").WhoseValue.Should().Be(todoItem.Assignee.LastName);
         responseDocument.Included[1].Relationships.Should().BeNull();
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."Description", t1."DurationInHours", t2."Id", t2."LastName", t3."Id", t3."LastName"
@@ -193,22 +183,9 @@ public sealed class SparseFieldSets : IClassFixture<DapperTestContext>
             value.Data.Value.Should().BeNull();
         });
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "Tags" AS t1
-                LEFT JOIN "TodoItems" AS t2 ON t1."TodoItemId" = t2."Id"
-                WHERE t2."Id" = @p1
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", todoItem.Id);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t2."Id"

--- a/test/DapperTests/IntegrationTests/ReadWrite/Relationships/FetchRelationshipTests.cs
+++ b/test/DapperTests/IntegrationTests/ReadWrite/Relationships/FetchRelationshipTests.cs
@@ -146,22 +146,9 @@ public sealed class FetchRelationshipTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(2);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "Tags" AS t1
-                LEFT JOIN "TodoItems" AS t2 ON t1."TodoItemId" = t2."Id"
-                WHERE t2."Id" = @p1
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", todoItem.Id);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t2."Id"

--- a/test/DapperTests/IntegrationTests/ReadWrite/Resources/FetchResourceTests.cs
+++ b/test/DapperTests/IntegrationTests/ReadWrite/Resources/FetchResourceTests.cs
@@ -70,19 +70,9 @@ public sealed class FetchResourceTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(2);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority"
@@ -224,22 +214,9 @@ public sealed class FetchResourceTests : IClassFixture<DapperTestContext>
 
         responseDocument.Meta.Should().ContainTotal(2);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "Tags" AS t1
-                LEFT JOIN "TodoItems" AS t2 ON t1."TodoItemId" = t2."Id"
-                WHERE t2."Id" = @p1
-                """));
-
-            command.Parameters.Should().HaveCount(1);
-            command.Parameters.Should().Contain("@p1", todoItem.Id);
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t2."Id", t2."Name"

--- a/test/DapperTests/IntegrationTests/Sql/SubQueryInJoinTests.cs
+++ b/test/DapperTests/IntegrationTests/Sql/SubQueryInJoinTests.cs
@@ -44,19 +44,9 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName", t2."Id", t2."LastUsedAt", t2."UserName"
@@ -92,19 +82,9 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName", t2."Id", t2."CreatedAt", t2."Description", t2."DurationInHours", t2."LastModifiedAt", t2."Priority"
@@ -141,19 +121,9 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName", t2."Id", t2."CreatedAt", t2."Description", t2."DurationInHours", t2."LastModifiedAt", t2."Priority"
@@ -190,19 +160,9 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName", t2."Id", t2."CreatedAt", t2."Description", t2."DurationInHours", t2."LastModifiedAt", t2."Priority"
@@ -243,19 +203,9 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName", t2."Id", t2."CreatedAt", t2."Description", t2."DurationInHours", t2."LastModifiedAt", t2."Priority", t4."Id", t4."Name"
@@ -299,19 +249,9 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "TodoItems" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."CreatedAt", t1."Description", t1."DurationInHours", t1."LastModifiedAt", t1."Priority", t2."Id", t2."FirstName", t2."LastName", t3."Id", t3."CreatedAt", t3."Description", t3."DurationInHours", t3."LastModifiedAt", t3."Priority", t5."Id", t5."Name", t6."Id", t6."CreatedAt", t6."Description", t6."DurationInHours", t6."LastModifiedAt", t6."Priority", t8."Id", t8."Name"
@@ -360,19 +300,9 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName", t3."Id", t3."CreatedAt", t3."Description", t3."DurationInHours", t3."LastModifiedAt", t3."Priority"
@@ -414,19 +344,9 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName", t4."Id", t4."CreatedAt", t4."Description", t4."DurationInHours", t4."LastModifiedAt", t4."Priority"
@@ -471,19 +391,9 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName", t4."Id", t4."CreatedAt", t4."Description", t4."DurationInHours", t4."LastModifiedAt", t4."Priority"
@@ -530,19 +440,9 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName", t5."Id", t5."CreatedAt", t5."Description", t5."DurationInHours", t5."LastModifiedAt", t5."Priority", t5.Id0 AS Id, t5."Name"
@@ -591,19 +491,9 @@ public sealed class SubQueryInJoinTests : IClassFixture<DapperTestContext>
         // Assert
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
-        store.SqlCommands.Should().HaveCount(2);
+        store.SqlCommands.Should().HaveCount(1);
 
         store.SqlCommands[0].With(command =>
-        {
-            command.Statement.Should().Be(_testContext.AdaptSql("""
-                SELECT COUNT(*)
-                FROM "People" AS t1
-                """));
-
-            command.Parameters.Should().BeEmpty();
-        });
-
-        store.SqlCommands[1].With(command =>
         {
             command.Statement.Should().Be(_testContext.AdaptSql("""
                 SELECT t1."Id", t1."FirstName", t1."LastName", t7."Id", t7."CreatedAt", t7."Description", t7."DurationInHours", t7."LastModifiedAt", t7."Priority", t7.Id00 AS Id, t7."Name"

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ResourceDefinitionReadTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ResourceDefinitions/Reading/ResourceDefinitionReadTests.cs
@@ -44,6 +44,43 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
     }
 
     [Fact]
+    public async Task Has_total_when_pagination_disabled_at_primary_endpoint()
+    {
+        // Arrange
+        var hitCounter = _testContext.Factory.Services.GetRequiredService<ResourceDefinitionHitCounter>();
+
+        Constellation constellation = _fakers.Constellation.GenerateOne();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await dbContext.ClearTableAsync<Constellation>();
+            dbContext.Constellations.Add(constellation);
+            await dbContext.SaveChangesAsync();
+        });
+
+        const string route = "/constellations?page[size]=0";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        responseDocument.Meta.Should().ContainTotal(1);
+
+        hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
+        {
+            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
+            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplySort),
+            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
+            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.GetMeta)
+        }, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
     public async Task Include_from_resource_definition_is_blocked()
     {
         // Arrange
@@ -78,7 +115,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
         {
-            (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
@@ -243,7 +279,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
         {
-            (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
@@ -298,7 +333,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
         {
-            (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
@@ -345,8 +379,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
         {
-            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
-            (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
@@ -354,6 +386,8 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+            (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.GetMeta),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.GetMeta)
@@ -396,8 +430,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
         {
-            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
-            (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
@@ -405,7 +437,9 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
-            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter)
+            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+            (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter)
         }, options => options.WithStrictOrdering());
     }
 
@@ -442,13 +476,13 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
         {
-            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.GetMeta)
@@ -493,15 +527,15 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
         {
-            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
-            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySort),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
             (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
-            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplyFilter)
+            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter)
         }, options => options.WithStrictOrdering());
     }
 
@@ -538,7 +572,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
         {
-            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySort),
@@ -546,6 +579,7 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
             (typeof(Planet), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
+            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter)
         }, options => options.WithStrictOrdering());
     }
@@ -588,8 +622,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
         {
-            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
-            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySort),
@@ -597,7 +629,9 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyIncludes),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
             (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplySparseFieldSet),
-            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplyFilter)
+            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+            (typeof(Constellation), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
+            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter)
         }, options => options.WithStrictOrdering());
     }
 
@@ -640,7 +674,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
         {
-            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySort),
@@ -692,7 +725,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
         {
-            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySort),
@@ -732,7 +764,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
 
         hitCounter.HitExtensibilityPoints.Should().BeEquivalentTo(new[]
         {
-            (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Star), ResourceDefinitionExtensibilityPoints.OnApplySort),
@@ -944,7 +975,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
         {
             (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnRegisterQueryableHandlersForQueryStringParameters),
             (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnRegisterQueryableHandlersForQueryStringParameters),
-            (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySort),
@@ -1001,7 +1031,6 @@ public sealed class ResourceDefinitionReadTests : IClassFixture<IntegrationTestC
         {
             (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnRegisterQueryableHandlersForQueryStringParameters),
             (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnRegisterQueryableHandlersForQueryStringParameters),
-            (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyPagination),
             (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplyFilter),
             (typeof(Moon), ResourceDefinitionExtensibilityPoints.OnApplySort),


### PR DESCRIPTION
This PR eliminates the SQL `COUNT(*)` query when pagination is disabled (either via options or the query string) for GET requests. As all resources are being returned in this case, they can simply be counted in-memory to set `total` in the response.

Additionally, this PR slightly changes the execution order of resource-definition callbacks for certain GET requests and eliminates redundant ones. Before any SQL executes, all callbacks are invoked now. This is needed to determine whether pagination is active, so we can possibly skip the COUNT query. As a result:
- `GET /blogs`: No longer calls the first `OnApplyFilter`, which was used to prepare the COUNT query. Related to that, the `IQueryLayerComposer.GetPrimaryFilterFromConstraints` method has been marked obsolete because it is no longer used.
- `GET /blogs/1/posts` and `GET /blogs/1/relationships/posts`: `OnApplyFilter` callbacks for left/right to determine count happen _after_ the callbacks for fetching data. They don't happen at all when the optimization kicks in.

In the unlikely case your resource definition callbacks depend on execution order, it is recommended to verify that nothing broke.

Finally, this PR fixes a bug in the NoEntityFrameworkExample where `total` was not always returned.

Closes #1752.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
