### PR TITLE
Deprecate relaxed variants of media types

### DIFF
--- a/docs/ext/openapi/index.md
+++ b/docs/ext/openapi/index.md
@@ -1,6 +1,6 @@
 # JSON:API Extension for OpenAPI
 
-This extension facilitates using OpenAPI client generators targeting JSON:API documents.
+This extension facilitates the use of OpenAPI client generators targeting JSON:API documents.
 
 In JSON:API, a resource object contains the `type` member, which defines the structure of nested [attributes](https://jsonapi.org/format/#document-resource-object-attributes) and [relationships](https://jsonapi.org/format/#document-resource-object-relationships) objects.
 While OpenAPI supports such constraints using `allOf` inheritance with a discriminator property for the `data` member,
@@ -11,30 +11,10 @@ This extension addresses that limitation by defining additional discriminator pr
 ## URI
 
 This extension has the URI `https://www.jsonapi.net/ext/openapi`.
-Because code generators often choke on the double quotes in `Accept` and `Content-Type` HTTP header values, a relaxed form is also permitted: `openapi`.
 
-For example, the following `Content-Type` header:
-
-```http
-Content-Type: application/vnd.api+json; ext="https://www.jsonapi.net/ext/openapi"
-```
-
-is equivalent to:
-
-```http
-Content-Type: application/vnd.api+json; ext=openapi
-```
-
-To avoid the need for double quotes when multiple extensions are used, the following relaxed form can be used:
-
-```http
-Content-Type: application/vnd.api+json; ext=openapi; ext=atomic
-```
-
-> [!NOTE]
-> The [base specification](https://jsonapi.org/format/#media-type-parameter-rules) *forbids* the use of multiple `ext` parameters
-> and *requires* that each extension name must be a URI.
-> This extension relaxes both constraints for practical reasons, to workaround bugs in client generators that produce broken code otherwise.
+> [!CAUTION]
+> Early preview versions of this specification also permitted using `openapi` instead of the URI to work around bugs in client generators.
+> This is no longer supported and is not part of the final version.
 
 ## Namespace
 
@@ -55,7 +35,7 @@ in [attributes](https://jsonapi.org/format/#document-resource-object-attributes)
 
 * `openapi:discriminator` - A string that MUST be identical to the `type` member in the containing [resource object](https://jsonapi.org/format/#document-resource-objects).
 
-Here's how an article (i.e. a resource of type "articles") might appear in a document:
+Here's how an article (a resource of type "articles") might appear in a document:
 
 ```json
 {
@@ -81,7 +61,7 @@ Here's how an article (i.e. a resource of type "articles") might appear in a doc
 In addition to the members allowed by the [Atomic Operations extension](https://jsonapi.org/ext/atomic/),
 the following member MAY be included in elements of an `atomic:operations` array:
 
-* `openapi:discriminator` - A free-format string to facilitate generation of client code.
+* `openapi:discriminator` - A free-format string to facilitate the generation of client code.
 
 For example:
 

--- a/src/Examples/JsonApiDotNetCoreExample/GeneratedSwagger/JsonApiDotNetCoreExample.json
+++ b/src/Examples/JsonApiDotNetCoreExample/GeneratedSwagger/JsonApiDotNetCoreExample.json
@@ -157,7 +157,7 @@
         "requestBody": {
           "description": "An array of mutation operations. For syntax, see the [Atomic Operations documentation](https://jsonapi.org/ext/atomic/).",
           "content": {
-            "application/vnd.api+json; ext=atomic; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -173,7 +173,7 @@
           "200": {
             "description": "All operations were successfully applied, which resulted in additional changes.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/operationsResponseDocument"
                 }
@@ -186,7 +186,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -196,7 +196,7 @@
           "403": {
             "description": "An operation is not accessible or a client-generated ID is used.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -206,7 +206,7 @@
           "404": {
             "description": "A resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -216,7 +216,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -226,7 +226,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -279,7 +279,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/personCollectionResponseDocument"
                 }
@@ -301,7 +301,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -402,7 +402,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the person to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -428,7 +428,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryPersonResponseDocument"
                 }
@@ -441,7 +441,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -451,7 +451,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -461,7 +461,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -471,7 +471,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -481,7 +481,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -545,7 +545,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryPersonResponseDocument"
                 }
@@ -567,7 +567,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -577,7 +577,7 @@
           "404": {
             "description": "The person does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -703,7 +703,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the person to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -719,7 +719,7 @@
           "200": {
             "description": "The person was successfully updated, which resulted in additional changes. The updated person is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryPersonResponseDocument"
                 }
@@ -732,7 +732,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -742,7 +742,7 @@
           "404": {
             "description": "The person or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -752,7 +752,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -762,7 +762,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -797,7 +797,7 @@
           "404": {
             "description": "The person does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -861,7 +861,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/todoItemCollectionResponseDocument"
                 }
@@ -883,7 +883,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -893,7 +893,7 @@
           "404": {
             "description": "The person does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1039,7 +1039,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/todoItemIdentifierCollectionResponseDocument"
                 }
@@ -1061,7 +1061,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1071,7 +1071,7 @@
           "404": {
             "description": "The person does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1184,7 +1184,7 @@
         "requestBody": {
           "description": "The identities of the todoItems to add to the assignedTodoItems relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1203,7 +1203,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1213,7 +1213,7 @@
           "404": {
             "description": "The person or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1223,7 +1223,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1233,7 +1233,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1264,7 +1264,7 @@
         "requestBody": {
           "description": "The identities of the todoItems to assign to the assignedTodoItems relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1283,7 +1283,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1293,7 +1293,7 @@
           "404": {
             "description": "The person or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1303,7 +1303,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1313,7 +1313,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1344,7 +1344,7 @@
         "requestBody": {
           "description": "The identities of the todoItems to remove from the assignedTodoItems relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1363,7 +1363,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1373,7 +1373,7 @@
           "404": {
             "description": "The person or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1383,7 +1383,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1393,7 +1393,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1457,7 +1457,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/todoItemCollectionResponseDocument"
                 }
@@ -1479,7 +1479,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1489,7 +1489,7 @@
           "404": {
             "description": "The person does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1635,7 +1635,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/todoItemIdentifierCollectionResponseDocument"
                 }
@@ -1657,7 +1657,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1667,7 +1667,7 @@
           "404": {
             "description": "The person does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1780,7 +1780,7 @@
         "requestBody": {
           "description": "The identities of the todoItems to add to the ownedTodoItems relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1799,7 +1799,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1809,7 +1809,7 @@
           "404": {
             "description": "The person or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1819,7 +1819,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1829,7 +1829,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1860,7 +1860,7 @@
         "requestBody": {
           "description": "The identities of the todoItems to assign to the ownedTodoItems relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1879,7 +1879,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1889,7 +1889,7 @@
           "404": {
             "description": "The person or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1899,7 +1899,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1909,7 +1909,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1940,7 +1940,7 @@
         "requestBody": {
           "description": "The identities of the todoItems to remove from the ownedTodoItems relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1959,7 +1959,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1969,7 +1969,7 @@
           "404": {
             "description": "The person or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1979,7 +1979,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1989,7 +1989,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2042,7 +2042,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/tagCollectionResponseDocument"
                 }
@@ -2064,7 +2064,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2165,7 +2165,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the tag to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2191,7 +2191,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryTagResponseDocument"
                 }
@@ -2204,7 +2204,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2214,7 +2214,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2224,7 +2224,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2234,7 +2234,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2244,7 +2244,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2308,7 +2308,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryTagResponseDocument"
                 }
@@ -2330,7 +2330,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2340,7 +2340,7 @@
           "404": {
             "description": "The tag does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2466,7 +2466,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the tag to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2482,7 +2482,7 @@
           "200": {
             "description": "The tag was successfully updated, which resulted in additional changes. The updated tag is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryTagResponseDocument"
                 }
@@ -2495,7 +2495,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2505,7 +2505,7 @@
           "404": {
             "description": "The tag or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2515,7 +2515,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2525,7 +2525,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2560,7 +2560,7 @@
           "404": {
             "description": "The tag does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2624,7 +2624,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/todoItemCollectionResponseDocument"
                 }
@@ -2646,7 +2646,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2656,7 +2656,7 @@
           "404": {
             "description": "The tag does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2802,7 +2802,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/todoItemIdentifierCollectionResponseDocument"
                 }
@@ -2824,7 +2824,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2834,7 +2834,7 @@
           "404": {
             "description": "The tag does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2947,7 +2947,7 @@
         "requestBody": {
           "description": "The identities of the todoItems to add to the todoItems relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2966,7 +2966,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2976,7 +2976,7 @@
           "404": {
             "description": "The tag or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2986,7 +2986,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2996,7 +2996,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3027,7 +3027,7 @@
         "requestBody": {
           "description": "The identities of the todoItems to assign to the todoItems relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3046,7 +3046,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3056,7 +3056,7 @@
           "404": {
             "description": "The tag or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3066,7 +3066,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3076,7 +3076,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3107,7 +3107,7 @@
         "requestBody": {
           "description": "The identities of the todoItems to remove from the todoItems relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3126,7 +3126,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3136,7 +3136,7 @@
           "404": {
             "description": "The tag or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3146,7 +3146,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3156,7 +3156,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3209,7 +3209,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/todoItemCollectionResponseDocument"
                 }
@@ -3231,7 +3231,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3332,7 +3332,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the todoItem to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3358,7 +3358,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryTodoItemResponseDocument"
                 }
@@ -3371,7 +3371,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3381,7 +3381,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3391,7 +3391,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3401,7 +3401,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3411,7 +3411,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3475,7 +3475,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryTodoItemResponseDocument"
                 }
@@ -3497,7 +3497,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3507,7 +3507,7 @@
           "404": {
             "description": "The todoItem does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3633,7 +3633,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the todoItem to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3649,7 +3649,7 @@
           "200": {
             "description": "The todoItem was successfully updated, which resulted in additional changes. The updated todoItem is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryTodoItemResponseDocument"
                 }
@@ -3662,7 +3662,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3672,7 +3672,7 @@
           "404": {
             "description": "The todoItem or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3682,7 +3682,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3692,7 +3692,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3727,7 +3727,7 @@
           "404": {
             "description": "The todoItem does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3791,7 +3791,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableSecondaryPersonResponseDocument"
                 }
@@ -3813,7 +3813,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3823,7 +3823,7 @@
           "404": {
             "description": "The todoItem does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3969,7 +3969,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullablePersonIdentifierResponseDocument"
                 }
@@ -3991,7 +3991,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4001,7 +4001,7 @@
           "404": {
             "description": "The todoItem does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4114,7 +4114,7 @@
         "requestBody": {
           "description": "The identity of the person to assign to the assignee relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4133,7 +4133,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4143,7 +4143,7 @@
           "404": {
             "description": "The todoItem or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4153,7 +4153,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4163,7 +4163,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4227,7 +4227,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryPersonResponseDocument"
                 }
@@ -4249,7 +4249,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4259,7 +4259,7 @@
           "404": {
             "description": "The todoItem does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4405,7 +4405,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/personIdentifierResponseDocument"
                 }
@@ -4427,7 +4427,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4437,7 +4437,7 @@
           "404": {
             "description": "The todoItem does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4550,7 +4550,7 @@
         "requestBody": {
           "description": "The identity of the person to assign to the owner relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4569,7 +4569,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4579,7 +4579,7 @@
           "404": {
             "description": "The todoItem or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4589,7 +4589,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4599,7 +4599,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4663,7 +4663,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/tagCollectionResponseDocument"
                 }
@@ -4685,7 +4685,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4695,7 +4695,7 @@
           "404": {
             "description": "The todoItem does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4841,7 +4841,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/tagIdentifierCollectionResponseDocument"
                 }
@@ -4863,7 +4863,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4873,7 +4873,7 @@
           "404": {
             "description": "The todoItem does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4986,7 +4986,7 @@
         "requestBody": {
           "description": "The identities of the tags to add to the tags relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5005,7 +5005,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5015,7 +5015,7 @@
           "404": {
             "description": "The todoItem or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5025,7 +5025,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5035,7 +5035,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5066,7 +5066,7 @@
         "requestBody": {
           "description": "The identities of the tags to assign to the tags relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5085,7 +5085,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5095,7 +5095,7 @@
           "404": {
             "description": "The todoItem or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5105,7 +5105,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5115,7 +5115,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5146,7 +5146,7 @@
         "requestBody": {
           "description": "The identities of the tags to remove from the tags relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5165,7 +5165,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5175,7 +5175,7 @@
           "404": {
             "description": "The todoItem or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5185,7 +5185,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5195,7 +5195,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/Operations/OperationsRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/Operations/OperationsRequestBuilder.cs
@@ -75,8 +75,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.Operations
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=atomic;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=atomic;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/People/Item/AssignedTodoItems/AssignedTodoItemsRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/People/Item/AssignedTodoItems/AssignedTodoItemsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item.AssignedTodoIt
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/People/Item/OwnedTodoItems/OwnedTodoItemsRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/People/Item/OwnedTodoItems/OwnedTodoItemsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item.OwnedTodoItems
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/People/Item/PeopleItemRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/People/Item/PeopleItemRequestBuilder.cs
@@ -138,7 +138,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -151,7 +151,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -178,8 +178,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/People/Item/Relationships/AssignedTodoItems/AssignedTodoItemsRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/People/Item/Relationships/AssignedTodoItems/AssignedTodoItemsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item.Relationships.
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item.Relationships.
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item.Relationships.
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item.Relationships.
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/People/Item/Relationships/OwnedTodoItems/OwnedTodoItemsRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/People/Item/Relationships/OwnedTodoItems/OwnedTodoItemsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item.Relationships.
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item.Relationships.
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item.Relationships.
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People.Item.Relationships.
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/People/PeopleRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/People/PeopleRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.People
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/Tags/Item/Relationships/TodoItems/TodoItemsRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/Tags/Item/Relationships/TodoItems/TodoItemsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.Tags.Item.Relationships.To
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.Tags.Item.Relationships.To
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.Tags.Item.Relationships.To
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.Tags.Item.Relationships.To
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/Tags/Item/TagsItemRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/Tags/Item/TagsItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.Tags.Item
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.Tags.Item
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.Tags.Item
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/Tags/Item/TodoItems/TodoItemsRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/Tags/Item/TodoItems/TodoItemsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.Tags.Item.TodoItems
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/Tags/TagsRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/Tags/TagsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.Tags
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.Tags
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/Assignee/AssigneeRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/Assignee/AssigneeRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item.Assignee
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/Owner/OwnerRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/Owner/OwnerRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item.Owner
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/Relationships/Assignee/AssigneeRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/Relationships/Assignee/AssigneeRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item.Relationshi
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item.Relationshi
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/Relationships/Owner/OwnerRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/Relationships/Owner/OwnerRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item.Relationshi
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item.Relationshi
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/Relationships/Tags/TagsRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/Relationships/Tags/TagsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item.Relationshi
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item.Relationshi
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item.Relationshi
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item.Relationshi
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/Tags/TagsRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/Tags/TagsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item.Tags
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/TodoItemsItemRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/Item/TodoItemsItemRequestBuilder.cs
@@ -145,7 +145,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -158,7 +158,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -185,8 +185,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems.Item
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/TodoItemsRequestBuilder.cs
+++ b/src/Examples/OpenApiKiotaClientExample/GeneratedCode/Api/TodoItems/TodoItemsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaClientExample.GeneratedCode.Api.TodoItems
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/ConfigureMvcOptions.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/ConfigureMvcOptions.cs
@@ -24,6 +24,8 @@ internal sealed class ConfigureMvcOptions : IConfigureOptions<MvcOptions>
 
         options.InputFormatters.Add(_jsonApiRequestFormatMetadataProvider);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         _jsonApiOptions.IncludeExtensions(OpenApiMediaTypeExtension.OpenApi, OpenApiMediaTypeExtension.RelaxedOpenApi);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiContentNegotiator.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiContentNegotiator.cs
@@ -28,6 +28,7 @@ internal sealed class OpenApiContentNegotiator(IJsonApiOptions options, IHttpCon
         // JSON:API compliant entries come after relaxed entries, which makes them less likely to be selected.
         // This improves compatibility with client generators, which often generate broken code due to the double quotes.
 
+#pragma warning disable CS0618 // Type or member is obsolete
         if (IsOperationsEndpoint())
         {
             if (_options.Extensions.Contains(JsonApiMediaTypeExtension.RelaxedAtomicOperations))
@@ -65,6 +66,7 @@ internal sealed class OpenApiContentNegotiator(IJsonApiOptions options, IHttpCon
 
             mediaTypes.Add(JsonApiMediaType.Default);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         return mediaTypes.AsReadOnly();
     }

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiContentTypeProvider.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiContentTypeProvider.cs
@@ -21,12 +21,12 @@ internal sealed class OpenApiContentTypeProvider
 
         if (documentType == typeof(OperationsRequestDocument))
         {
-            return [OpenApiMediaTypes.RelaxedAtomicOperationsWithRelaxedOpenApi.ToString()];
+            return [OpenApiMediaTypes.AtomicOperationsWithOpenApi.ToString()];
         }
 
         if (JsonApiSchemaFacts.IsRequestDocumentSchemaType(documentType))
         {
-            return [OpenApiMediaTypes.RelaxedOpenApi.ToString()];
+            return [OpenApiMediaTypes.OpenApi.ToString()];
         }
 
         return [];
@@ -38,17 +38,17 @@ internal sealed class OpenApiContentTypeProvider
 
         if (documentType == typeof(OperationsResponseDocument))
         {
-            return [OpenApiMediaTypes.RelaxedAtomicOperationsWithRelaxedOpenApi.ToString()];
+            return [OpenApiMediaTypes.AtomicOperationsWithOpenApi.ToString()];
         }
 
         if (documentType == typeof(ErrorResponseDocument))
         {
-            return [OpenApiMediaTypes.RelaxedOpenApi.ToString()];
+            return [OpenApiMediaTypes.OpenApi.ToString()];
         }
 
         if (documentType != null && JsonApiSchemaFacts.IsResponseDocumentSchemaType(documentType))
         {
-            return [OpenApiMediaTypes.RelaxedOpenApi.ToString()];
+            return [OpenApiMediaTypes.OpenApi.ToString()];
         }
 
         return [];

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiMediaTypeExtension.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiMediaTypeExtension.cs
@@ -10,5 +10,7 @@ internal static class OpenApiMediaTypeExtension
     public const string DiscriminatorPropertyName = "discriminator";
     public const string FullyQualifiedOpenApiDiscriminatorPropertyName = $"{ExtensionNamespace}:{DiscriminatorPropertyName}";
     public static readonly JsonApiMediaTypeExtension OpenApi = new("https://www.jsonapi.net/ext/openapi");
+
+    [Obsolete("This media type is no longer needed and will be removed in a future version. Use OpenApi instead.")]
     public static readonly JsonApiMediaTypeExtension RelaxedOpenApi = new("openapi");
 }

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiMediaTypes.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiMediaTypes.cs
@@ -7,6 +7,8 @@ namespace JsonApiDotNetCore.OpenApi.Swashbuckle;
 internal static class OpenApiMediaTypes
 {
     public static readonly JsonApiMediaType OpenApi = new([OpenApiMediaTypeExtension.OpenApi]);
+
+    [Obsolete("This media type is no longer needed and will be removed in a future version. Use OpenApi instead.")]
     public static readonly JsonApiMediaType RelaxedOpenApi = new([OpenApiMediaTypeExtension.RelaxedOpenApi]);
 
     public static readonly JsonApiMediaType AtomicOperationsWithOpenApi = new([
@@ -14,6 +16,7 @@ internal static class OpenApiMediaTypes
         OpenApiMediaTypeExtension.OpenApi
     ]);
 
+    [Obsolete("This media type is no longer needed and will be removed in a future version. Use AtomicOperationsWithOpenApi instead.")]
     public static readonly JsonApiMediaType RelaxedAtomicOperationsWithRelaxedOpenApi = new([
         JsonApiMediaTypeExtension.RelaxedAtomicOperations,
         OpenApiMediaTypeExtension.RelaxedOpenApi

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiResourceObjectConverter.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiResourceObjectConverter.cs
@@ -20,8 +20,10 @@ internal sealed class OpenApiResourceObjectConverter : ResourceObjectConverter
                 return false;
             }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             return _requestAccessor.Current.Extensions.Contains(OpenApiMediaTypeExtension.OpenApi) ||
                 _requestAccessor.Current.Extensions.Contains(OpenApiMediaTypeExtension.RelaxedOpenApi);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 

--- a/src/JsonApiDotNetCore/Middleware/HeaderConstants.cs
+++ b/src/JsonApiDotNetCore/Middleware/HeaderConstants.cs
@@ -13,6 +13,7 @@ public static class HeaderConstants
     [Obsolete($"Use {nameof(JsonApiMediaType)}.{nameof(JsonApiMediaType.AtomicOperations)}.ToString() instead.")]
     public const string AtomicOperationsMediaType = $"{MediaType}; ext=\"https://jsonapi.org/ext/atomic\"";
 
-    [Obsolete($"Use {nameof(JsonApiMediaType)}.{nameof(JsonApiMediaType.RelaxedAtomicOperations)}.ToString() instead.")]
+    [Obsolete($"This media type is no longer needed and will be removed in a future version. " +
+        $"Use {nameof(JsonApiMediaType)}.{nameof(JsonApiMediaType.AtomicOperations)}.ToString() instead.")]
     public const string RelaxedAtomicOperationsMediaType = $"{MediaType}; ext=atomic";
 }

--- a/src/JsonApiDotNetCore/Middleware/JsonApiContentNegotiator.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiContentNegotiator.cs
@@ -190,10 +190,12 @@ public class JsonApiContentNegotiator : IJsonApiContentNegotiator
                 mediaTypes.Add(JsonApiMediaType.AtomicOperations);
             }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (_options.Extensions.Contains(JsonApiMediaTypeExtension.RelaxedAtomicOperations))
             {
                 mediaTypes.Add(JsonApiMediaType.RelaxedAtomicOperations);
             }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
         else
         {

--- a/src/JsonApiDotNetCore/Middleware/JsonApiMediaType.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiMediaType.cs
@@ -27,6 +27,7 @@ public sealed class JsonApiMediaType : IEquatable<JsonApiMediaType>
     /// <summary>
     /// Gets the JSON:API media type with the "atomic" extension.
     /// </summary>
+    [Obsolete("This media type is no longer needed and will be removed in a future version. Use AtomicOperations instead.")]
     public static readonly JsonApiMediaType RelaxedAtomicOperations = new([JsonApiMediaTypeExtension.RelaxedAtomicOperations]);
 
     public IReadOnlySet<JsonApiMediaTypeExtension> Extensions { get; }

--- a/src/JsonApiDotNetCore/Middleware/JsonApiMediaTypeExtension.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiMediaTypeExtension.cs
@@ -9,6 +9,8 @@ namespace JsonApiDotNetCore.Middleware;
 public sealed class JsonApiMediaTypeExtension : IEquatable<JsonApiMediaTypeExtension>
 {
     public static readonly JsonApiMediaTypeExtension AtomicOperations = new("https://jsonapi.org/ext/atomic");
+
+    [Obsolete("This media type is no longer needed and will be removed in a future version. Use AtomicOperations instead.")]
     public static readonly JsonApiMediaTypeExtension RelaxedAtomicOperations = new("atomic");
 
     public string UnescapedValue { get; }

--- a/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
@@ -186,10 +186,12 @@ public sealed partial class JsonApiMiddleware
 
     private static void AssertNoAtomicOperationsExtension(IReadOnlySet<JsonApiMediaTypeExtension> extensions)
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         if (extensions.Contains(JsonApiMediaTypeExtension.AtomicOperations) || extensions.Contains(JsonApiMediaTypeExtension.RelaxedAtomicOperations))
         {
             throw new InvalidOperationException("Incorrect content negotiation implementation detected: Unexpected atomic:operations extension found.");
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     private static string? GetPrimaryRequestId(RouteValueDictionary routeValues)
@@ -225,10 +227,12 @@ public sealed partial class JsonApiMiddleware
 
     private static void AssertHasAtomicOperationsExtension(IReadOnlySet<JsonApiMediaTypeExtension> extensions)
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         if (!extensions.Contains(JsonApiMediaTypeExtension.AtomicOperations) && !extensions.Contains(JsonApiMediaTypeExtension.RelaxedAtomicOperations))
         {
             throw new InvalidOperationException("Incorrect content negotiation implementation detected: Missing atomic:operations extension.");
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     private static async Task FlushResponseAsync(HttpResponse httpResponse, JsonSerializerOptions serializerOptions, JsonApiException exception)

--- a/src/JsonApiDotNetCore/Middleware/JsonApiRoutingConvention.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiRoutingConvention.cs
@@ -122,7 +122,9 @@ public sealed partial class JsonApiRoutingConvention : IJsonApiRoutingConvention
             else
             {
                 var options = (JsonApiOptions)_options;
+#pragma warning disable CS0618 // Type or member is obsolete
                 options.IncludeExtensions(JsonApiMediaTypeExtension.AtomicOperations, JsonApiMediaTypeExtension.RelaxedAtomicOperations);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             if (IsRoutingConventionDisabled(controller))

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/AcceptHeaderTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/AcceptHeaderTests.cs
@@ -136,52 +136,6 @@ public sealed class AcceptHeaderTests : IClassFixture<IntegrationTestContext<Tes
     }
 
     [Fact]
-    public async Task Prefers_JsonApi_with_relaxed_AtomicOperations_extension_in_Accept_headers_at_operations_endpoint()
-    {
-        // Arrange
-        var requestBody = new
-        {
-            atomic__operations = new[]
-            {
-                new
-                {
-                    op = "add",
-                    data = new
-                    {
-                        type = "policies",
-                        attributes = new
-                        {
-                            name = "some"
-                        }
-                    }
-                }
-            }
-        };
-
-        const string route = "/operations";
-        string contentType = JsonApiMediaType.RelaxedAtomicOperations.ToString();
-
-        Action<HttpRequestHeaders> setRequestHeaders = headers =>
-        {
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("text/html"));
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default}; profile=some"));
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(JsonApiMediaType.Default.ToString()));
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default}; unknown=unexpected"));
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default};EXT=\"https://jsonapi.org/ext/atomic\"; q=0.8"));
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"{JsonApiMediaType.Default};EXT=atomic; q=0.2"));
-        };
-
-        // Act
-        (HttpResponseMessage httpResponse, _) = await _testContext.ExecutePostAsync<Document>(route, requestBody, contentType, setRequestHeaders);
-
-        // Assert
-        httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
-
-        httpResponse.Content.Headers.ContentType.Should().NotBeNull();
-        httpResponse.Content.Headers.ContentType.ToString().Should().Be(JsonApiMediaType.RelaxedAtomicOperations.ToString());
-    }
-
-    [Fact]
     public async Task Denies_JsonApi_with_parameters_in_Accept_headers()
     {
         // Arrange
@@ -254,7 +208,9 @@ public sealed class AcceptHeaderTests : IClassFixture<IntegrationTestContext<Tes
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
         error.Title.Should().Be("The specified Accept header value does not contain any supported media types.");
+#pragma warning disable CS0618 // Type or member is obsolete
         error.Detail.Should().Be($"Include '{JsonApiMediaType.AtomicOperations}' or '{JsonApiMediaType.RelaxedAtomicOperations}' in the Accept header values.");
+#pragma warning restore CS0618 // Type or member is obsolete
         error.Source.Should().NotBeNull();
         error.Source.Header.Should().Be("Accept");
     }
@@ -300,7 +256,9 @@ public sealed class AcceptHeaderTests : IClassFixture<IntegrationTestContext<Tes
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
         error.Title.Should().Be("The specified Accept header value does not contain any supported media types.");
+#pragma warning disable CS0618 // Type or member is obsolete
         error.Detail.Should().Be($"Include '{JsonApiMediaType.AtomicOperations}' or '{JsonApiMediaType.RelaxedAtomicOperations}' in the Accept header values.");
+#pragma warning restore CS0618 // Type or member is obsolete
         error.Source.Should().NotBeNull();
         error.Source.Header.Should().Be("Accept");
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/ContentTypeHeaderTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/ContentTypeHeaderTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Net.Http.Headers;
 using FluentAssertions;
 using JsonApiDotNetCore.Middleware;
 using JsonApiDotNetCore.Serialization.Objects;
@@ -69,45 +68,6 @@ public sealed class ContentTypeHeaderTests : IClassFixture<IntegrationTestContex
 
         httpResponse.Content.Headers.ContentType.Should().NotBeNull();
         httpResponse.Content.Headers.ContentType.ToString().Should().Be(JsonApiMediaType.AtomicOperations.ToString());
-    }
-
-    [Fact]
-    public async Task Returns_JsonApi_ContentType_header_with_relaxed_AtomicOperations_extension()
-    {
-        // Arrange
-        var requestBody = new
-        {
-            atomic__operations = new[]
-            {
-                new
-                {
-                    op = "add",
-                    data = new
-                    {
-                        type = "policies",
-                        attributes = new
-                        {
-                            name = "some"
-                        }
-                    }
-                }
-            }
-        };
-
-        const string route = "/operations";
-        string contentType = JsonApiMediaType.RelaxedAtomicOperations.ToString();
-
-        Action<HttpRequestHeaders> setRequestHeaders = headers =>
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(JsonApiMediaType.RelaxedAtomicOperations.ToString()));
-
-        // Act
-        (HttpResponseMessage httpResponse, _) = await _testContext.ExecutePostAsync<Document>(route, requestBody, contentType, setRequestHeaders);
-
-        // Assert
-        httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
-
-        httpResponse.Content.Headers.ContentType.Should().NotBeNull();
-        httpResponse.Content.Headers.ContentType.ToString().Should().Be(JsonApiMediaType.RelaxedAtomicOperations.ToString());
     }
 
     [Fact]
@@ -185,8 +145,10 @@ public sealed class ContentTypeHeaderTests : IClassFixture<IntegrationTestContex
 
         responseDocument.Errors.Should().HaveCount(1);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         string detail =
             $"Use '{JsonApiMediaType.AtomicOperations}' or '{JsonApiMediaType.RelaxedAtomicOperations}' instead of 'text/html' for the Content-Type header value.";
+#pragma warning restore CS0618 // Type or member is obsolete
 
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
@@ -326,8 +288,10 @@ public sealed class ContentTypeHeaderTests : IClassFixture<IntegrationTestContex
 
         responseDocument.Errors.Should().HaveCount(1);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         string detail =
             $"Use '{JsonApiMediaType.AtomicOperations}' or '{JsonApiMediaType.RelaxedAtomicOperations}' instead of '{contentType}' for the Content-Type header value.";
+#pragma warning restore CS0618 // Type or member is obsolete
 
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
@@ -335,45 +299,6 @@ public sealed class ContentTypeHeaderTests : IClassFixture<IntegrationTestContex
         error.Detail.Should().Be(detail);
         error.Source.Should().NotBeNull();
         error.Source.Header.Should().Be("Content-Type");
-    }
-
-    [Fact]
-    public async Task Permits_JsonApi_ContentType_header_with_relaxed_AtomicOperations_extension_at_operations_endpoint()
-    {
-        // Arrange
-        var requestBody = new
-        {
-            atomic__operations = new[]
-            {
-                new
-                {
-                    op = "add",
-                    data = new
-                    {
-                        type = "policies",
-                        attributes = new
-                        {
-                            name = "some"
-                        }
-                    }
-                }
-            }
-        };
-
-        const string route = "/operations";
-        string contentType = JsonApiMediaType.RelaxedAtomicOperations.ToString();
-
-        Action<HttpRequestHeaders> setRequestHeaders = headers =>
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(JsonApiMediaType.RelaxedAtomicOperations.ToString()));
-
-        // Act
-        (HttpResponseMessage httpResponse, _) = await _testContext.ExecutePostAsync<Document>(route, requestBody, contentType, setRequestHeaders);
-
-        // Assert
-        httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
-
-        httpResponse.Content.Headers.ContentType.Should().NotBeNull();
-        httpResponse.Content.Headers.ContentType.ToString().Should().Be(JsonApiMediaType.RelaxedAtomicOperations.ToString());
     }
 
     [Fact]
@@ -432,44 +357,6 @@ public sealed class ContentTypeHeaderTests : IClassFixture<IntegrationTestContex
 
         const string route = "/policies";
         string contentType = JsonApiMediaType.AtomicOperations.ToString();
-
-        // Act
-        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody, contentType);
-
-        // Assert
-        httpResponse.ShouldHaveStatusCode(HttpStatusCode.UnsupportedMediaType);
-
-        httpResponse.Content.Headers.ContentType.Should().NotBeNull();
-        httpResponse.Content.Headers.ContentType.ToString().Should().Be(JsonApiMediaType.Default.ToString());
-
-        responseDocument.Errors.Should().HaveCount(1);
-
-        ErrorObject error = responseDocument.Errors[0];
-        error.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
-        error.Title.Should().Be("The specified Content-Type header value is not supported.");
-        error.Detail.Should().Be($"Use '{JsonApiMediaType.Default}' instead of '{contentType}' for the Content-Type header value.");
-        error.Source.Should().NotBeNull();
-        error.Source.Header.Should().Be("Content-Type");
-    }
-
-    [Fact]
-    public async Task Denies_JsonApi_ContentType_header_with_relaxed_AtomicOperations_extension_at_resource_endpoint()
-    {
-        // Arrange
-        var requestBody = new
-        {
-            data = new
-            {
-                type = "policies",
-                attributes = new
-                {
-                    name = "some"
-                }
-            }
-        };
-
-        const string route = "/policies";
-        string contentType = JsonApiMediaType.RelaxedAtomicOperations.ToString();
 
         // Act
         (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody, contentType);
@@ -641,8 +528,10 @@ public sealed class ContentTypeHeaderTests : IClassFixture<IntegrationTestContex
 
         responseDocument.Errors.Should().HaveCount(1);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         string detail =
             $"Use '{JsonApiMediaType.AtomicOperations}' or '{JsonApiMediaType.RelaxedAtomicOperations}' instead of '{contentType}' for the Content-Type header value.";
+#pragma warning restore CS0618 // Type or member is obsolete
 
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/CustomExtensionsAcceptHeaderTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/CustomExtensionsAcceptHeaderTests.cs
@@ -30,7 +30,7 @@ public sealed class CustomExtensionsAcceptHeaderTests : IClassFixture<Integratio
         });
 
         var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
-        options.IncludeExtensions(ServerTimeMediaTypeExtension.ServerTime, ServerTimeMediaTypeExtension.RelaxedServerTime);
+        options.IncludeExtensions(ServerTimeMediaTypeExtension.ServerTime);
     }
 
     [Fact]
@@ -68,7 +68,6 @@ public sealed class CustomExtensionsAcceptHeaderTests : IClassFixture<Integratio
         {
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("text/html"));
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(JsonApiMediaType.Default.ToString()));
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ServerTimeMediaTypes.RelaxedServerTime.ToString()));
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ServerTimeMediaTypes.ServerTime.ToString()));
         };
 
@@ -143,8 +142,8 @@ public sealed class CustomExtensionsAcceptHeaderTests : IClassFixture<Integratio
 
         responseDocument.Errors.Should().HaveCount(1);
 
-        string detail = $"Include '{JsonApiMediaType.AtomicOperations}' or '{ServerTimeMediaTypes.AtomicOperationsWithServerTime}' or " +
-            $"'{JsonApiMediaType.RelaxedAtomicOperations}' or '{ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime}' in the Accept header values.";
+        string detail =
+            $"Include '{JsonApiMediaType.AtomicOperations}' or '{ServerTimeMediaTypes.AtomicOperationsWithServerTime}' in the Accept header values.";
 
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/CustomExtensionsAcceptHeaderTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/CustomExtensionsAcceptHeaderTests.cs
@@ -30,7 +30,9 @@ public sealed class CustomExtensionsAcceptHeaderTests : IClassFixture<Integratio
         });
 
         var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
-        options.IncludeExtensions(ServerTimeMediaTypeExtension.ServerTime);
+#pragma warning disable CS0618 // Type or member is obsolete
+        options.IncludeExtensions(ServerTimeMediaTypeExtension.ServerTime, ServerTimeMediaTypeExtension.RelaxedServerTime);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     [Fact]
@@ -68,6 +70,9 @@ public sealed class CustomExtensionsAcceptHeaderTests : IClassFixture<Integratio
         {
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("text/html"));
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(JsonApiMediaType.Default.ToString()));
+#pragma warning disable CS0618 // Type or member is obsolete
+            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ServerTimeMediaTypes.RelaxedServerTime.ToString()));
+#pragma warning restore CS0618 // Type or member is obsolete
             headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ServerTimeMediaTypes.ServerTime.ToString()));
         };
 
@@ -142,8 +147,10 @@ public sealed class CustomExtensionsAcceptHeaderTests : IClassFixture<Integratio
 
         responseDocument.Errors.Should().HaveCount(1);
 
-        string detail =
-            $"Include '{JsonApiMediaType.AtomicOperations}' or '{ServerTimeMediaTypes.AtomicOperationsWithServerTime}' in the Accept header values.";
+#pragma warning disable CS0618 // Type or member is obsolete
+        string detail = $"Include '{JsonApiMediaType.AtomicOperations}' or '{ServerTimeMediaTypes.AtomicOperationsWithServerTime}' or " +
+            $"'{JsonApiMediaType.RelaxedAtomicOperations}' or '{ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime}' in the Accept header values.";
+#pragma warning restore CS0618 // Type or member is obsolete
 
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/CustomExtensionsContentTypeTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/CustomExtensionsContentTypeTests.cs
@@ -46,7 +46,7 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
             ServiceDescriptor.Singleton<TimeProvider>(new FrozenTimeProvider(CurrentTime, TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time")))));
 
         var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
-        options.IncludeExtensions(ServerTimeMediaTypeExtension.ServerTime, ServerTimeMediaTypeExtension.RelaxedServerTime);
+        options.IncludeExtensions(ServerTimeMediaTypeExtension.ServerTime);
     }
 
     [Fact]
@@ -119,42 +119,6 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
     }
 
     [Fact]
-    public async Task Permits_JsonApi_ContentType_header_with_relaxed_ServerTime_extension()
-    {
-        // Arrange
-        var requestBody = new
-        {
-            data = new
-            {
-                type = "policies",
-                attributes = new
-                {
-                    name = "some"
-                }
-            }
-        };
-
-        const string route = "/policies";
-        string contentType = ServerTimeMediaTypes.RelaxedServerTime.ToString();
-
-        Action<HttpRequestHeaders> setRequestHeaders = headers =>
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ServerTimeMediaTypes.RelaxedServerTime.ToString()));
-
-        // Act
-        (HttpResponseMessage httpResponse, Document responseDocument) =
-            await _testContext.ExecutePostAsync<Document>(route, requestBody, contentType, setRequestHeaders);
-
-        // Assert
-        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Created);
-
-        httpResponse.Content.Headers.ContentType.Should().NotBeNull();
-        httpResponse.Content.Headers.ContentType.ToString().Should().Be(ServerTimeMediaTypes.RelaxedServerTime.ToString());
-
-        responseDocument.Meta.Should().ContainKey("utcServerTime").WhoseValue.Should().NotBeNull().And.Subject.ToString().Should()
-            .Be("2024-12-31T21:53:40.0000000Z");
-    }
-
-    [Fact]
     public async Task Permits_JsonApi_ContentType_header_with_AtomicOperations_and_ServerTime_extension_at_operations_endpoint()
     {
         // Arrange
@@ -198,53 +162,6 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
     }
 
     [Fact]
-    public async Task Permits_JsonApi_ContentType_header_with_relaxed_AtomicOperations_and_relaxed_ServerTime_extension_at_operations_endpoint()
-    {
-        // Arrange
-        var requestBody = new
-        {
-            meta = new
-            {
-                useLocalTime = true
-            },
-
-            atomic__operations = new[]
-            {
-                new
-                {
-                    op = "add",
-                    data = new
-                    {
-                        type = "policies",
-                        attributes = new
-                        {
-                            name = "some"
-                        }
-                    }
-                }
-            }
-        };
-
-        const string route = "/operations";
-        string contentType = ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime.ToString();
-
-        Action<HttpRequestHeaders> setRequestHeaders = headers =>
-            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime.ToString()));
-
-        // Act
-        (HttpResponseMessage httpResponse, Document responseDocument) =
-            await _testContext.ExecutePostAsync<Document>(route, requestBody, contentType, setRequestHeaders);
-
-        // Assert
-        httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
-
-        httpResponse.Content.Headers.ContentType.Should().NotBeNull();
-        httpResponse.Content.Headers.ContentType.ToString().Should().Be(ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime.ToString());
-
-        responseDocument.Meta.Should().ContainKey("localServerTime");
-    }
-
-    [Fact]
     public async Task Denies_JsonApi_ContentType_header_with_AtomicOperations_extension_and_ServerTime_at_resource_endpoint()
     {
         // Arrange
@@ -274,8 +191,8 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
 
         responseDocument.Errors.Should().HaveCount(1);
 
-        string detail = $"Use '{JsonApiMediaType.Default}' or '{ServerTimeMediaTypes.ServerTime}' or " +
-            $"'{ServerTimeMediaTypes.RelaxedServerTime}' instead of '{contentType}' for the Content-Type header value.";
+        string detail =
+            $"Use '{JsonApiMediaType.Default}' or '{ServerTimeMediaTypes.ServerTime}' instead of '{contentType}' for the Content-Type header value.";
 
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
@@ -286,7 +203,7 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
     }
 
     [Fact]
-    public async Task Denies_JsonApi_ContentType_header_with_relaxed_ServerTime_at_operations_endpoint()
+    public async Task Denies_JsonApi_ContentType_header_with_ServerTime_at_operations_endpoint()
     {
         // Arrange
         var requestBody = new
@@ -309,7 +226,7 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
         };
 
         const string route = "/operations";
-        string contentType = ServerTimeMediaTypes.RelaxedServerTime.ToString();
+        string contentType = ServerTimeMediaTypes.ServerTime.ToString();
 
         // Act
         (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody, contentType);
@@ -322,9 +239,8 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
 
         responseDocument.Errors.Should().HaveCount(1);
 
-        string detail = $"Use '{JsonApiMediaType.AtomicOperations}' or '{ServerTimeMediaTypes.AtomicOperationsWithServerTime}' or " +
-            $"'{JsonApiMediaType.RelaxedAtomicOperations}' or '{ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime}' " +
-            $"instead of '{contentType}' for the Content-Type header value.";
+        string detail =
+            $"Use '{JsonApiMediaType.AtomicOperations}' or '{ServerTimeMediaTypes.AtomicOperationsWithServerTime}' instead of '{contentType}' for the Content-Type header value.";
 
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/CustomExtensionsContentTypeTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/CustomExtensionsContentTypeTests.cs
@@ -46,7 +46,9 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
             ServiceDescriptor.Singleton<TimeProvider>(new FrozenTimeProvider(CurrentTime, TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time")))));
 
         var options = (JsonApiOptions)_testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
-        options.IncludeExtensions(ServerTimeMediaTypeExtension.ServerTime);
+#pragma warning disable CS0618 // Type or member is obsolete
+        options.IncludeExtensions(ServerTimeMediaTypeExtension.ServerTime, ServerTimeMediaTypeExtension.RelaxedServerTime);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     [Fact]
@@ -118,6 +120,44 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
             .Be("2025-01-01T06:53:40.0000000+09:00");
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
+    [Fact]
+    public async Task Permits_JsonApi_ContentType_header_with_relaxed_ServerTime_extension()
+    {
+        // Arrange
+        var requestBody = new
+        {
+            data = new
+            {
+                type = "policies",
+                attributes = new
+                {
+                    name = "some"
+                }
+            }
+        };
+
+        const string route = "/policies";
+        string contentType = ServerTimeMediaTypes.RelaxedServerTime.ToString();
+
+        Action<HttpRequestHeaders> setRequestHeaders = headers =>
+            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ServerTimeMediaTypes.RelaxedServerTime.ToString()));
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) =
+            await _testContext.ExecutePostAsync<Document>(route, requestBody, contentType, setRequestHeaders);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Created);
+
+        httpResponse.Content.Headers.ContentType.Should().NotBeNull();
+        httpResponse.Content.Headers.ContentType.ToString().Should().Be(ServerTimeMediaTypes.RelaxedServerTime.ToString());
+
+        responseDocument.Meta.Should().ContainKey("utcServerTime").WhoseValue.Should().NotBeNull().And.Subject.ToString().Should()
+            .Be("2024-12-31T21:53:40.0000000Z");
+    }
+#pragma warning restore CS0618 // Type or member is obsolete
+
     [Fact]
     public async Task Permits_JsonApi_ContentType_header_with_AtomicOperations_and_ServerTime_extension_at_operations_endpoint()
     {
@@ -161,6 +201,55 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
             .Be("2024-12-31T21:53:40.0000000Z");
     }
 
+#pragma warning disable CS0618 // Type or member is obsolete
+    [Fact]
+    public async Task Permits_JsonApi_ContentType_header_with_relaxed_AtomicOperations_and_relaxed_ServerTime_extension_at_operations_endpoint()
+    {
+        // Arrange
+        var requestBody = new
+        {
+            meta = new
+            {
+                useLocalTime = true
+            },
+
+            atomic__operations = new[]
+            {
+                new
+                {
+                    op = "add",
+                    data = new
+                    {
+                        type = "policies",
+                        attributes = new
+                        {
+                            name = "some"
+                        }
+                    }
+                }
+            }
+        };
+
+        const string route = "/operations";
+        string contentType = ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime.ToString();
+
+        Action<HttpRequestHeaders> setRequestHeaders = headers =>
+            headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime.ToString()));
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) =
+            await _testContext.ExecutePostAsync<Document>(route, requestBody, contentType, setRequestHeaders);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
+
+        httpResponse.Content.Headers.ContentType.Should().NotBeNull();
+        httpResponse.Content.Headers.ContentType.ToString().Should().Be(ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime.ToString());
+
+        responseDocument.Meta.Should().ContainKey("localServerTime");
+    }
+#pragma warning restore CS0618 // Type or member is obsolete
+
     [Fact]
     public async Task Denies_JsonApi_ContentType_header_with_AtomicOperations_extension_and_ServerTime_at_resource_endpoint()
     {
@@ -191,8 +280,10 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
 
         responseDocument.Errors.Should().HaveCount(1);
 
-        string detail =
-            $"Use '{JsonApiMediaType.Default}' or '{ServerTimeMediaTypes.ServerTime}' instead of '{contentType}' for the Content-Type header value.";
+#pragma warning disable CS0618 // Type or member is obsolete
+        string detail = $"Use '{JsonApiMediaType.Default}' or '{ServerTimeMediaTypes.ServerTime}' or " +
+            $"'{ServerTimeMediaTypes.RelaxedServerTime}' instead of '{contentType}' for the Content-Type header value.";
+#pragma warning restore CS0618 // Type or member is obsolete
 
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
@@ -239,8 +330,11 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
 
         responseDocument.Errors.Should().HaveCount(1);
 
-        string detail =
-            $"Use '{JsonApiMediaType.AtomicOperations}' or '{ServerTimeMediaTypes.AtomicOperationsWithServerTime}' instead of '{contentType}' for the Content-Type header value.";
+#pragma warning disable CS0618 // Type or member is obsolete
+        string detail = $"Use '{JsonApiMediaType.AtomicOperations}' or '{ServerTimeMediaTypes.AtomicOperationsWithServerTime}' or " +
+            $"'{JsonApiMediaType.RelaxedAtomicOperations}' or '{ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime}' " +
+            $"instead of '{contentType}' for the Content-Type header value.";
+#pragma warning restore CS0618 // Type or member is obsolete
 
         ErrorObject error = responseDocument.Errors[0];
         error.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
@@ -249,4 +343,55 @@ public sealed class CustomExtensionsContentTypeTests : IClassFixture<Integration
         error.Source.Should().NotBeNull();
         error.Source.Header.Should().Be("Content-Type");
     }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+    [Fact]
+    public async Task Denies_JsonApi_ContentType_header_with_relaxed_ServerTime_at_operations_endpoint()
+    {
+        // Arrange
+        var requestBody = new
+        {
+            atomic__operations = new[]
+            {
+                new
+                {
+                    op = "add",
+                    data = new
+                    {
+                        type = "policies",
+                        attributes = new
+                        {
+                            name = "some"
+                        }
+                    }
+                }
+            }
+        };
+
+        const string route = "/operations";
+        string contentType = ServerTimeMediaTypes.RelaxedServerTime.ToString();
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecutePostAsync<Document>(route, requestBody, contentType);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.UnsupportedMediaType);
+
+        httpResponse.Content.Headers.ContentType.Should().NotBeNull();
+        httpResponse.Content.Headers.ContentType.ToString().Should().Be(JsonApiMediaType.Default.ToString());
+
+        responseDocument.Errors.Should().HaveCount(1);
+
+        string detail = $"Use '{JsonApiMediaType.AtomicOperations}' or '{ServerTimeMediaTypes.AtomicOperationsWithServerTime}' or " +
+            $"'{JsonApiMediaType.RelaxedAtomicOperations}' or '{ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime}' " +
+            $"instead of '{contentType}' for the Content-Type header value.";
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        error.Title.Should().Be("The specified Content-Type header value is not supported.");
+        error.Detail.Should().Be(detail);
+        error.Source.Should().NotBeNull();
+        error.Source.Header.Should().Be("Content-Type");
+    }
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeContentNegotiator.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeContentNegotiator.cs
@@ -13,8 +13,6 @@ internal sealed class ServerTimeContentNegotiator(IJsonApiOptions options, IHttp
     {
         List<JsonApiMediaType> mediaTypes = [];
 
-        // Relaxed entries come after JSON:API compliant entries, which makes them less likely to be selected.
-
         if (IsOperationsEndpoint())
         {
             if (_options.Extensions.Contains(JsonApiMediaTypeExtension.AtomicOperations))
@@ -27,17 +25,6 @@ internal sealed class ServerTimeContentNegotiator(IJsonApiOptions options, IHttp
             {
                 mediaTypes.Add(ServerTimeMediaTypes.AtomicOperationsWithServerTime);
             }
-
-            if (_options.Extensions.Contains(JsonApiMediaTypeExtension.RelaxedAtomicOperations))
-            {
-                mediaTypes.Add(JsonApiMediaType.RelaxedAtomicOperations);
-            }
-
-            if (_options.Extensions.Contains(JsonApiMediaTypeExtension.RelaxedAtomicOperations) &&
-                _options.Extensions.Contains(ServerTimeMediaTypeExtension.RelaxedServerTime))
-            {
-                mediaTypes.Add(ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime);
-            }
         }
         else
         {
@@ -46,11 +33,6 @@ internal sealed class ServerTimeContentNegotiator(IJsonApiOptions options, IHttp
             if (_options.Extensions.Contains(ServerTimeMediaTypeExtension.ServerTime))
             {
                 mediaTypes.Add(ServerTimeMediaTypes.ServerTime);
-            }
-
-            if (_options.Extensions.Contains(ServerTimeMediaTypeExtension.RelaxedServerTime))
-            {
-                mediaTypes.Add(ServerTimeMediaTypes.RelaxedServerTime);
             }
         }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeContentNegotiator.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeContentNegotiator.cs
@@ -13,6 +13,9 @@ internal sealed class ServerTimeContentNegotiator(IJsonApiOptions options, IHttp
     {
         List<JsonApiMediaType> mediaTypes = [];
 
+        // Relaxed entries come after JSON:API compliant entries, which makes them less likely to be selected.
+
+#pragma warning disable CS0618 // Type or member is obsolete
         if (IsOperationsEndpoint())
         {
             if (_options.Extensions.Contains(JsonApiMediaTypeExtension.AtomicOperations))
@@ -25,6 +28,17 @@ internal sealed class ServerTimeContentNegotiator(IJsonApiOptions options, IHttp
             {
                 mediaTypes.Add(ServerTimeMediaTypes.AtomicOperationsWithServerTime);
             }
+
+            if (_options.Extensions.Contains(JsonApiMediaTypeExtension.RelaxedAtomicOperations))
+            {
+                mediaTypes.Add(JsonApiMediaType.RelaxedAtomicOperations);
+            }
+
+            if (_options.Extensions.Contains(JsonApiMediaTypeExtension.RelaxedAtomicOperations) &&
+                _options.Extensions.Contains(ServerTimeMediaTypeExtension.RelaxedServerTime))
+            {
+                mediaTypes.Add(ServerTimeMediaTypes.RelaxedAtomicOperationsWithRelaxedServerTime);
+            }
         }
         else
         {
@@ -34,7 +48,13 @@ internal sealed class ServerTimeContentNegotiator(IJsonApiOptions options, IHttp
             {
                 mediaTypes.Add(ServerTimeMediaTypes.ServerTime);
             }
+
+            if (_options.Extensions.Contains(ServerTimeMediaTypeExtension.RelaxedServerTime))
+            {
+                mediaTypes.Add(ServerTimeMediaTypes.RelaxedServerTime);
+            }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         return mediaTypes.AsReadOnly();
     }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeMediaTypeExtension.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeMediaTypeExtension.cs
@@ -7,5 +7,4 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ContentNegotiation.CustomExten
 internal static class ServerTimeMediaTypeExtension
 {
     public static readonly JsonApiMediaTypeExtension ServerTime = new("https://www.jsonapi.net/ext/server-time");
-    public static readonly JsonApiMediaTypeExtension RelaxedServerTime = new("server-time");
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeMediaTypeExtension.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeMediaTypeExtension.cs
@@ -7,4 +7,7 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ContentNegotiation.CustomExten
 internal static class ServerTimeMediaTypeExtension
 {
     public static readonly JsonApiMediaTypeExtension ServerTime = new("https://www.jsonapi.net/ext/server-time");
+
+    [Obsolete("This media type is no longer needed and will be removed in a future version. Use ServerTime instead.")]
+    public static readonly JsonApiMediaTypeExtension RelaxedServerTime = new("server-time");
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeMediaTypes.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeMediaTypes.cs
@@ -7,15 +7,9 @@ namespace JsonApiDotNetCoreTests.IntegrationTests.ContentNegotiation.CustomExten
 internal static class ServerTimeMediaTypes
 {
     public static readonly JsonApiMediaType ServerTime = new([ServerTimeMediaTypeExtension.ServerTime]);
-    public static readonly JsonApiMediaType RelaxedServerTime = new([ServerTimeMediaTypeExtension.RelaxedServerTime]);
 
     public static readonly JsonApiMediaType AtomicOperationsWithServerTime = new([
         JsonApiMediaTypeExtension.AtomicOperations,
         ServerTimeMediaTypeExtension.ServerTime
-    ]);
-
-    public static readonly JsonApiMediaType RelaxedAtomicOperationsWithRelaxedServerTime = new([
-        JsonApiMediaTypeExtension.RelaxedAtomicOperations,
-        ServerTimeMediaTypeExtension.RelaxedServerTime
     ]);
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeMediaTypes.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeMediaTypes.cs
@@ -8,8 +8,17 @@ internal static class ServerTimeMediaTypes
 {
     public static readonly JsonApiMediaType ServerTime = new([ServerTimeMediaTypeExtension.ServerTime]);
 
+    [Obsolete("This media type is no longer needed and will be removed in a future version. Use ServerTime instead.")]
+    public static readonly JsonApiMediaType RelaxedServerTime = new([ServerTimeMediaTypeExtension.RelaxedServerTime]);
+
     public static readonly JsonApiMediaType AtomicOperationsWithServerTime = new([
         JsonApiMediaTypeExtension.AtomicOperations,
         ServerTimeMediaTypeExtension.ServerTime
+    ]);
+
+    [Obsolete("This media type is no longer needed and will be removed in a future version. Use AtomicOperationsWithServerTime instead.")]
+    public static readonly JsonApiMediaType RelaxedAtomicOperationsWithRelaxedServerTime = new([
+        JsonApiMediaTypeExtension.RelaxedAtomicOperations,
+        ServerTimeMediaTypeExtension.RelaxedServerTime
     ]);
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeResponseMeta.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeResponseMeta.cs
@@ -12,7 +12,10 @@ internal sealed class ServerTimeResponseMeta(IJsonApiRequest request, RequestDoc
 
     public IDictionary<string, object?>? GetMeta()
     {
-        if (_request.Extensions.Contains(ServerTimeMediaTypeExtension.ServerTime))
+#pragma warning disable CS0618 // Type or member is obsolete
+        if (_request.Extensions.Contains(ServerTimeMediaTypeExtension.ServerTime) ||
+            _request.Extensions.Contains(ServerTimeMediaTypeExtension.RelaxedServerTime))
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             if (_documentStore.Document is not { Meta: not null } || !_documentStore.Document.Meta.TryGetValue("useLocalTime", out object? useLocalTimeValue) ||
                 useLocalTimeValue == null || !bool.TryParse(useLocalTimeValue.ToString(), out bool useLocalTime))

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeResponseMeta.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeResponseMeta.cs
@@ -12,8 +12,7 @@ internal sealed class ServerTimeResponseMeta(IJsonApiRequest request, RequestDoc
 
     public IDictionary<string, object?>? GetMeta()
     {
-        if (_request.Extensions.Contains(ServerTimeMediaTypeExtension.ServerTime) ||
-            _request.Extensions.Contains(ServerTimeMediaTypeExtension.RelaxedServerTime))
+        if (_request.Extensions.Contains(ServerTimeMediaTypeExtension.ServerTime))
         {
             if (_documentStore.Document is not { Meta: not null } || !_documentStore.Document.Meta.TryGetValue("useLocalTime", out object? useLocalTimeValue) ||
                 useLocalTimeValue == null || !bool.TryParse(useLocalTimeValue.ToString(), out bool useLocalTime))

--- a/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Operations/OperationsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/AtomicOperations/GeneratedCode/Operations/OperationsRequestBuilder.cs
@@ -75,8 +75,8 @@ namespace OpenApiKiotaEndToEndTests.AtomicOperations.GeneratedCode.Operations
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=atomic;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=atomic;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/AttributeTypes/GeneratedCode/TypeContainers/Item/TypeContainersItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/AttributeTypes/GeneratedCode/TypeContainers/Item/TypeContainersItemRequestBuilder.cs
@@ -117,7 +117,7 @@ namespace OpenApiKiotaEndToEndTests.AttributeTypes.GeneratedCode.TypeContainers.
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -130,7 +130,7 @@ namespace OpenApiKiotaEndToEndTests.AttributeTypes.GeneratedCode.TypeContainers.
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -157,8 +157,8 @@ namespace OpenApiKiotaEndToEndTests.AttributeTypes.GeneratedCode.TypeContainers.
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/AttributeTypes/GeneratedCode/TypeContainers/TypeContainersRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/AttributeTypes/GeneratedCode/TypeContainers/TypeContainersRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.AttributeTypes.GeneratedCode.TypeContainers
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.AttributeTypes.GeneratedCode.TypeContainers
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Games/GamesRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Games/GamesRequestBuilder.cs
@@ -73,8 +73,8 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Games
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/PlayerGroups/PlayerGroupsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/PlayerGroups/PlayerGroupsRequestBuilder.cs
@@ -75,8 +75,8 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Player
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Players/PlayersRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ClientIdGenerationModes/GeneratedCode/Players/PlayersRequestBuilder.cs
@@ -73,8 +73,8 @@ namespace OpenApiKiotaEndToEndTests.ClientIdGenerationModes.GeneratedCode.Player
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Countries/CountriesRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Countries/CountriesRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Countries/Item/CountriesItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Countries/Item/CountriesItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries.Item
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries.Item
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries.Item
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Countries/Item/Languages/LanguagesRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Countries/Item/Languages/LanguagesRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries.Item.Languag
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Countries/Item/Relationships/Languages/LanguagesRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Headers/GeneratedCode/Countries/Item/Relationships/Languages/LanguagesRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries.Item.Relatio
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries.Item.Relatio
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries.Item.Relatio
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.Headers.GeneratedCode.Countries.Item.Relatio
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/BankAccounts/BankAccountsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/BankAccounts/BankAccountsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.BankAccounts
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.BankAccounts
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/BankAccounts/Item/BankAccountsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/BankAccounts/Item/BankAccountsItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.BankAccounts.Ite
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.BankAccounts.Ite
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.BankAccounts.Ite
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/BankAccounts/Item/Cards/CardsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/BankAccounts/Item/Cards/CardsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.BankAccounts.Ite
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/BankAccounts/Item/Relationships/Cards/CardsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/BankAccounts/Item/Relationships/Cards/CardsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.BankAccounts.Ite
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.BankAccounts.Ite
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.BankAccounts.Ite
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.BankAccounts.Ite
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/DebitCards/DebitCardsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/DebitCards/DebitCardsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.DebitCards
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.DebitCards
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/DebitCards/Item/Account/AccountRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/DebitCards/Item/Account/AccountRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.DebitCards.Item.
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/DebitCards/Item/DebitCardsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/DebitCards/Item/DebitCardsItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.DebitCards.Item
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.DebitCards.Item
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.DebitCards.Item
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/DebitCards/Item/Relationships/Account/AccountRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/DebitCards/Item/Relationships/Account/AccountRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.DebitCards.Item.
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.DebitCards.Item.
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/Operations/OperationsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/IdObfuscation/GeneratedCode/Operations/OperationsRequestBuilder.cs
@@ -75,8 +75,8 @@ namespace OpenApiKiotaEndToEndTests.IdObfuscation.GeneratedCode.Operations
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=atomic;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=atomic;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Accommodations/AccommodationsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Accommodations/AccommodationsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Accommodations
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Accommodations
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Accommodations/Item/AccommodationsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Accommodations/Item/AccommodationsItemRequestBuilder.cs
@@ -117,7 +117,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Accommodations.Item
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -130,7 +130,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Accommodations.Item
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -157,8 +157,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Accommodations.Item
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Excursions/ExcursionsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Excursions/ExcursionsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Excursions
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Excursions
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Excursions/Item/ExcursionsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Excursions/Item/ExcursionsItemRequestBuilder.cs
@@ -117,7 +117,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Excursions.Item
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -130,7 +130,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Excursions.Item
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -157,8 +157,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Excursions.Item
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Transports/Item/TransportsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Transports/Item/TransportsItemRequestBuilder.cs
@@ -117,7 +117,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Transports.Item
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -130,7 +130,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Transports.Item
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -157,8 +157,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Transports.Item
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Transports/TransportsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Transports/TransportsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Transports
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Transports
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/Accommodation/AccommodationRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/Accommodation/AccommodationRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item.Accommoda
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/Excursions/ExcursionsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/Excursions/ExcursionsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item.Excursion
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/Relationships/Accommodation/AccommodationRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/Relationships/Accommodation/AccommodationRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item.Relations
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item.Relations
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/Relationships/Excursions/ExcursionsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/Relationships/Excursions/ExcursionsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item.Relations
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item.Relations
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item.Relations
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item.Relations
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/Relationships/Transport/TransportRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/Relationships/Transport/TransportRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item.Relations
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item.Relations
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/Transport/TransportRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/Transport/TransportRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item.Transport
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/VacationsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/Item/VacationsItemRequestBuilder.cs
@@ -145,7 +145,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -158,7 +158,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -185,8 +185,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations.Item
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/VacationsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/Links/GeneratedCode/Vacations/VacationsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.Links.GeneratedCode.Vacations
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/MixedControllers/GeneratedCode/CoffeeSummaries/Summary/SummaryRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/MixedControllers/GeneratedCode/CoffeeSummaries/Summary/SummaryRequestBuilder.cs
@@ -75,7 +75,7 @@ namespace OpenApiKiotaEndToEndTests.MixedControllers.GeneratedCode.CoffeeSummari
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/MixedControllers/GeneratedCode/CupOfCoffees/Batch/BatchRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/MixedControllers/GeneratedCode/CupOfCoffees/Batch/BatchRequestBuilder.cs
@@ -91,7 +91,7 @@ namespace OpenApiKiotaEndToEndTests.MixedControllers.GeneratedCode.CupOfCoffees.
         {
             var requestInfo = new RequestInformation(Method.DELETE, "{+baseurl}/cupOfCoffees/batch", PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -118,8 +118,8 @@ namespace OpenApiKiotaEndToEndTests.MixedControllers.GeneratedCode.CupOfCoffees.
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/MixedControllers/GeneratedCode/CupOfCoffees/CupOfCoffeesRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/MixedControllers/GeneratedCode/CupOfCoffees/CupOfCoffeesRequestBuilder.cs
@@ -102,7 +102,7 @@ namespace OpenApiKiotaEndToEndTests.MixedControllers.GeneratedCode.CupOfCoffees
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/MixedControllers/GeneratedCode/CupOfCoffees/Item/CupOfCoffeesItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/MixedControllers/GeneratedCode/CupOfCoffees/Item/CupOfCoffeesItemRequestBuilder.cs
@@ -62,7 +62,7 @@ namespace OpenApiKiotaEndToEndTests.MixedControllers.GeneratedCode.CupOfCoffees.
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/MixedControllers/GeneratedCode/CupOfCoffees/OnlyBlack/Item/OnlyBlackItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/MixedControllers/GeneratedCode/CupOfCoffees/OnlyBlack/Item/OnlyBlackItemRequestBuilder.cs
@@ -75,7 +75,7 @@ namespace OpenApiKiotaEndToEndTests.MixedControllers.GeneratedCode.CupOfCoffees.
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/MixedControllers/GeneratedCode/CupOfCoffees/OnlyBlack/OnlyBlackRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/MixedControllers/GeneratedCode/CupOfCoffees/OnlyBlack/OnlyBlackRequestBuilder.cs
@@ -84,7 +84,7 @@ namespace OpenApiKiotaEndToEndTests.MixedControllers.GeneratedCode.CupOfCoffees.
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ModelStateValidation/GeneratedCode/SocialMediaAccounts/Item/SocialMediaAccountsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ModelStateValidation/GeneratedCode/SocialMediaAccounts/Item/SocialMediaAccountsItemRequestBuilder.cs
@@ -73,8 +73,8 @@ namespace OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.SocialMed
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ModelStateValidation/GeneratedCode/SocialMediaAccounts/SocialMediaAccountsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ModelStateValidation/GeneratedCode/SocialMediaAccounts/SocialMediaAccountsRequestBuilder.cs
@@ -89,8 +89,8 @@ namespace OpenApiKiotaEndToEndTests.ModelStateValidation.GeneratedCode.SocialMed
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/NameValuePairs/Item/NameValuePairsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/NameValuePairs/Item/NameValuePairsItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.NameValuePairs.It
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.NameValuePairs.It
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.NameValuePairs.It
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/NameValuePairs/Item/Owner/OwnerRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/NameValuePairs/Item/Owner/OwnerRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.NameValuePairs.It
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/NameValuePairs/Item/Relationships/Owner/OwnerRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/NameValuePairs/Item/Relationships/Owner/OwnerRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.NameValuePairs.It
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.NameValuePairs.It
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/NameValuePairs/NameValuePairsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/NameValuePairs/NameValuePairsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.NameValuePairs
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.NameValuePairs
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/Children/ChildrenRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/Children/ChildrenRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Childr
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/NodesItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/NodesItemRequestBuilder.cs
@@ -145,7 +145,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -158,7 +158,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -185,8 +185,8 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/Parent/ParentRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/Parent/ParentRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Parent
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/Relationships/Children/ChildrenRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/Relationships/Children/ChildrenRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Relati
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Relati
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Relati
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Relati
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/Relationships/Parent/ParentRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/Relationships/Parent/ParentRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Relati
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Relati
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/Relationships/Values/ValuesRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/Relationships/Values/ValuesRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Relati
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Relati
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Relati
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Relati
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/Values/ValuesRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/Item/Values/ValuesRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes.Item.Values
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/NodesRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/QueryStrings/GeneratedCode/Nodes/NodesRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.QueryStrings.GeneratedCode.Nodes
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bathrooms/BathroomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bathrooms/BathroomsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bathrooms/Item/BathroomsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bathrooms/Item/BathroomsItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bathrooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bathrooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bathrooms/Item/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bathrooms/Item/Residence/ResidenceRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bedrooms/BedroomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bedrooms/BedroomsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bedrooms/Item/BedroomsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bedrooms/Item/BedroomsItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bedrooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bedrooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bedrooms/Item/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Bedrooms/Item/Residence/ResidenceRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Buildings/BuildingsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Buildings/BuildingsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Buildings/Item/BuildingsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Buildings/Item/BuildingsItemRequestBuilder.cs
@@ -117,7 +117,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -130,7 +130,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -157,8 +157,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/CyclePaths/CyclePathsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/CyclePaths/CyclePathsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/CyclePaths/Item/CyclePathsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/CyclePaths/Item/CyclePathsItemRequestBuilder.cs
@@ -117,7 +117,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -130,7 +130,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -157,8 +157,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Districts/DistrictsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Districts/DistrictsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Districts/Item/Buildings/BuildingsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Districts/Item/Buildings/BuildingsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Districts/Item/DistrictsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Districts/Item/DistrictsItemRequestBuilder.cs
@@ -138,7 +138,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -151,7 +151,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -178,8 +178,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Districts/Item/Relationships/Buildings/BuildingsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Districts/Item/Relationships/Buildings/BuildingsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Districts/Item/Relationships/Roads/RoadsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Districts/Item/Relationships/Roads/RoadsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Districts/Item/Roads/RoadsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Districts/Item/Roads/RoadsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/FamilyHomes/FamilyHomesRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/FamilyHomes/FamilyHomesRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/FamilyHomes/Item/FamilyHomesItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/FamilyHomes/Item/FamilyHomesItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/FamilyHomes/Item/Relationships/Rooms/RoomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/FamilyHomes/Item/Relationships/Rooms/RoomsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/FamilyHomes/Item/Rooms/RoomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/FamilyHomes/Item/Rooms/RoomsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Kitchens/Item/KitchensItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Kitchens/Item/KitchensItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Kitchens/Item/Relationships/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Kitchens/Item/Relationships/Residence/ResidenceRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Kitchens/Item/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Kitchens/Item/Residence/ResidenceRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Kitchens/KitchensRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Kitchens/KitchensRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/LivingRooms/Item/LivingRoomsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/LivingRooms/Item/LivingRoomsItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/LivingRooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/LivingRooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/LivingRooms/Item/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/LivingRooms/Item/Residence/ResidenceRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/LivingRooms/LivingRoomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/LivingRooms/LivingRoomsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Mansions/Item/MansionsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Mansions/Item/MansionsItemRequestBuilder.cs
@@ -138,7 +138,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -151,7 +151,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -178,8 +178,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Mansions/Item/Relationships/Rooms/RoomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Mansions/Item/Relationships/Rooms/RoomsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Mansions/Item/Relationships/Staff/StaffRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Mansions/Item/Relationships/Staff/StaffRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Mansions/Item/Rooms/RoomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Mansions/Item/Rooms/RoomsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Mansions/Item/Staff/StaffRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Mansions/Item/Staff/StaffRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Mansions/MansionsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Mansions/MansionsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Operations/OperationsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Operations/OperationsRequestBuilder.cs
@@ -75,8 +75,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=atomic;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=atomic;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Residences/Item/Relationships/Rooms/RoomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Residences/Item/Relationships/Rooms/RoomsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Residences/Item/ResidencesItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Residences/Item/ResidencesItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Residences/Item/Rooms/RoomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Residences/Item/Rooms/RoomsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Residences/ResidencesRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Residences/ResidencesRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Roads/Item/RoadsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Roads/Item/RoadsItemRequestBuilder.cs
@@ -117,7 +117,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -130,7 +130,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -157,8 +157,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Roads/RoadsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Roads/RoadsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Rooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Rooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Rooms/Item/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Rooms/Item/Residence/ResidenceRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Rooms/Item/RoomsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Rooms/Item/RoomsItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Rooms/RoomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Rooms/RoomsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/StaffMembers/Item/StaffMembersItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/StaffMembers/Item/StaffMembersItemRequestBuilder.cs
@@ -117,7 +117,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -130,7 +130,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -157,8 +157,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/StaffMembers/StaffMembersRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/StaffMembers/StaffMembersRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Toilets/Item/Relationships/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Toilets/Item/Relationships/Residence/ResidenceRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Toilets/Item/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Toilets/Item/Residence/ResidenceRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Toilets/Item/ToiletsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Toilets/Item/ToiletsItemRequestBuilder.cs
@@ -131,7 +131,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -144,7 +144,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -171,8 +171,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Toilets/ToiletsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/NoOperations/GeneratedCode/Toilets/ToiletsRequestBuilder.cs
@@ -115,7 +115,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -142,8 +142,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.NoOperations.GeneratedCo
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Bathrooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Bathrooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Bedrooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Bedrooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Districts/Item/Relationships/Buildings/BuildingsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Districts/Item/Relationships/Buildings/BuildingsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Districts/Item/Relationships/Roads/RoadsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Districts/Item/Relationships/Roads/RoadsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/FamilyHomes/Item/Relationships/Rooms/RoomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/FamilyHomes/Item/Relationships/Rooms/RoomsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Kitchens/Item/Relationships/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Kitchens/Item/Relationships/Residence/ResidenceRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/LivingRooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/LivingRooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Mansions/Item/Relationships/Rooms/RoomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Mansions/Item/Relationships/Rooms/RoomsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Mansions/Item/Relationships/Staff/StaffRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Mansions/Item/Relationships/Staff/StaffRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Operations/OperationsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Operations/OperationsRequestBuilder.cs
@@ -75,8 +75,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=atomic;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=atomic;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Residences/Item/Relationships/Rooms/RoomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Residences/Item/Relationships/Rooms/RoomsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Rooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Rooms/Item/Relationships/Residence/ResidenceRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Toilets/Item/Relationships/Residence/ResidenceRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/OnlyRelationships/GeneratedCode/Toilets/Item/Relationships/Residence/ResidenceRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.OnlyRelationships.Genera
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/SubsetOfOperations/GeneratedCode/Operations/OperationsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/SubsetOfOperations/GeneratedCode/Operations/OperationsRequestBuilder.cs
@@ -75,8 +75,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.SubsetOfOperations.Gener
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=atomic;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=atomic;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/SubsetOfVarious/GeneratedCode/Buildings/BuildingsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/SubsetOfVarious/GeneratedCode/Buildings/BuildingsRequestBuilder.cs
@@ -89,8 +89,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.SubsetOfVarious.Generate
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/SubsetOfVarious/GeneratedCode/Buildings/Item/BuildingsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/SubsetOfVarious/GeneratedCode/Buildings/Item/BuildingsItemRequestBuilder.cs
@@ -73,8 +73,8 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.SubsetOfVarious.Generate
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/SubsetOfVarious/GeneratedCode/CyclePaths/Item/CyclePathsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/SubsetOfVarious/GeneratedCode/CyclePaths/Item/CyclePathsItemRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.SubsetOfVarious.Generate
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/SubsetOfVarious/GeneratedCode/Districts/DistrictsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/SubsetOfVarious/GeneratedCode/Districts/DistrictsRequestBuilder.cs
@@ -74,7 +74,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.SubsetOfVarious.Generate
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/ResourceInheritance/SubsetOfVarious/GeneratedCode/FamilyHomes/Item/Relationships/Rooms/RoomsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/ResourceInheritance/SubsetOfVarious/GeneratedCode/FamilyHomes/Item/Relationships/Rooms/RoomsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.ResourceInheritance.SubsetOfVarious.Generate
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/DataStreams/DataStreamsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/DataStreams/DataStreamsRequestBuilder.cs
@@ -88,7 +88,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.DataStre
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/DataStreams/Item/DataStreamsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/DataStreams/Item/DataStreamsItemRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.DataStre
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/AudioStreams/AudioStreamsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/AudioStreams/AudioStreamsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/ReadOnlyChannelsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/ReadOnlyChannelsItemRequestBuilder.cs
@@ -104,7 +104,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/Relationships/AudioStreams/AudioStreamsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/Relationships/AudioStreams/AudioStreamsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/Relationships/UltraHighDefinitionVideoStream/UltraHighDefinitionVideoStreamRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/Relationships/UltraHighDefinitionVideoStream/UltraHighDefinitionVideoStreamRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/Relationships/VideoStream/VideoStreamRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/Relationships/VideoStream/VideoStreamRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/UltraHighDefinitionVideoStream/UltraHighDefinitionVideoStreamRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/UltraHighDefinitionVideoStream/UltraHighDefinitionVideoStreamRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/VideoStream/VideoStreamRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/Item/VideoStream/VideoStreamRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/ReadOnlyChannelsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyChannels/ReadOnlyChannelsRequestBuilder.cs
@@ -88,7 +88,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyResourceChannels/Item/AudioStreams/AudioStreamsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyResourceChannels/Item/AudioStreams/AudioStreamsRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyResourceChannels/Item/ReadOnlyResourceChannelsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyResourceChannels/Item/ReadOnlyResourceChannelsItemRequestBuilder.cs
@@ -97,7 +97,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyResourceChannels/Item/UltraHighDefinitionVideoStream/UltraHighDefinitionVideoStreamRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyResourceChannels/Item/UltraHighDefinitionVideoStream/UltraHighDefinitionVideoStreamRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyResourceChannels/Item/VideoStream/VideoStreamRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyResourceChannels/Item/VideoStream/VideoStreamRequestBuilder.cs
@@ -76,7 +76,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyResourceChannels/ReadOnlyResourceChannelsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/ReadOnlyResourceChannels/ReadOnlyResourceChannelsRequestBuilder.cs
@@ -88,7 +88,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.ReadOnly
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/RelationshipChannels/Item/Relationships/AudioStreams/AudioStreamsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/RelationshipChannels/Item/Relationships/AudioStreams/AudioStreamsRequestBuilder.cs
@@ -150,8 +150,8 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.Relation
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -164,7 +164,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.Relation
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -191,8 +191,8 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.Relation
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -207,8 +207,8 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.Relation
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/RelationshipChannels/Item/Relationships/UltraHighDefinitionVideoStream/UltraHighDefinitionVideoStreamRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/RelationshipChannels/Item/Relationships/UltraHighDefinitionVideoStream/UltraHighDefinitionVideoStreamRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.Relation
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.Relation
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/RelationshipChannels/Item/Relationships/VideoStream/VideoStreamRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/RelationshipChannels/Item/Relationships/VideoStream/VideoStreamRequestBuilder.cs
@@ -100,7 +100,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.Relation
         {
             var requestInfo = new RequestInformation(Method.GET, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -127,8 +127,8 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.Relation
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/WriteOnlyChannels/Item/Relationships/AudioStreams/AudioStreamsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/WriteOnlyChannels/Item/Relationships/AudioStreams/AudioStreamsRequestBuilder.cs
@@ -120,8 +120,8 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.WriteOnl
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -136,8 +136,8 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.WriteOnl
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 
@@ -152,8 +152,8 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.WriteOnl
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/WriteOnlyChannels/Item/Relationships/UltraHighDefinitionVideoStream/UltraHighDefinitionVideoStreamRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/WriteOnlyChannels/Item/Relationships/UltraHighDefinitionVideoStream/UltraHighDefinitionVideoStreamRequestBuilder.cs
@@ -72,8 +72,8 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.WriteOnl
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/WriteOnlyChannels/Item/Relationships/VideoStream/VideoStreamRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/WriteOnlyChannels/Item/Relationships/VideoStream/VideoStreamRequestBuilder.cs
@@ -72,8 +72,8 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.WriteOnl
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/WriteOnlyChannels/Item/WriteOnlyChannelsItemRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/WriteOnlyChannels/Item/WriteOnlyChannelsItemRequestBuilder.cs
@@ -94,7 +94,7 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.WriteOnl
         {
             var requestInfo = new RequestInformation(Method.DELETE, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
             return requestInfo;
         }
 
@@ -109,8 +109,8 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.WriteOnl
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.PATCH, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/WriteOnlyChannels/WriteOnlyChannelsRequestBuilder.cs
+++ b/test/OpenApiKiotaEndToEndTests/RestrictedControllers/GeneratedCode/WriteOnlyChannels/WriteOnlyChannelsRequestBuilder.cs
@@ -89,8 +89,8 @@ namespace OpenApiKiotaEndToEndTests.RestrictedControllers.GeneratedCode.WriteOnl
             if(ReferenceEquals(body, null)) throw new ArgumentNullException(nameof(body));
             var requestInfo = new RequestInformation(Method.POST, UrlTemplate, PathParameters);
             requestInfo.Configure(requestConfiguration);
-            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=openapi");
-            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=openapi", body);
+            requestInfo.Headers.TryAdd("Accept", "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"");
+            requestInfo.SetContentFromParsable(RequestAdapter, "application/vnd.api+json;ext=\"https://www.jsonapi.net/ext/openapi\"", body);
             return requestInfo;
         }
 

--- a/test/OpenApiNSwagClientTests/LegacyOpenApi/RequestTests.cs
+++ b/test/OpenApiNSwagClientTests/LegacyOpenApi/RequestTests.cs
@@ -12,7 +12,10 @@ namespace OpenApiNSwagClientTests.LegacyOpenApi;
 
 public sealed class RequestTests
 {
-    private const string OpenApiMediaType = "application/vnd.api+json; ext=openapi";
+    private const string OpenApiMediaType = """
+        application/vnd.api+json; ext="https://www.jsonapi.net/ext/openapi"
+        """;
+
     private const string HostPrefix = "http://localhost/api/";
 
     [Fact]

--- a/test/OpenApiTests/AtomicOperations/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/AtomicOperations/GeneratedSwagger/swagger.g.json
@@ -20,7 +20,7 @@
         "requestBody": {
           "description": "An array of mutation operations. For syntax, see the [Atomic Operations documentation](https://jsonapi.org/ext/atomic/).",
           "content": {
-            "application/vnd.api+json; ext=atomic; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -36,7 +36,7 @@
           "200": {
             "description": "All operations were successfully applied, which resulted in additional changes.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/operationsResponseDocument"
                 }
@@ -49,7 +49,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -59,7 +59,7 @@
           "403": {
             "description": "An operation is not accessible or a client-generated ID is used.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -69,7 +69,7 @@
           "404": {
             "description": "A resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -79,7 +79,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -89,7 +89,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/AtomicOperations/OperationsTests.cs
+++ b/test/OpenApiTests/AtomicOperations/OperationsTests.cs
@@ -41,7 +41,7 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
               "requestBody": {
                 "description": "An array of mutation operations. For syntax, see the [Atomic Operations documentation](https://jsonapi.org/ext/atomic/).",
                 "content": {
-                  "application/vnd.api+json; ext=atomic; ext=openapi": {
+                  "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                     "schema": {
                       "allOf": [
                         {
@@ -57,7 +57,7 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                 "200": {
                   "description": "All operations were successfully applied, which resulted in additional changes.",
                   "content": {
-                    "application/vnd.api+json; ext=atomic; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/operationsResponseDocument"
                       }
@@ -70,7 +70,7 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                 "400": {
                   "description": "The request body is missing or malformed.",
                   "content": {
-                    "application/vnd.api+json; ext=atomic; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/errorResponseDocument"
                       }
@@ -80,7 +80,7 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                 "403": {
                   "description": "An operation is not accessible or a client-generated ID is used.",
                   "content": {
-                    "application/vnd.api+json; ext=atomic; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/errorResponseDocument"
                       }
@@ -90,7 +90,7 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                 "404": {
                   "description": "A resource or a related resource does not exist.",
                   "content": {
-                    "application/vnd.api+json; ext=atomic; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/errorResponseDocument"
                       }
@@ -100,7 +100,7 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                 "409": {
                   "description": "The request body contains conflicting information or another resource with the same ID already exists.",
                   "content": {
-                    "application/vnd.api+json; ext=atomic; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/errorResponseDocument"
                       }
@@ -110,7 +110,7 @@ public sealed class OperationsTests : IClassFixture<OpenApiTestContext<OpenApiSt
                 "422": {
                   "description": "Validation of the request body failed.",
                   "content": {
-                    "application/vnd.api+json; ext=atomic; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/errorResponseDocument"
                       }

--- a/test/OpenApiTests/AttributeTypes/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/AttributeTypes/GeneratedSwagger/swagger.g.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/typeContainerCollectionResponseDocument"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -176,7 +176,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the typeContainer to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -202,7 +202,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryTypeContainerResponseDocument"
                 }
@@ -215,7 +215,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -225,7 +225,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -235,7 +235,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -245,7 +245,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -255,7 +255,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -319,7 +319,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryTypeContainerResponseDocument"
                 }
@@ -341,7 +341,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -351,7 +351,7 @@
           "404": {
             "description": "The typeContainer does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -477,7 +477,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the typeContainer to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -493,7 +493,7 @@
           "200": {
             "description": "The typeContainer was successfully updated, which resulted in additional changes. The updated typeContainer is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryTypeContainerResponseDocument"
                 }
@@ -506,7 +506,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -516,7 +516,7 @@
           "404": {
             "description": "The typeContainer or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -526,7 +526,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -536,7 +536,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -571,7 +571,7 @@
           "404": {
             "description": "The typeContainer does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/ClientIdGenerationModes/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ClientIdGenerationModes/GeneratedSwagger/swagger.g.json
@@ -35,7 +35,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the game to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -61,7 +61,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryGameResponseDocument"
                 }
@@ -74,7 +74,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -84,7 +84,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -94,7 +94,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -104,7 +104,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -139,7 +139,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the playerGroup to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -165,7 +165,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryPlayerGroupResponseDocument"
                 }
@@ -178,7 +178,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -188,7 +188,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -198,7 +198,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -208,7 +208,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -218,7 +218,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -253,7 +253,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the player to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -279,7 +279,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryPlayerResponseDocument"
                 }
@@ -292,7 +292,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -302,7 +302,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -312,7 +312,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -322,7 +322,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/Documentation/ErrorResponseTests.cs
+++ b/test/OpenApiTests/Documentation/ErrorResponseTests.cs
@@ -8,8 +8,10 @@ namespace OpenApiTests.Documentation;
 
 public sealed class ErrorResponseTests : IClassFixture<OpenApiTestContext<DocumentationStartup<DocumentationDbContext>, DocumentationDbContext>>
 {
-    private const string EscapedJsonApiMediaType = "['application/vnd.api+json; ext=openapi']";
-    private const string EscapedOperationsMediaType = "['application/vnd.api+json; ext=atomic; ext=openapi']";
+    private const string EscapedJsonApiMediaType = """['application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"']""";
+
+    private const string EscapedOperationsMediaType =
+        """['application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"']""";
 
     private readonly OpenApiTestContext<DocumentationStartup<DocumentationDbContext>, DocumentationDbContext> _testContext;
 

--- a/test/OpenApiTests/Headers/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/Headers/GeneratedSwagger/swagger.g.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/countryCollectionResponseDocument"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -176,7 +176,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the country to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -202,7 +202,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryCountryResponseDocument"
                 }
@@ -215,7 +215,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -225,7 +225,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -235,7 +235,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -245,7 +245,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -255,7 +255,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -319,7 +319,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryCountryResponseDocument"
                 }
@@ -341,7 +341,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -351,7 +351,7 @@
           "404": {
             "description": "The country does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -477,7 +477,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the country to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -493,7 +493,7 @@
           "200": {
             "description": "The country was successfully updated, which resulted in additional changes. The updated country is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryCountryResponseDocument"
                 }
@@ -506,7 +506,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -516,7 +516,7 @@
           "404": {
             "description": "The country or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -526,7 +526,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -536,7 +536,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -571,7 +571,7 @@
           "404": {
             "description": "The country does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -635,7 +635,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/languageCollectionResponseDocument"
                 }
@@ -657,7 +657,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -667,7 +667,7 @@
           "404": {
             "description": "The country does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -813,7 +813,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/languageIdentifierCollectionResponseDocument"
                 }
@@ -835,7 +835,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -845,7 +845,7 @@
           "404": {
             "description": "The country does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -958,7 +958,7 @@
         "requestBody": {
           "description": "The identities of the languages to add to the languages relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -977,7 +977,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -987,7 +987,7 @@
           "404": {
             "description": "The country or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -997,7 +997,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1007,7 +1007,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1038,7 +1038,7 @@
         "requestBody": {
           "description": "The identities of the languages to assign to the languages relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1057,7 +1057,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1067,7 +1067,7 @@
           "404": {
             "description": "The country or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1077,7 +1077,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1087,7 +1087,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1118,7 +1118,7 @@
         "requestBody": {
           "description": "The identities of the languages to remove from the languages relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1137,7 +1137,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1147,7 +1147,7 @@
           "404": {
             "description": "The country or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1157,7 +1157,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1167,7 +1167,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/IdObfuscation/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/IdObfuscation/GeneratedSwagger/swagger.g.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/bankAccountCollectionResponseDocument"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -176,7 +176,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the bankAccount to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -202,7 +202,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBankAccountResponseDocument"
                 }
@@ -215,7 +215,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -225,7 +225,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -235,7 +235,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -245,7 +245,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -255,7 +255,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -317,7 +317,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBankAccountResponseDocument"
                 }
@@ -339,7 +339,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -349,7 +349,7 @@
           "404": {
             "description": "The bankAccount does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -471,7 +471,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the bankAccount to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -487,7 +487,7 @@
           "200": {
             "description": "The bankAccount was successfully updated, which resulted in additional changes. The updated bankAccount is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBankAccountResponseDocument"
                 }
@@ -500,7 +500,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -510,7 +510,7 @@
           "404": {
             "description": "The bankAccount or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -520,7 +520,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -530,7 +530,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -563,7 +563,7 @@
           "404": {
             "description": "The bankAccount does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -625,7 +625,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/debitCardCollectionResponseDocument"
                 }
@@ -647,7 +647,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -657,7 +657,7 @@
           "404": {
             "description": "The bankAccount does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -799,7 +799,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/debitCardIdentifierCollectionResponseDocument"
                 }
@@ -821,7 +821,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -831,7 +831,7 @@
           "404": {
             "description": "The bankAccount does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -940,7 +940,7 @@
         "requestBody": {
           "description": "The identities of the debitCards to add to the cards relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -959,7 +959,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -969,7 +969,7 @@
           "404": {
             "description": "The bankAccount or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -979,7 +979,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -989,7 +989,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1018,7 +1018,7 @@
         "requestBody": {
           "description": "The identities of the debitCards to assign to the cards relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1037,7 +1037,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1047,7 +1047,7 @@
           "404": {
             "description": "The bankAccount or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1057,7 +1057,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1067,7 +1067,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1096,7 +1096,7 @@
         "requestBody": {
           "description": "The identities of the debitCards to remove from the cards relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1115,7 +1115,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1125,7 +1125,7 @@
           "404": {
             "description": "The bankAccount or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1135,7 +1135,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1145,7 +1145,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1198,7 +1198,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/debitCardCollectionResponseDocument"
                 }
@@ -1220,7 +1220,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1321,7 +1321,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the debitCard to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1347,7 +1347,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryDebitCardResponseDocument"
                 }
@@ -1360,7 +1360,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1370,7 +1370,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1380,7 +1380,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1390,7 +1390,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1400,7 +1400,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1462,7 +1462,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryDebitCardResponseDocument"
                 }
@@ -1484,7 +1484,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1494,7 +1494,7 @@
           "404": {
             "description": "The debitCard does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1616,7 +1616,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the debitCard to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1632,7 +1632,7 @@
           "200": {
             "description": "The debitCard was successfully updated, which resulted in additional changes. The updated debitCard is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryDebitCardResponseDocument"
                 }
@@ -1645,7 +1645,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1655,7 +1655,7 @@
           "404": {
             "description": "The debitCard or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1665,7 +1665,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1675,7 +1675,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1708,7 +1708,7 @@
           "404": {
             "description": "The debitCard does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1770,7 +1770,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryBankAccountResponseDocument"
                 }
@@ -1792,7 +1792,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1802,7 +1802,7 @@
           "404": {
             "description": "The debitCard does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1944,7 +1944,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/bankAccountIdentifierResponseDocument"
                 }
@@ -1966,7 +1966,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1976,7 +1976,7 @@
           "404": {
             "description": "The debitCard does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2085,7 +2085,7 @@
         "requestBody": {
           "description": "The identity of the bankAccount to assign to the account relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2104,7 +2104,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2114,7 +2114,7 @@
           "404": {
             "description": "The debitCard or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2124,7 +2124,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2134,7 +2134,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2154,7 +2154,7 @@
         "requestBody": {
           "description": "An array of mutation operations. For syntax, see the [Atomic Operations documentation](https://jsonapi.org/ext/atomic/).",
           "content": {
-            "application/vnd.api+json; ext=atomic; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2170,7 +2170,7 @@
           "200": {
             "description": "All operations were successfully applied, which resulted in additional changes.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/operationsResponseDocument"
                 }
@@ -2183,7 +2183,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2193,7 +2193,7 @@
           "403": {
             "description": "An operation is not accessible or a client-generated ID is used.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2203,7 +2203,7 @@
           "404": {
             "description": "A resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2213,7 +2213,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2223,7 +2223,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/LegacyOpenApi/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/LegacyOpenApi/GeneratedSwagger/swagger.g.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/airplane-collection-response-document"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -176,7 +176,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the airplane to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -202,7 +202,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-airplane-response-document"
                 }
@@ -215,7 +215,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -225,7 +225,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -235,7 +235,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -245,7 +245,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -255,7 +255,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -317,7 +317,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-airplane-response-document"
                 }
@@ -339,7 +339,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -349,7 +349,7 @@
           "404": {
             "description": "The airplane does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -471,7 +471,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the airplane to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -487,7 +487,7 @@
           "200": {
             "description": "The airplane was successfully updated, which resulted in additional changes. The updated airplane is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-airplane-response-document"
                 }
@@ -500,7 +500,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -510,7 +510,7 @@
           "404": {
             "description": "The airplane or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -520,7 +520,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -530,7 +530,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -563,7 +563,7 @@
           "404": {
             "description": "The airplane does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -625,7 +625,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-collection-response-document"
                 }
@@ -647,7 +647,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -657,7 +657,7 @@
           "404": {
             "description": "The airplane does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -799,7 +799,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-identifier-collection-response-document"
                 }
@@ -821,7 +821,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -831,7 +831,7 @@
           "404": {
             "description": "The airplane does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -940,7 +940,7 @@
         "requestBody": {
           "description": "The identities of the flights to add to the flights relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -959,7 +959,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -969,7 +969,7 @@
           "404": {
             "description": "The airplane or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -979,7 +979,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -989,7 +989,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1018,7 +1018,7 @@
         "requestBody": {
           "description": "The identities of the flights to assign to the flights relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1037,7 +1037,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1047,7 +1047,7 @@
           "404": {
             "description": "The airplane or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1057,7 +1057,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1067,7 +1067,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1096,7 +1096,7 @@
         "requestBody": {
           "description": "The identities of the flights to remove from the flights relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1115,7 +1115,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1125,7 +1125,7 @@
           "404": {
             "description": "The airplane or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1135,7 +1135,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1145,7 +1145,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1198,7 +1198,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-attendant-collection-response-document"
                 }
@@ -1220,7 +1220,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1321,7 +1321,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the flight-attendant to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1347,7 +1347,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-flight-attendant-response-document"
                 }
@@ -1360,7 +1360,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1370,7 +1370,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1380,7 +1380,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1390,7 +1390,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1400,7 +1400,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1462,7 +1462,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-flight-attendant-response-document"
                 }
@@ -1484,7 +1484,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1494,7 +1494,7 @@
           "404": {
             "description": "The flight-attendant does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1616,7 +1616,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the flight-attendant to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1632,7 +1632,7 @@
           "200": {
             "description": "The flight-attendant was successfully updated, which resulted in additional changes. The updated flight-attendant is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-flight-attendant-response-document"
                 }
@@ -1645,7 +1645,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1655,7 +1655,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1665,7 +1665,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1675,7 +1675,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1708,7 +1708,7 @@
           "404": {
             "description": "The flight-attendant does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1770,7 +1770,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-collection-response-document"
                 }
@@ -1792,7 +1792,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1802,7 +1802,7 @@
           "404": {
             "description": "The flight-attendant does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1944,7 +1944,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-identifier-collection-response-document"
                 }
@@ -1966,7 +1966,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1976,7 +1976,7 @@
           "404": {
             "description": "The flight-attendant does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2085,7 +2085,7 @@
         "requestBody": {
           "description": "The identities of the flights to add to the purser-on-flights relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2104,7 +2104,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2114,7 +2114,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2124,7 +2124,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2134,7 +2134,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2163,7 +2163,7 @@
         "requestBody": {
           "description": "The identities of the flights to assign to the purser-on-flights relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2182,7 +2182,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2192,7 +2192,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2202,7 +2202,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2212,7 +2212,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2241,7 +2241,7 @@
         "requestBody": {
           "description": "The identities of the flights to remove from the purser-on-flights relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2260,7 +2260,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2270,7 +2270,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2280,7 +2280,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2290,7 +2290,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2352,7 +2352,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-collection-response-document"
                 }
@@ -2374,7 +2374,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2384,7 +2384,7 @@
           "404": {
             "description": "The flight-attendant does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2526,7 +2526,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-identifier-collection-response-document"
                 }
@@ -2548,7 +2548,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2558,7 +2558,7 @@
           "404": {
             "description": "The flight-attendant does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2667,7 +2667,7 @@
         "requestBody": {
           "description": "The identities of the flights to add to the scheduled-for-flights relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2686,7 +2686,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2696,7 +2696,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2706,7 +2706,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2716,7 +2716,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2745,7 +2745,7 @@
         "requestBody": {
           "description": "The identities of the flights to assign to the scheduled-for-flights relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2764,7 +2764,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2774,7 +2774,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2784,7 +2784,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2794,7 +2794,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2823,7 +2823,7 @@
         "requestBody": {
           "description": "The identities of the flights to remove from the scheduled-for-flights relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2842,7 +2842,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2852,7 +2852,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2862,7 +2862,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2872,7 +2872,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2925,7 +2925,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-collection-response-document"
                 }
@@ -2947,7 +2947,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3048,7 +3048,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the flight to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3074,7 +3074,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-flight-response-document"
                 }
@@ -3087,7 +3087,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3097,7 +3097,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3107,7 +3107,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3117,7 +3117,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3127,7 +3127,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3189,7 +3189,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-flight-response-document"
                 }
@@ -3211,7 +3211,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3221,7 +3221,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3343,7 +3343,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the flight to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3359,7 +3359,7 @@
           "200": {
             "description": "The flight was successfully updated, which resulted in additional changes. The updated flight is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-flight-response-document"
                 }
@@ -3372,7 +3372,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3382,7 +3382,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3392,7 +3392,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3402,7 +3402,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3435,7 +3435,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3497,7 +3497,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullable-secondary-flight-attendant-response-document"
                 }
@@ -3519,7 +3519,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3529,7 +3529,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3671,7 +3671,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullable-flight-attendant-identifier-response-document"
                 }
@@ -3693,7 +3693,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3703,7 +3703,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3812,7 +3812,7 @@
         "requestBody": {
           "description": "The identity of the flight-attendant to assign to the backup-purser relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3831,7 +3831,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3841,7 +3841,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3851,7 +3851,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3861,7 +3861,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3923,7 +3923,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-attendant-collection-response-document"
                 }
@@ -3945,7 +3945,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3955,7 +3955,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4097,7 +4097,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-attendant-identifier-collection-response-document"
                 }
@@ -4119,7 +4119,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4129,7 +4129,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4238,7 +4238,7 @@
         "requestBody": {
           "description": "The identities of the flight-attendants to add to the cabin-crew-members relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4257,7 +4257,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4267,7 +4267,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4277,7 +4277,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4287,7 +4287,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4316,7 +4316,7 @@
         "requestBody": {
           "description": "The identities of the flight-attendants to assign to the cabin-crew-members relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4335,7 +4335,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4345,7 +4345,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4355,7 +4355,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4365,7 +4365,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4394,7 +4394,7 @@
         "requestBody": {
           "description": "The identities of the flight-attendants to remove from the cabin-crew-members relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4413,7 +4413,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4423,7 +4423,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4433,7 +4433,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4443,7 +4443,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4505,7 +4505,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/passenger-collection-response-document"
                 }
@@ -4527,7 +4527,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4537,7 +4537,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4679,7 +4679,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/passenger-identifier-collection-response-document"
                 }
@@ -4701,7 +4701,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4711,7 +4711,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4820,7 +4820,7 @@
         "requestBody": {
           "description": "The identities of the passengers to add to the passengers relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4839,7 +4839,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4849,7 +4849,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4859,7 +4859,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4869,7 +4869,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4898,7 +4898,7 @@
         "requestBody": {
           "description": "The identities of the passengers to assign to the passengers relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4917,7 +4917,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4927,7 +4927,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4937,7 +4937,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4947,7 +4947,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4976,7 +4976,7 @@
         "requestBody": {
           "description": "The identities of the passengers to remove from the passengers relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4995,7 +4995,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5005,7 +5005,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5015,7 +5015,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5025,7 +5025,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5087,7 +5087,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondary-flight-attendant-response-document"
                 }
@@ -5109,7 +5109,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5119,7 +5119,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5261,7 +5261,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-attendant-identifier-response-document"
                 }
@@ -5283,7 +5283,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5293,7 +5293,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5402,7 +5402,7 @@
         "requestBody": {
           "description": "The identity of the flight-attendant to assign to the purser relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5421,7 +5421,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5431,7 +5431,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5441,7 +5441,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5451,7 +5451,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5504,7 +5504,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/passenger-collection-response-document"
                 }
@@ -5526,7 +5526,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5627,7 +5627,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the passenger to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5653,7 +5653,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-passenger-response-document"
                 }
@@ -5666,7 +5666,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5676,7 +5676,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5686,7 +5686,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5696,7 +5696,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5706,7 +5706,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5768,7 +5768,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-passenger-response-document"
                 }
@@ -5790,7 +5790,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5800,7 +5800,7 @@
           "404": {
             "description": "The passenger does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5922,7 +5922,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the passenger to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5938,7 +5938,7 @@
           "200": {
             "description": "The passenger was successfully updated, which resulted in additional changes. The updated passenger is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-passenger-response-document"
                 }
@@ -5951,7 +5951,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5961,7 +5961,7 @@
           "404": {
             "description": "The passenger or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5971,7 +5971,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5981,7 +5981,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -6014,7 +6014,7 @@
           "404": {
             "description": "The passenger does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }

--- a/test/OpenApiTests/LegacyOpenApi/expected-swagger.json
+++ b/test/OpenApiTests/LegacyOpenApi/expected-swagger.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/airplane-collection-response-document"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -176,7 +176,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the airplane to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -202,7 +202,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-airplane-response-document"
                 }
@@ -215,7 +215,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -225,7 +225,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -235,7 +235,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -245,7 +245,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -255,7 +255,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -317,7 +317,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-airplane-response-document"
                 }
@@ -339,7 +339,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -349,7 +349,7 @@
           "404": {
             "description": "The airplane does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -471,7 +471,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the airplane to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -487,7 +487,7 @@
           "200": {
             "description": "The airplane was successfully updated, which resulted in additional changes. The updated airplane is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-airplane-response-document"
                 }
@@ -500,7 +500,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -510,7 +510,7 @@
           "404": {
             "description": "The airplane or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -520,7 +520,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -530,7 +530,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -563,7 +563,7 @@
           "404": {
             "description": "The airplane does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -625,7 +625,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-collection-response-document"
                 }
@@ -647,7 +647,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -657,7 +657,7 @@
           "404": {
             "description": "The airplane does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -799,7 +799,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-identifier-collection-response-document"
                 }
@@ -821,7 +821,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -831,7 +831,7 @@
           "404": {
             "description": "The airplane does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -940,7 +940,7 @@
         "requestBody": {
           "description": "The identities of the flights to add to the flights relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -959,7 +959,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -969,7 +969,7 @@
           "404": {
             "description": "The airplane or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -979,7 +979,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -989,7 +989,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1018,7 +1018,7 @@
         "requestBody": {
           "description": "The identities of the flights to assign to the flights relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1037,7 +1037,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1047,7 +1047,7 @@
           "404": {
             "description": "The airplane or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1057,7 +1057,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1067,7 +1067,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1096,7 +1096,7 @@
         "requestBody": {
           "description": "The identities of the flights to remove from the flights relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1115,7 +1115,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1125,7 +1125,7 @@
           "404": {
             "description": "The airplane or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1135,7 +1135,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1145,7 +1145,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1198,7 +1198,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-attendant-collection-response-document"
                 }
@@ -1220,7 +1220,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1321,7 +1321,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the flight-attendant to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1347,7 +1347,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-flight-attendant-response-document"
                 }
@@ -1360,7 +1360,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1370,7 +1370,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1380,7 +1380,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1390,7 +1390,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1400,7 +1400,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1462,7 +1462,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-flight-attendant-response-document"
                 }
@@ -1484,7 +1484,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1494,7 +1494,7 @@
           "404": {
             "description": "The flight-attendant does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1616,7 +1616,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the flight-attendant to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1632,7 +1632,7 @@
           "200": {
             "description": "The flight-attendant was successfully updated, which resulted in additional changes. The updated flight-attendant is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-flight-attendant-response-document"
                 }
@@ -1645,7 +1645,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1655,7 +1655,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1665,7 +1665,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1675,7 +1675,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1708,7 +1708,7 @@
           "404": {
             "description": "The flight-attendant does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1770,7 +1770,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-collection-response-document"
                 }
@@ -1792,7 +1792,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1802,7 +1802,7 @@
           "404": {
             "description": "The flight-attendant does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1944,7 +1944,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-identifier-collection-response-document"
                 }
@@ -1966,7 +1966,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1976,7 +1976,7 @@
           "404": {
             "description": "The flight-attendant does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2085,7 +2085,7 @@
         "requestBody": {
           "description": "The identities of the flights to add to the purser-on-flights relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2104,7 +2104,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2114,7 +2114,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2124,7 +2124,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2134,7 +2134,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2163,7 +2163,7 @@
         "requestBody": {
           "description": "The identities of the flights to assign to the purser-on-flights relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2182,7 +2182,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2192,7 +2192,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2202,7 +2202,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2212,7 +2212,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2241,7 +2241,7 @@
         "requestBody": {
           "description": "The identities of the flights to remove from the purser-on-flights relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2260,7 +2260,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2270,7 +2270,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2280,7 +2280,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2290,7 +2290,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2352,7 +2352,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-collection-response-document"
                 }
@@ -2374,7 +2374,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2384,7 +2384,7 @@
           "404": {
             "description": "The flight-attendant does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2526,7 +2526,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-identifier-collection-response-document"
                 }
@@ -2548,7 +2548,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2558,7 +2558,7 @@
           "404": {
             "description": "The flight-attendant does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2667,7 +2667,7 @@
         "requestBody": {
           "description": "The identities of the flights to add to the scheduled-for-flights relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2686,7 +2686,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2696,7 +2696,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2706,7 +2706,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2716,7 +2716,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2745,7 +2745,7 @@
         "requestBody": {
           "description": "The identities of the flights to assign to the scheduled-for-flights relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2764,7 +2764,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2774,7 +2774,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2784,7 +2784,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2794,7 +2794,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2823,7 +2823,7 @@
         "requestBody": {
           "description": "The identities of the flights to remove from the scheduled-for-flights relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2842,7 +2842,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2852,7 +2852,7 @@
           "404": {
             "description": "The flight-attendant or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2862,7 +2862,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2872,7 +2872,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2925,7 +2925,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-collection-response-document"
                 }
@@ -2947,7 +2947,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3048,7 +3048,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the flight to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3074,7 +3074,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-flight-response-document"
                 }
@@ -3087,7 +3087,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3097,7 +3097,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3107,7 +3107,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3117,7 +3117,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3127,7 +3127,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3189,7 +3189,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-flight-response-document"
                 }
@@ -3211,7 +3211,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3221,7 +3221,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3343,7 +3343,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the flight to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3359,7 +3359,7 @@
           "200": {
             "description": "The flight was successfully updated, which resulted in additional changes. The updated flight is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-flight-response-document"
                 }
@@ -3372,7 +3372,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3382,7 +3382,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3392,7 +3392,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3402,7 +3402,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3435,7 +3435,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3497,7 +3497,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullable-secondary-flight-attendant-response-document"
                 }
@@ -3519,7 +3519,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3529,7 +3529,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3671,7 +3671,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullable-flight-attendant-identifier-response-document"
                 }
@@ -3693,7 +3693,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3703,7 +3703,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3812,7 +3812,7 @@
         "requestBody": {
           "description": "The identity of the flight-attendant to assign to the backup-purser relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3831,7 +3831,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3841,7 +3841,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3851,7 +3851,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3861,7 +3861,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3923,7 +3923,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-attendant-collection-response-document"
                 }
@@ -3945,7 +3945,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -3955,7 +3955,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4097,7 +4097,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-attendant-identifier-collection-response-document"
                 }
@@ -4119,7 +4119,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4129,7 +4129,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4238,7 +4238,7 @@
         "requestBody": {
           "description": "The identities of the flight-attendants to add to the cabin-crew-members relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4257,7 +4257,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4267,7 +4267,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4277,7 +4277,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4287,7 +4287,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4316,7 +4316,7 @@
         "requestBody": {
           "description": "The identities of the flight-attendants to assign to the cabin-crew-members relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4335,7 +4335,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4345,7 +4345,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4355,7 +4355,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4365,7 +4365,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4394,7 +4394,7 @@
         "requestBody": {
           "description": "The identities of the flight-attendants to remove from the cabin-crew-members relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4413,7 +4413,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4423,7 +4423,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4433,7 +4433,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4443,7 +4443,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4505,7 +4505,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/passenger-collection-response-document"
                 }
@@ -4527,7 +4527,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4537,7 +4537,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4679,7 +4679,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/passenger-identifier-collection-response-document"
                 }
@@ -4701,7 +4701,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4711,7 +4711,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4820,7 +4820,7 @@
         "requestBody": {
           "description": "The identities of the passengers to add to the passengers relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4839,7 +4839,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4849,7 +4849,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4859,7 +4859,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4869,7 +4869,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4898,7 +4898,7 @@
         "requestBody": {
           "description": "The identities of the passengers to assign to the passengers relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4917,7 +4917,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4927,7 +4927,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4937,7 +4937,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4947,7 +4947,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -4976,7 +4976,7 @@
         "requestBody": {
           "description": "The identities of the passengers to remove from the passengers relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4995,7 +4995,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5005,7 +5005,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5015,7 +5015,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5025,7 +5025,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5087,7 +5087,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondary-flight-attendant-response-document"
                 }
@@ -5109,7 +5109,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5119,7 +5119,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5261,7 +5261,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/flight-attendant-identifier-response-document"
                 }
@@ -5283,7 +5283,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5293,7 +5293,7 @@
           "404": {
             "description": "The flight does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5402,7 +5402,7 @@
         "requestBody": {
           "description": "The identity of the flight-attendant to assign to the purser relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5421,7 +5421,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5431,7 +5431,7 @@
           "404": {
             "description": "The flight or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5441,7 +5441,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5451,7 +5451,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5504,7 +5504,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/passenger-collection-response-document"
                 }
@@ -5526,7 +5526,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5627,7 +5627,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the passenger to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5653,7 +5653,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-passenger-response-document"
                 }
@@ -5666,7 +5666,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5676,7 +5676,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5686,7 +5686,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5696,7 +5696,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5706,7 +5706,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5768,7 +5768,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-passenger-response-document"
                 }
@@ -5790,7 +5790,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5800,7 +5800,7 @@
           "404": {
             "description": "The passenger does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5922,7 +5922,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the passenger to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5938,7 +5938,7 @@
           "200": {
             "description": "The passenger was successfully updated, which resulted in additional changes. The updated passenger is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-passenger-response-document"
                 }
@@ -5951,7 +5951,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5961,7 +5961,7 @@
           "404": {
             "description": "The passenger or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5971,7 +5971,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -5981,7 +5981,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -6014,7 +6014,7 @@
           "404": {
             "description": "The passenger does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }

--- a/test/OpenApiTests/Links/Enabled/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/Links/Enabled/GeneratedSwagger/swagger.g.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/accommodationCollectionResponseDocument"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -176,7 +176,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the accommodation to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -202,7 +202,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryAccommodationResponseDocument"
                 }
@@ -215,7 +215,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -225,7 +225,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -235,7 +235,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -245,7 +245,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -255,7 +255,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -319,7 +319,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryAccommodationResponseDocument"
                 }
@@ -341,7 +341,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -351,7 +351,7 @@
           "404": {
             "description": "The accommodation does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -477,7 +477,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the accommodation to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -493,7 +493,7 @@
           "200": {
             "description": "The accommodation was successfully updated, which resulted in additional changes. The updated accommodation is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryAccommodationResponseDocument"
                 }
@@ -506,7 +506,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -516,7 +516,7 @@
           "404": {
             "description": "The accommodation or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -526,7 +526,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -536,7 +536,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -571,7 +571,7 @@
           "404": {
             "description": "The accommodation does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -624,7 +624,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/excursionCollectionResponseDocument"
                 }
@@ -646,7 +646,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -747,7 +747,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the excursion to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -773,7 +773,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryExcursionResponseDocument"
                 }
@@ -786,7 +786,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -796,7 +796,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -806,7 +806,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -816,7 +816,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -826,7 +826,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -890,7 +890,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryExcursionResponseDocument"
                 }
@@ -912,7 +912,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -922,7 +922,7 @@
           "404": {
             "description": "The excursion does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1048,7 +1048,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the excursion to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1064,7 +1064,7 @@
           "200": {
             "description": "The excursion was successfully updated, which resulted in additional changes. The updated excursion is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryExcursionResponseDocument"
                 }
@@ -1077,7 +1077,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1087,7 +1087,7 @@
           "404": {
             "description": "The excursion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1097,7 +1097,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1107,7 +1107,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1142,7 +1142,7 @@
           "404": {
             "description": "The excursion does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1195,7 +1195,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/transportCollectionResponseDocument"
                 }
@@ -1217,7 +1217,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1318,7 +1318,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the transport to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1344,7 +1344,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryTransportResponseDocument"
                 }
@@ -1357,7 +1357,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1367,7 +1367,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1377,7 +1377,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1387,7 +1387,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1397,7 +1397,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1461,7 +1461,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryTransportResponseDocument"
                 }
@@ -1483,7 +1483,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1493,7 +1493,7 @@
           "404": {
             "description": "The transport does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1619,7 +1619,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the transport to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1635,7 +1635,7 @@
           "200": {
             "description": "The transport was successfully updated, which resulted in additional changes. The updated transport is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryTransportResponseDocument"
                 }
@@ -1648,7 +1648,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1658,7 +1658,7 @@
           "404": {
             "description": "The transport or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1668,7 +1668,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1678,7 +1678,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1713,7 +1713,7 @@
           "404": {
             "description": "The transport does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1766,7 +1766,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/vacationCollectionResponseDocument"
                 }
@@ -1788,7 +1788,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1889,7 +1889,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the vacation to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1915,7 +1915,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryVacationResponseDocument"
                 }
@@ -1928,7 +1928,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1938,7 +1938,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1948,7 +1948,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1958,7 +1958,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1968,7 +1968,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2032,7 +2032,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryVacationResponseDocument"
                 }
@@ -2054,7 +2054,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2064,7 +2064,7 @@
           "404": {
             "description": "The vacation does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2190,7 +2190,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the vacation to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2206,7 +2206,7 @@
           "200": {
             "description": "The vacation was successfully updated, which resulted in additional changes. The updated vacation is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryVacationResponseDocument"
                 }
@@ -2219,7 +2219,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2229,7 +2229,7 @@
           "404": {
             "description": "The vacation or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2239,7 +2239,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2249,7 +2249,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2284,7 +2284,7 @@
           "404": {
             "description": "The vacation does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2348,7 +2348,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryAccommodationResponseDocument"
                 }
@@ -2370,7 +2370,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2380,7 +2380,7 @@
           "404": {
             "description": "The vacation does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2526,7 +2526,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/accommodationIdentifierResponseDocument"
                 }
@@ -2548,7 +2548,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2558,7 +2558,7 @@
           "404": {
             "description": "The vacation does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2671,7 +2671,7 @@
         "requestBody": {
           "description": "The identity of the accommodation to assign to the accommodation relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2690,7 +2690,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2700,7 +2700,7 @@
           "404": {
             "description": "The vacation or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2710,7 +2710,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2720,7 +2720,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2784,7 +2784,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/excursionCollectionResponseDocument"
                 }
@@ -2806,7 +2806,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2816,7 +2816,7 @@
           "404": {
             "description": "The vacation does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2962,7 +2962,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/excursionIdentifierCollectionResponseDocument"
                 }
@@ -2984,7 +2984,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2994,7 +2994,7 @@
           "404": {
             "description": "The vacation does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3107,7 +3107,7 @@
         "requestBody": {
           "description": "The identities of the excursions to add to the excursions relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3126,7 +3126,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3136,7 +3136,7 @@
           "404": {
             "description": "The vacation or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3146,7 +3146,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3156,7 +3156,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3187,7 +3187,7 @@
         "requestBody": {
           "description": "The identities of the excursions to assign to the excursions relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3206,7 +3206,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3216,7 +3216,7 @@
           "404": {
             "description": "The vacation or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3226,7 +3226,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3236,7 +3236,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3267,7 +3267,7 @@
         "requestBody": {
           "description": "The identities of the excursions to remove from the excursions relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3286,7 +3286,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3296,7 +3296,7 @@
           "404": {
             "description": "The vacation or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3306,7 +3306,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3316,7 +3316,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3380,7 +3380,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableSecondaryTransportResponseDocument"
                 }
@@ -3402,7 +3402,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3412,7 +3412,7 @@
           "404": {
             "description": "The vacation does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3558,7 +3558,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableTransportIdentifierResponseDocument"
                 }
@@ -3580,7 +3580,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3590,7 +3590,7 @@
           "404": {
             "description": "The vacation does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3703,7 +3703,7 @@
         "requestBody": {
           "description": "The identity of the transport to assign to the transport relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3722,7 +3722,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3732,7 +3732,7 @@
           "404": {
             "description": "The vacation or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3742,7 +3742,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3752,7 +3752,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/MixedControllers/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/MixedControllers/GeneratedSwagger/swagger.g.json
@@ -21,7 +21,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryCoffeeSummaryResponseDocument"
                 }
@@ -31,7 +31,7 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -67,7 +67,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/cupOfCoffeeCollectionResponseDocument"
                 }
@@ -112,7 +112,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryCupOfCoffeeResponseDocument"
                 }
@@ -122,7 +122,7 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -181,7 +181,7 @@
         ],
         "requestBody": {
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -200,7 +200,7 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -234,7 +234,7 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -287,7 +287,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/cupOfCoffeeCollectionResponseDocument"
                 }
@@ -309,7 +309,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -414,7 +414,7 @@
           "404": {
             "description": "The cupOfCoffee does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/MixedControllers/MixedControllerTests.cs
+++ b/test/OpenApiTests/MixedControllers/MixedControllerTests.cs
@@ -61,7 +61,7 @@ public sealed class MixedControllerTests : IClassFixture<OpenApiTestContext<Mixe
                 "200": {
                   "description": "OK",
                   "content": {
-                    "application/vnd.api+json; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/primaryCoffeeSummaryResponseDocument"
                       }
@@ -71,7 +71,7 @@ public sealed class MixedControllerTests : IClassFixture<OpenApiTestContext<Mixe
                 "404": {
                   "description": "Not Found",
                   "content": {
-                    "application/vnd.api+json; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/errorResponseDocument"
                       }
@@ -119,7 +119,7 @@ public sealed class MixedControllerTests : IClassFixture<OpenApiTestContext<Mixe
                 "200": {
                   "description": "OK",
                   "content": {
-                    "application/vnd.api+json; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/cupOfCoffeeCollectionResponseDocument"
                       }
@@ -176,7 +176,7 @@ public sealed class MixedControllerTests : IClassFixture<OpenApiTestContext<Mixe
                 "200": {
                   "description": "OK",
                   "content": {
-                    "application/vnd.api+json; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/primaryCupOfCoffeeResponseDocument"
                       }
@@ -186,7 +186,7 @@ public sealed class MixedControllerTests : IClassFixture<OpenApiTestContext<Mixe
                 "404": {
                   "description": "Not Found",
                   "content": {
-                    "application/vnd.api+json; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/errorResponseDocument"
                       }
@@ -257,7 +257,7 @@ public sealed class MixedControllerTests : IClassFixture<OpenApiTestContext<Mixe
               ],
               "requestBody": {
                 "content": {
-                  "application/vnd.api+json; ext=openapi": {
+                  "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                     "schema": {
                       "allOf": [
                         {
@@ -276,7 +276,7 @@ public sealed class MixedControllerTests : IClassFixture<OpenApiTestContext<Mixe
                 "400": {
                   "description": "Bad Request",
                   "content": {
-                    "application/vnd.api+json; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/errorResponseDocument"
                       }
@@ -332,7 +332,7 @@ public sealed class MixedControllerTests : IClassFixture<OpenApiTestContext<Mixe
                 "404": {
                   "description": "Not Found",
                   "content": {
-                    "application/vnd.api+json; ext=openapi": {
+                    "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                       "schema": {
                         "$ref": "#/components/schemas/errorResponseDocument"
                       }

--- a/test/OpenApiTests/ModelStateValidation/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ModelStateValidation/GeneratedSwagger/swagger.g.json
@@ -35,7 +35,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the socialMediaAccount to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -61,7 +61,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primarySocialMediaAccountResponseDocument"
                 }
@@ -74,7 +74,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -84,7 +84,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -94,7 +94,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -104,7 +104,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -114,7 +114,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -160,7 +160,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the socialMediaAccount to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -176,7 +176,7 @@
           "200": {
             "description": "The socialMediaAccount was successfully updated, which resulted in additional changes. The updated socialMediaAccount is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primarySocialMediaAccountResponseDocument"
                 }
@@ -189,7 +189,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -199,7 +199,7 @@
           "404": {
             "description": "The socialMediaAccount or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -209,7 +209,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -219,7 +219,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/NamingConventions/CamelCase/CamelCaseTests.cs
+++ b/test/OpenApiTests/NamingConventions/CamelCase/CamelCaseTests.cs
@@ -7,8 +7,10 @@ namespace OpenApiTests.NamingConventions.CamelCase;
 
 public sealed class CamelCaseTests : IClassFixture<OpenApiTestContext<CamelCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext>>
 {
-    private const string EscapedJsonApiMediaType = "['application/vnd.api+json; ext=openapi']";
-    private const string EscapedOperationsMediaType = "['application/vnd.api+json; ext=atomic; ext=openapi']";
+    private const string EscapedJsonApiMediaType = """['application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"']""";
+
+    private const string EscapedOperationsMediaType =
+        """['application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"']""";
 
     private readonly OpenApiTestContext<CamelCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext> _testContext;
 

--- a/test/OpenApiTests/NamingConventions/CamelCase/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/NamingConventions/CamelCase/GeneratedSwagger/swagger.g.json
@@ -20,7 +20,7 @@
         "requestBody": {
           "description": "An array of mutation operations. For syntax, see the [Atomic Operations documentation](https://jsonapi.org/ext/atomic/).",
           "content": {
-            "application/vnd.api+json; ext=atomic; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -36,7 +36,7 @@
           "200": {
             "description": "All operations were successfully applied, which resulted in additional changes.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/operationsResponseDocument"
                 }
@@ -49,7 +49,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -59,7 +59,7 @@
           "403": {
             "description": "An operation is not accessible or a client-generated ID is used.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -69,7 +69,7 @@
           "404": {
             "description": "A resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -79,7 +79,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -89,7 +89,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -142,7 +142,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/staffMemberCollectionResponseDocument"
                 }
@@ -164,7 +164,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -265,7 +265,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the staffMember to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -291,7 +291,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryStaffMemberResponseDocument"
                 }
@@ -304,7 +304,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -314,7 +314,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -324,7 +324,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -334,7 +334,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -344,7 +344,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -408,7 +408,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryStaffMemberResponseDocument"
                 }
@@ -430,7 +430,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -440,7 +440,7 @@
           "404": {
             "description": "The staffMember does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -566,7 +566,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the staffMember to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -582,7 +582,7 @@
           "200": {
             "description": "The staffMember was successfully updated, which resulted in additional changes. The updated staffMember is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryStaffMemberResponseDocument"
                 }
@@ -595,7 +595,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -605,7 +605,7 @@
           "404": {
             "description": "The staffMember or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -615,7 +615,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -625,7 +625,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -660,7 +660,7 @@
           "404": {
             "description": "The staffMember does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -713,7 +713,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/supermarketCollectionResponseDocument"
                 }
@@ -735,7 +735,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -836,7 +836,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the supermarket to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -862,7 +862,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primarySupermarketResponseDocument"
                 }
@@ -875,7 +875,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -885,7 +885,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -895,7 +895,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -905,7 +905,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -915,7 +915,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -979,7 +979,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primarySupermarketResponseDocument"
                 }
@@ -1001,7 +1001,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1011,7 +1011,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1137,7 +1137,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the supermarket to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1153,7 +1153,7 @@
           "200": {
             "description": "The supermarket was successfully updated, which resulted in additional changes. The updated supermarket is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primarySupermarketResponseDocument"
                 }
@@ -1166,7 +1166,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1176,7 +1176,7 @@
           "404": {
             "description": "The supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1186,7 +1186,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1196,7 +1196,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1231,7 +1231,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1295,7 +1295,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableSecondaryStaffMemberResponseDocument"
                 }
@@ -1317,7 +1317,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1327,7 +1327,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1473,7 +1473,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableStaffMemberIdentifierResponseDocument"
                 }
@@ -1495,7 +1495,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1505,7 +1505,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1618,7 +1618,7 @@
         "requestBody": {
           "description": "The identity of the staffMember to assign to the backupStoreManager relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1637,7 +1637,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1647,7 +1647,7 @@
           "404": {
             "description": "The supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1657,7 +1657,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1667,7 +1667,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1731,7 +1731,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/staffMemberCollectionResponseDocument"
                 }
@@ -1753,7 +1753,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1763,7 +1763,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1909,7 +1909,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/staffMemberIdentifierCollectionResponseDocument"
                 }
@@ -1931,7 +1931,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1941,7 +1941,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2054,7 +2054,7 @@
         "requestBody": {
           "description": "The identities of the staffMembers to add to the cashiers relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2073,7 +2073,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2083,7 +2083,7 @@
           "404": {
             "description": "The supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2093,7 +2093,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2103,7 +2103,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2134,7 +2134,7 @@
         "requestBody": {
           "description": "The identities of the staffMembers to assign to the cashiers relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2153,7 +2153,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2163,7 +2163,7 @@
           "404": {
             "description": "The supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2173,7 +2173,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2183,7 +2183,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2214,7 +2214,7 @@
         "requestBody": {
           "description": "The identities of the staffMembers to remove from the cashiers relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2233,7 +2233,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2243,7 +2243,7 @@
           "404": {
             "description": "The supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2253,7 +2253,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2263,7 +2263,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2327,7 +2327,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryStaffMemberResponseDocument"
                 }
@@ -2349,7 +2349,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2359,7 +2359,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2505,7 +2505,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/staffMemberIdentifierResponseDocument"
                 }
@@ -2527,7 +2527,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2537,7 +2537,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2650,7 +2650,7 @@
         "requestBody": {
           "description": "The identity of the staffMember to assign to the storeManager relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2669,7 +2669,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2679,7 +2679,7 @@
           "404": {
             "description": "The supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2689,7 +2689,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2699,7 +2699,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/NamingConventions/KebabCase/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/NamingConventions/KebabCase/GeneratedSwagger/swagger.g.json
@@ -20,7 +20,7 @@
         "requestBody": {
           "description": "An array of mutation operations. For syntax, see the [Atomic Operations documentation](https://jsonapi.org/ext/atomic/).",
           "content": {
-            "application/vnd.api+json; ext=atomic; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -36,7 +36,7 @@
           "200": {
             "description": "All operations were successfully applied, which resulted in additional changes.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/operations-response-document"
                 }
@@ -49,7 +49,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -59,7 +59,7 @@
           "403": {
             "description": "An operation is not accessible or a client-generated ID is used.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -69,7 +69,7 @@
           "404": {
             "description": "A resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -79,7 +79,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -89,7 +89,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -142,7 +142,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/staff-member-collection-response-document"
                 }
@@ -164,7 +164,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -265,7 +265,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the staff-member to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -291,7 +291,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-staff-member-response-document"
                 }
@@ -304,7 +304,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -314,7 +314,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -324,7 +324,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -334,7 +334,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -344,7 +344,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -408,7 +408,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-staff-member-response-document"
                 }
@@ -430,7 +430,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -440,7 +440,7 @@
           "404": {
             "description": "The staff-member does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -566,7 +566,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the staff-member to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -582,7 +582,7 @@
           "200": {
             "description": "The staff-member was successfully updated, which resulted in additional changes. The updated staff-member is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-staff-member-response-document"
                 }
@@ -595,7 +595,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -605,7 +605,7 @@
           "404": {
             "description": "The staff-member or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -615,7 +615,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -625,7 +625,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -660,7 +660,7 @@
           "404": {
             "description": "The staff-member does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -713,7 +713,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/supermarket-collection-response-document"
                 }
@@ -735,7 +735,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -836,7 +836,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the supermarket to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -862,7 +862,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-supermarket-response-document"
                 }
@@ -875,7 +875,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -885,7 +885,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -895,7 +895,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -905,7 +905,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -915,7 +915,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -979,7 +979,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-supermarket-response-document"
                 }
@@ -1001,7 +1001,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1011,7 +1011,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1137,7 +1137,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the supermarket to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1153,7 +1153,7 @@
           "200": {
             "description": "The supermarket was successfully updated, which resulted in additional changes. The updated supermarket is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primary-supermarket-response-document"
                 }
@@ -1166,7 +1166,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1176,7 +1176,7 @@
           "404": {
             "description": "The supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1186,7 +1186,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1196,7 +1196,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1231,7 +1231,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1295,7 +1295,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullable-secondary-staff-member-response-document"
                 }
@@ -1317,7 +1317,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1327,7 +1327,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1473,7 +1473,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullable-staff-member-identifier-response-document"
                 }
@@ -1495,7 +1495,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1505,7 +1505,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1618,7 +1618,7 @@
         "requestBody": {
           "description": "The identity of the staff-member to assign to the backup-store-manager relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1637,7 +1637,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1647,7 +1647,7 @@
           "404": {
             "description": "The supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1657,7 +1657,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1667,7 +1667,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1731,7 +1731,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/staff-member-collection-response-document"
                 }
@@ -1753,7 +1753,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1763,7 +1763,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1909,7 +1909,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/staff-member-identifier-collection-response-document"
                 }
@@ -1931,7 +1931,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -1941,7 +1941,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2054,7 +2054,7 @@
         "requestBody": {
           "description": "The identities of the staff-members to add to the cashiers relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2073,7 +2073,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2083,7 +2083,7 @@
           "404": {
             "description": "The supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2093,7 +2093,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2103,7 +2103,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2134,7 +2134,7 @@
         "requestBody": {
           "description": "The identities of the staff-members to assign to the cashiers relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2153,7 +2153,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2163,7 +2163,7 @@
           "404": {
             "description": "The supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2173,7 +2173,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2183,7 +2183,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2214,7 +2214,7 @@
         "requestBody": {
           "description": "The identities of the staff-members to remove from the cashiers relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2233,7 +2233,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2243,7 +2243,7 @@
           "404": {
             "description": "The supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2253,7 +2253,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2263,7 +2263,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2327,7 +2327,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondary-staff-member-response-document"
                 }
@@ -2349,7 +2349,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2359,7 +2359,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2505,7 +2505,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/staff-member-identifier-response-document"
                 }
@@ -2527,7 +2527,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2537,7 +2537,7 @@
           "404": {
             "description": "The supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2650,7 +2650,7 @@
         "requestBody": {
           "description": "The identity of the staff-member to assign to the store-manager relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2669,7 +2669,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2679,7 +2679,7 @@
           "404": {
             "description": "The supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2689,7 +2689,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }
@@ -2699,7 +2699,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/error-response-document"
                 }

--- a/test/OpenApiTests/NamingConventions/KebabCase/KebabCaseTests.cs
+++ b/test/OpenApiTests/NamingConventions/KebabCase/KebabCaseTests.cs
@@ -7,8 +7,10 @@ namespace OpenApiTests.NamingConventions.KebabCase;
 
 public sealed class KebabCaseTests : IClassFixture<OpenApiTestContext<KebabCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext>>
 {
-    private const string EscapedJsonApiMediaType = "['application/vnd.api+json; ext=openapi']";
-    private const string EscapedOperationsMediaType = "['application/vnd.api+json; ext=atomic; ext=openapi']";
+    private const string EscapedJsonApiMediaType = """['application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"']""";
+
+    private const string EscapedOperationsMediaType =
+        """['application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"']""";
 
     private readonly OpenApiTestContext<KebabCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext> _testContext;
 

--- a/test/OpenApiTests/NamingConventions/PascalCase/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/NamingConventions/PascalCase/GeneratedSwagger/swagger.g.json
@@ -20,7 +20,7 @@
         "requestBody": {
           "description": "An array of mutation operations. For syntax, see the [Atomic Operations documentation](https://jsonapi.org/ext/atomic/).",
           "content": {
-            "application/vnd.api+json; ext=atomic; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -36,7 +36,7 @@
           "200": {
             "description": "All operations were successfully applied, which resulted in additional changes.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/OperationsResponseDocument"
                 }
@@ -49,7 +49,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -59,7 +59,7 @@
           "403": {
             "description": "An operation is not accessible or a client-generated ID is used.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -69,7 +69,7 @@
           "404": {
             "description": "A resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -79,7 +79,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -89,7 +89,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -142,7 +142,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/StaffMemberCollectionResponseDocument"
                 }
@@ -164,7 +164,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -265,7 +265,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the StaffMember to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -291,7 +291,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/PrimaryStaffMemberResponseDocument"
                 }
@@ -304,7 +304,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -314,7 +314,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -324,7 +324,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -334,7 +334,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -344,7 +344,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -408,7 +408,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/PrimaryStaffMemberResponseDocument"
                 }
@@ -430,7 +430,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -440,7 +440,7 @@
           "404": {
             "description": "The StaffMember does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -566,7 +566,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the StaffMember to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -582,7 +582,7 @@
           "200": {
             "description": "The StaffMember was successfully updated, which resulted in additional changes. The updated StaffMember is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/PrimaryStaffMemberResponseDocument"
                 }
@@ -595,7 +595,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -605,7 +605,7 @@
           "404": {
             "description": "The StaffMember or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -615,7 +615,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -625,7 +625,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -660,7 +660,7 @@
           "404": {
             "description": "The StaffMember does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -713,7 +713,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/SupermarketCollectionResponseDocument"
                 }
@@ -735,7 +735,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -836,7 +836,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the Supermarket to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -862,7 +862,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/PrimarySupermarketResponseDocument"
                 }
@@ -875,7 +875,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -885,7 +885,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -895,7 +895,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -905,7 +905,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -915,7 +915,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -979,7 +979,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/PrimarySupermarketResponseDocument"
                 }
@@ -1001,7 +1001,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1011,7 +1011,7 @@
           "404": {
             "description": "The Supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1137,7 +1137,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the Supermarket to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1153,7 +1153,7 @@
           "200": {
             "description": "The Supermarket was successfully updated, which resulted in additional changes. The updated Supermarket is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/PrimarySupermarketResponseDocument"
                 }
@@ -1166,7 +1166,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1176,7 +1176,7 @@
           "404": {
             "description": "The Supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1186,7 +1186,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1196,7 +1196,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1231,7 +1231,7 @@
           "404": {
             "description": "The Supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1295,7 +1295,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/NullableSecondaryStaffMemberResponseDocument"
                 }
@@ -1317,7 +1317,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1327,7 +1327,7 @@
           "404": {
             "description": "The Supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1473,7 +1473,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/NullableStaffMemberIdentifierResponseDocument"
                 }
@@ -1495,7 +1495,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1505,7 +1505,7 @@
           "404": {
             "description": "The Supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1618,7 +1618,7 @@
         "requestBody": {
           "description": "The identity of the StaffMember to assign to the BackupStoreManager relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1637,7 +1637,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1647,7 +1647,7 @@
           "404": {
             "description": "The Supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1657,7 +1657,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1667,7 +1667,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1731,7 +1731,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/StaffMemberCollectionResponseDocument"
                 }
@@ -1753,7 +1753,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1763,7 +1763,7 @@
           "404": {
             "description": "The Supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1909,7 +1909,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/StaffMemberIdentifierCollectionResponseDocument"
                 }
@@ -1931,7 +1931,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -1941,7 +1941,7 @@
           "404": {
             "description": "The Supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2054,7 +2054,7 @@
         "requestBody": {
           "description": "The identities of the StaffMembers to add to the Cashiers relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2073,7 +2073,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2083,7 +2083,7 @@
           "404": {
             "description": "The Supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2093,7 +2093,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2103,7 +2103,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2134,7 +2134,7 @@
         "requestBody": {
           "description": "The identities of the StaffMembers to assign to the Cashiers relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2153,7 +2153,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2163,7 +2163,7 @@
           "404": {
             "description": "The Supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2173,7 +2173,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2183,7 +2183,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2214,7 +2214,7 @@
         "requestBody": {
           "description": "The identities of the StaffMembers to remove from the Cashiers relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2233,7 +2233,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2243,7 +2243,7 @@
           "404": {
             "description": "The Supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2253,7 +2253,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2263,7 +2263,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2327,7 +2327,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/SecondaryStaffMemberResponseDocument"
                 }
@@ -2349,7 +2349,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2359,7 +2359,7 @@
           "404": {
             "description": "The Supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2505,7 +2505,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/StaffMemberIdentifierResponseDocument"
                 }
@@ -2527,7 +2527,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2537,7 +2537,7 @@
           "404": {
             "description": "The Supermarket does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2650,7 +2650,7 @@
         "requestBody": {
           "description": "The identity of the StaffMember to assign to the StoreManager relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2669,7 +2669,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2679,7 +2679,7 @@
           "404": {
             "description": "The Supermarket or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2689,7 +2689,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }
@@ -2699,7 +2699,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponseDocument"
                 }

--- a/test/OpenApiTests/NamingConventions/PascalCase/PascalCaseTests.cs
+++ b/test/OpenApiTests/NamingConventions/PascalCase/PascalCaseTests.cs
@@ -7,8 +7,10 @@ namespace OpenApiTests.NamingConventions.PascalCase;
 
 public sealed class PascalCaseTests : IClassFixture<OpenApiTestContext<PascalCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext>>
 {
-    private const string EscapedJsonApiMediaType = "['application/vnd.api+json; ext=openapi']";
-    private const string EscapedOperationsMediaType = "['application/vnd.api+json; ext=atomic; ext=openapi']";
+    private const string EscapedJsonApiMediaType = """['application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"']""";
+
+    private const string EscapedOperationsMediaType =
+        """['application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"']""";
 
     private readonly OpenApiTestContext<PascalCaseNamingConventionStartup<NamingConventionDbContext>, NamingConventionDbContext> _testContext;
 

--- a/test/OpenApiTests/QueryStrings/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/QueryStrings/GeneratedSwagger/swagger.g.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nameValuePairCollectionResponseDocument"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -176,7 +176,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the nameValuePair to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -202,7 +202,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryNameValuePairResponseDocument"
                 }
@@ -215,7 +215,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -225,7 +225,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -235,7 +235,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -245,7 +245,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -255,7 +255,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -319,7 +319,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryNameValuePairResponseDocument"
                 }
@@ -341,7 +341,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -351,7 +351,7 @@
           "404": {
             "description": "The nameValuePair does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -477,7 +477,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the nameValuePair to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -493,7 +493,7 @@
           "200": {
             "description": "The nameValuePair was successfully updated, which resulted in additional changes. The updated nameValuePair is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryNameValuePairResponseDocument"
                 }
@@ -506,7 +506,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -516,7 +516,7 @@
           "404": {
             "description": "The nameValuePair or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -526,7 +526,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -536,7 +536,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -571,7 +571,7 @@
           "404": {
             "description": "The nameValuePair does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -635,7 +635,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryNodeResponseDocument"
                 }
@@ -657,7 +657,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -667,7 +667,7 @@
           "404": {
             "description": "The nameValuePair does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -813,7 +813,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nodeIdentifierResponseDocument"
                 }
@@ -835,7 +835,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -845,7 +845,7 @@
           "404": {
             "description": "The nameValuePair does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -958,7 +958,7 @@
         "requestBody": {
           "description": "The identity of the node to assign to the owner relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -977,7 +977,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -987,7 +987,7 @@
           "404": {
             "description": "The nameValuePair or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -997,7 +997,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1007,7 +1007,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1060,7 +1060,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nodeCollectionResponseDocument"
                 }
@@ -1082,7 +1082,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1183,7 +1183,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the node to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1209,7 +1209,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryNodeResponseDocument"
                 }
@@ -1222,7 +1222,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1232,7 +1232,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1242,7 +1242,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1252,7 +1252,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1262,7 +1262,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1326,7 +1326,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryNodeResponseDocument"
                 }
@@ -1348,7 +1348,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1358,7 +1358,7 @@
           "404": {
             "description": "The node does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1484,7 +1484,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the node to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1500,7 +1500,7 @@
           "200": {
             "description": "The node was successfully updated, which resulted in additional changes. The updated node is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryNodeResponseDocument"
                 }
@@ -1513,7 +1513,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1523,7 +1523,7 @@
           "404": {
             "description": "The node or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1533,7 +1533,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1543,7 +1543,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1578,7 +1578,7 @@
           "404": {
             "description": "The node does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1642,7 +1642,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nodeCollectionResponseDocument"
                 }
@@ -1664,7 +1664,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1674,7 +1674,7 @@
           "404": {
             "description": "The node does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1820,7 +1820,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nodeIdentifierCollectionResponseDocument"
                 }
@@ -1842,7 +1842,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1852,7 +1852,7 @@
           "404": {
             "description": "The node does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1965,7 +1965,7 @@
         "requestBody": {
           "description": "The identities of the nodes to add to the children relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1984,7 +1984,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1994,7 +1994,7 @@
           "404": {
             "description": "The node or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2004,7 +2004,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2014,7 +2014,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2045,7 +2045,7 @@
         "requestBody": {
           "description": "The identities of the nodes to assign to the children relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2064,7 +2064,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2074,7 +2074,7 @@
           "404": {
             "description": "The node or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2084,7 +2084,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2094,7 +2094,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2125,7 +2125,7 @@
         "requestBody": {
           "description": "The identities of the nodes to remove from the children relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2144,7 +2144,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2154,7 +2154,7 @@
           "404": {
             "description": "The node or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2164,7 +2164,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2174,7 +2174,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2238,7 +2238,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableSecondaryNodeResponseDocument"
                 }
@@ -2260,7 +2260,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2270,7 +2270,7 @@
           "404": {
             "description": "The node does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2416,7 +2416,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableNodeIdentifierResponseDocument"
                 }
@@ -2438,7 +2438,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2448,7 +2448,7 @@
           "404": {
             "description": "The node does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2561,7 +2561,7 @@
         "requestBody": {
           "description": "The identity of the node to assign to the parent relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2580,7 +2580,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2590,7 +2590,7 @@
           "404": {
             "description": "The node or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2600,7 +2600,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2610,7 +2610,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2674,7 +2674,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nameValuePairCollectionResponseDocument"
                 }
@@ -2696,7 +2696,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2706,7 +2706,7 @@
           "404": {
             "description": "The node does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2852,7 +2852,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nameValuePairIdentifierCollectionResponseDocument"
                 }
@@ -2874,7 +2874,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2884,7 +2884,7 @@
           "404": {
             "description": "The node does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2997,7 +2997,7 @@
         "requestBody": {
           "description": "The identities of the nameValuePairs to add to the values relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3016,7 +3016,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3026,7 +3026,7 @@
           "404": {
             "description": "The node or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3036,7 +3036,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3046,7 +3046,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3077,7 +3077,7 @@
         "requestBody": {
           "description": "The identities of the nameValuePairs to assign to the values relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3096,7 +3096,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3106,7 +3106,7 @@
           "404": {
             "description": "The node or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3116,7 +3116,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3126,7 +3126,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3157,7 +3157,7 @@
         "requestBody": {
           "description": "The identities of the nameValuePairs to remove from the values relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3176,7 +3176,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3186,7 +3186,7 @@
           "404": {
             "description": "The node or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3196,7 +3196,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3206,7 +3206,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOff/GeneratedSwagger/swagger.g.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/resourceCollectionResponseDocument"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -176,7 +176,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the resource to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -202,7 +202,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResourceResponseDocument"
                 }
@@ -215,7 +215,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -225,7 +225,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -235,7 +235,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -245,7 +245,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -255,7 +255,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -319,7 +319,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResourceResponseDocument"
                 }
@@ -341,7 +341,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -351,7 +351,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -477,7 +477,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the resource to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -493,7 +493,7 @@
           "200": {
             "description": "The resource was successfully updated, which resulted in additional changes. The updated resource is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResourceResponseDocument"
                 }
@@ -506,7 +506,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -516,7 +516,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -526,7 +526,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -536,7 +536,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -571,7 +571,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -635,7 +635,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyCollectionResponseDocument"
                 }
@@ -657,7 +657,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -667,7 +667,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -813,7 +813,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
                 }
@@ -835,7 +835,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -845,7 +845,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -958,7 +958,7 @@
         "requestBody": {
           "description": "The identities of the empties to add to the requiredToMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -977,7 +977,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -987,7 +987,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -997,7 +997,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1007,7 +1007,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1038,7 +1038,7 @@
         "requestBody": {
           "description": "The identities of the empties to assign to the requiredToMany relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1057,7 +1057,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1067,7 +1067,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1077,7 +1077,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1087,7 +1087,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1118,7 +1118,7 @@
         "requestBody": {
           "description": "The identities of the empties to remove from the requiredToMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1137,7 +1137,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1147,7 +1147,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1157,7 +1157,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1167,7 +1167,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1231,7 +1231,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableSecondaryEmptyResponseDocument"
                 }
@@ -1253,7 +1253,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1263,7 +1263,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1409,7 +1409,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableEmptyIdentifierResponseDocument"
                 }
@@ -1431,7 +1431,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1441,7 +1441,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1554,7 +1554,7 @@
         "requestBody": {
           "description": "The identity of the empty to assign to the requiredToOne relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1573,7 +1573,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1583,7 +1583,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1593,7 +1593,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1603,7 +1603,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1667,7 +1667,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyCollectionResponseDocument"
                 }
@@ -1689,7 +1689,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1699,7 +1699,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1845,7 +1845,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
                 }
@@ -1867,7 +1867,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1877,7 +1877,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1990,7 +1990,7 @@
         "requestBody": {
           "description": "The identities of the empties to add to the toMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2009,7 +2009,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2019,7 +2019,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2029,7 +2029,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2039,7 +2039,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2070,7 +2070,7 @@
         "requestBody": {
           "description": "The identities of the empties to assign to the toMany relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2089,7 +2089,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2099,7 +2099,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2109,7 +2109,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2119,7 +2119,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2150,7 +2150,7 @@
         "requestBody": {
           "description": "The identities of the empties to remove from the toMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2169,7 +2169,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2179,7 +2179,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2189,7 +2189,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2199,7 +2199,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2263,7 +2263,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableSecondaryEmptyResponseDocument"
                 }
@@ -2285,7 +2285,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2295,7 +2295,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2441,7 +2441,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableEmptyIdentifierResponseDocument"
                 }
@@ -2463,7 +2463,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2473,7 +2473,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2586,7 +2586,7 @@
         "requestBody": {
           "description": "The identity of the empty to assign to the toOne relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2605,7 +2605,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2615,7 +2615,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2625,7 +2625,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2635,7 +2635,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOff/ModelStateValidationOn/GeneratedSwagger/swagger.g.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/resourceCollectionResponseDocument"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -176,7 +176,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the resource to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -202,7 +202,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResourceResponseDocument"
                 }
@@ -215,7 +215,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -225,7 +225,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -235,7 +235,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -245,7 +245,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -255,7 +255,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -319,7 +319,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResourceResponseDocument"
                 }
@@ -341,7 +341,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -351,7 +351,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -477,7 +477,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the resource to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -493,7 +493,7 @@
           "200": {
             "description": "The resource was successfully updated, which resulted in additional changes. The updated resource is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResourceResponseDocument"
                 }
@@ -506,7 +506,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -516,7 +516,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -526,7 +526,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -536,7 +536,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -571,7 +571,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -635,7 +635,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyCollectionResponseDocument"
                 }
@@ -657,7 +657,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -667,7 +667,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -813,7 +813,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
                 }
@@ -835,7 +835,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -845,7 +845,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -958,7 +958,7 @@
         "requestBody": {
           "description": "The identities of the empties to add to the requiredToMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -977,7 +977,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -987,7 +987,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -997,7 +997,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1007,7 +1007,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1038,7 +1038,7 @@
         "requestBody": {
           "description": "The identities of the empties to assign to the requiredToMany relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1057,7 +1057,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1067,7 +1067,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1077,7 +1077,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1087,7 +1087,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1118,7 +1118,7 @@
         "requestBody": {
           "description": "The identities of the empties to remove from the requiredToMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1137,7 +1137,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1147,7 +1147,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1157,7 +1157,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1167,7 +1167,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1231,7 +1231,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryEmptyResponseDocument"
                 }
@@ -1253,7 +1253,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1263,7 +1263,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1409,7 +1409,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierResponseDocument"
                 }
@@ -1431,7 +1431,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1441,7 +1441,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1554,7 +1554,7 @@
         "requestBody": {
           "description": "The identity of the empty to assign to the requiredToOne relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1573,7 +1573,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1583,7 +1583,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1593,7 +1593,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1603,7 +1603,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1667,7 +1667,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyCollectionResponseDocument"
                 }
@@ -1689,7 +1689,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1699,7 +1699,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1845,7 +1845,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
                 }
@@ -1867,7 +1867,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1877,7 +1877,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1990,7 +1990,7 @@
         "requestBody": {
           "description": "The identities of the empties to add to the toMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2009,7 +2009,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2019,7 +2019,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2029,7 +2029,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2039,7 +2039,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2070,7 +2070,7 @@
         "requestBody": {
           "description": "The identities of the empties to assign to the toMany relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2089,7 +2089,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2099,7 +2099,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2109,7 +2109,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2119,7 +2119,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2150,7 +2150,7 @@
         "requestBody": {
           "description": "The identities of the empties to remove from the toMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2169,7 +2169,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2179,7 +2179,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2189,7 +2189,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2199,7 +2199,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2263,7 +2263,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableSecondaryEmptyResponseDocument"
                 }
@@ -2285,7 +2285,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2295,7 +2295,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2441,7 +2441,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableEmptyIdentifierResponseDocument"
                 }
@@ -2463,7 +2463,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2473,7 +2473,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2586,7 +2586,7 @@
         "requestBody": {
           "description": "The identity of the empty to assign to the toOne relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2605,7 +2605,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2615,7 +2615,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2625,7 +2625,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2635,7 +2635,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOff/GeneratedSwagger/swagger.g.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/resourceCollectionResponseDocument"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -176,7 +176,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the resource to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -202,7 +202,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResourceResponseDocument"
                 }
@@ -215,7 +215,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -225,7 +225,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -235,7 +235,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -245,7 +245,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -255,7 +255,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -319,7 +319,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResourceResponseDocument"
                 }
@@ -341,7 +341,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -351,7 +351,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -477,7 +477,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the resource to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -493,7 +493,7 @@
           "200": {
             "description": "The resource was successfully updated, which resulted in additional changes. The updated resource is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResourceResponseDocument"
                 }
@@ -506,7 +506,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -516,7 +516,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -526,7 +526,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -536,7 +536,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -571,7 +571,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -635,7 +635,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryEmptyResponseDocument"
                 }
@@ -657,7 +657,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -667,7 +667,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -813,7 +813,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierResponseDocument"
                 }
@@ -835,7 +835,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -845,7 +845,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -958,7 +958,7 @@
         "requestBody": {
           "description": "The identity of the empty to assign to the nonNullableToOne relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -977,7 +977,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -987,7 +987,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -997,7 +997,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1007,7 +1007,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1071,7 +1071,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableSecondaryEmptyResponseDocument"
                 }
@@ -1093,7 +1093,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1103,7 +1103,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1249,7 +1249,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableEmptyIdentifierResponseDocument"
                 }
@@ -1271,7 +1271,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1281,7 +1281,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1394,7 +1394,7 @@
         "requestBody": {
           "description": "The identity of the empty to assign to the nullableToOne relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1413,7 +1413,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1423,7 +1423,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1433,7 +1433,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1443,7 +1443,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1507,7 +1507,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryEmptyResponseDocument"
                 }
@@ -1529,7 +1529,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1539,7 +1539,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1685,7 +1685,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierResponseDocument"
                 }
@@ -1707,7 +1707,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1717,7 +1717,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1830,7 +1830,7 @@
         "requestBody": {
           "description": "The identity of the empty to assign to the requiredNonNullableToOne relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1849,7 +1849,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1859,7 +1859,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1869,7 +1869,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1879,7 +1879,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1943,7 +1943,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableSecondaryEmptyResponseDocument"
                 }
@@ -1965,7 +1965,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1975,7 +1975,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2121,7 +2121,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableEmptyIdentifierResponseDocument"
                 }
@@ -2143,7 +2143,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2153,7 +2153,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2266,7 +2266,7 @@
         "requestBody": {
           "description": "The identity of the empty to assign to the requiredNullableToOne relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2285,7 +2285,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2295,7 +2295,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2305,7 +2305,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2315,7 +2315,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2379,7 +2379,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyCollectionResponseDocument"
                 }
@@ -2401,7 +2401,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2411,7 +2411,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2557,7 +2557,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
                 }
@@ -2579,7 +2579,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2589,7 +2589,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2702,7 +2702,7 @@
         "requestBody": {
           "description": "The identities of the empties to add to the requiredToMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2721,7 +2721,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2731,7 +2731,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2741,7 +2741,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2751,7 +2751,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2782,7 +2782,7 @@
         "requestBody": {
           "description": "The identities of the empties to assign to the requiredToMany relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2801,7 +2801,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2811,7 +2811,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2821,7 +2821,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2831,7 +2831,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2862,7 +2862,7 @@
         "requestBody": {
           "description": "The identities of the empties to remove from the requiredToMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2881,7 +2881,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2891,7 +2891,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2901,7 +2901,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2911,7 +2911,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2975,7 +2975,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyCollectionResponseDocument"
                 }
@@ -2997,7 +2997,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3007,7 +3007,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3153,7 +3153,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
                 }
@@ -3175,7 +3175,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3185,7 +3185,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3298,7 +3298,7 @@
         "requestBody": {
           "description": "The identities of the empties to add to the toMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3317,7 +3317,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3327,7 +3327,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3337,7 +3337,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3347,7 +3347,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3378,7 +3378,7 @@
         "requestBody": {
           "description": "The identities of the empties to assign to the toMany relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3397,7 +3397,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3407,7 +3407,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3417,7 +3417,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3427,7 +3427,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3458,7 +3458,7 @@
         "requestBody": {
           "description": "The identities of the empties to remove from the toMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3477,7 +3477,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3487,7 +3487,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3497,7 +3497,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3507,7 +3507,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ResourceFieldValidation/NullableReferenceTypesOn/ModelStateValidationOn/GeneratedSwagger/swagger.g.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/resourceCollectionResponseDocument"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -176,7 +176,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the resource to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -202,7 +202,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResourceResponseDocument"
                 }
@@ -215,7 +215,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -225,7 +225,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -235,7 +235,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -245,7 +245,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -255,7 +255,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -319,7 +319,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResourceResponseDocument"
                 }
@@ -341,7 +341,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -351,7 +351,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -477,7 +477,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the resource to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -493,7 +493,7 @@
           "200": {
             "description": "The resource was successfully updated, which resulted in additional changes. The updated resource is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResourceResponseDocument"
                 }
@@ -506,7 +506,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -516,7 +516,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -526,7 +526,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -536,7 +536,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -571,7 +571,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -635,7 +635,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryEmptyResponseDocument"
                 }
@@ -657,7 +657,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -667,7 +667,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -813,7 +813,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierResponseDocument"
                 }
@@ -835,7 +835,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -845,7 +845,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -958,7 +958,7 @@
         "requestBody": {
           "description": "The identity of the empty to assign to the nonNullableToOne relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -977,7 +977,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -987,7 +987,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -997,7 +997,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1007,7 +1007,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1071,7 +1071,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableSecondaryEmptyResponseDocument"
                 }
@@ -1093,7 +1093,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1103,7 +1103,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1249,7 +1249,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableEmptyIdentifierResponseDocument"
                 }
@@ -1271,7 +1271,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1281,7 +1281,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1394,7 +1394,7 @@
         "requestBody": {
           "description": "The identity of the empty to assign to the nullableToOne relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1413,7 +1413,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1423,7 +1423,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1433,7 +1433,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1443,7 +1443,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1507,7 +1507,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryEmptyResponseDocument"
                 }
@@ -1529,7 +1529,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1539,7 +1539,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1685,7 +1685,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierResponseDocument"
                 }
@@ -1707,7 +1707,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1717,7 +1717,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1830,7 +1830,7 @@
         "requestBody": {
           "description": "The identity of the empty to assign to the requiredNonNullableToOne relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1849,7 +1849,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1859,7 +1859,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1869,7 +1869,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1879,7 +1879,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1943,7 +1943,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryEmptyResponseDocument"
                 }
@@ -1965,7 +1965,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1975,7 +1975,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2121,7 +2121,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierResponseDocument"
                 }
@@ -2143,7 +2143,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2153,7 +2153,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2266,7 +2266,7 @@
         "requestBody": {
           "description": "The identity of the empty to assign to the requiredNullableToOne relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2285,7 +2285,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2295,7 +2295,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2305,7 +2305,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2315,7 +2315,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2379,7 +2379,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyCollectionResponseDocument"
                 }
@@ -2401,7 +2401,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2411,7 +2411,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2557,7 +2557,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
                 }
@@ -2579,7 +2579,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2589,7 +2589,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2702,7 +2702,7 @@
         "requestBody": {
           "description": "The identities of the empties to add to the requiredToMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2721,7 +2721,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2731,7 +2731,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2741,7 +2741,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2751,7 +2751,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2782,7 +2782,7 @@
         "requestBody": {
           "description": "The identities of the empties to assign to the requiredToMany relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2801,7 +2801,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2811,7 +2811,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2821,7 +2821,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2831,7 +2831,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2862,7 +2862,7 @@
         "requestBody": {
           "description": "The identities of the empties to remove from the requiredToMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2881,7 +2881,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2891,7 +2891,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2901,7 +2901,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2911,7 +2911,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2975,7 +2975,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyCollectionResponseDocument"
                 }
@@ -2997,7 +2997,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3007,7 +3007,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3153,7 +3153,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/emptyIdentifierCollectionResponseDocument"
                 }
@@ -3175,7 +3175,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3185,7 +3185,7 @@
           "404": {
             "description": "The resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3298,7 +3298,7 @@
         "requestBody": {
           "description": "The identities of the empties to add to the toMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3317,7 +3317,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3327,7 +3327,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3337,7 +3337,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3347,7 +3347,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3378,7 +3378,7 @@
         "requestBody": {
           "description": "The identities of the empties to assign to the toMany relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3397,7 +3397,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3407,7 +3407,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3417,7 +3417,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3427,7 +3427,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3458,7 +3458,7 @@
         "requestBody": {
           "description": "The identities of the empties to remove from the toMany relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3477,7 +3477,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3487,7 +3487,7 @@
           "404": {
             "description": "The resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3497,7 +3497,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3507,7 +3507,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/ResourceInheritance/NoOperations/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ResourceInheritance/NoOperations/GeneratedSwagger/swagger.g.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/bathroomCollectionResponseDocument"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -176,7 +176,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the bathroom to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -202,7 +202,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBathroomResponseDocument"
                 }
@@ -215,7 +215,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -225,7 +225,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -235,7 +235,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -245,7 +245,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -255,7 +255,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -319,7 +319,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBathroomResponseDocument"
                 }
@@ -341,7 +341,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -351,7 +351,7 @@
           "404": {
             "description": "The bathroom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -477,7 +477,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the bathroom to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -493,7 +493,7 @@
           "200": {
             "description": "The bathroom was successfully updated, which resulted in additional changes. The updated bathroom is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBathroomResponseDocument"
                 }
@@ -506,7 +506,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -516,7 +516,7 @@
           "404": {
             "description": "The bathroom or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -526,7 +526,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -536,7 +536,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -571,7 +571,7 @@
           "404": {
             "description": "The bathroom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -635,7 +635,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryResidenceResponseDocument"
                 }
@@ -657,7 +657,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -667,7 +667,7 @@
           "404": {
             "description": "The bathroom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -813,7 +813,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceIdentifierResponseDocument"
                 }
@@ -835,7 +835,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -845,7 +845,7 @@
           "404": {
             "description": "The bathroom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -958,7 +958,7 @@
         "requestBody": {
           "description": "The identity of the residence to assign to the residence relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -977,7 +977,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -987,7 +987,7 @@
           "404": {
             "description": "The bathroom or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -997,7 +997,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1007,7 +1007,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1060,7 +1060,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/bedroomCollectionResponseDocument"
                 }
@@ -1082,7 +1082,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1183,7 +1183,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the bedroom to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1209,7 +1209,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBedroomResponseDocument"
                 }
@@ -1222,7 +1222,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1232,7 +1232,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1242,7 +1242,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1252,7 +1252,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1262,7 +1262,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1326,7 +1326,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBedroomResponseDocument"
                 }
@@ -1348,7 +1348,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1358,7 +1358,7 @@
           "404": {
             "description": "The bedroom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1484,7 +1484,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the bedroom to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1500,7 +1500,7 @@
           "200": {
             "description": "The bedroom was successfully updated, which resulted in additional changes. The updated bedroom is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBedroomResponseDocument"
                 }
@@ -1513,7 +1513,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1523,7 +1523,7 @@
           "404": {
             "description": "The bedroom or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1533,7 +1533,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1543,7 +1543,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1578,7 +1578,7 @@
           "404": {
             "description": "The bedroom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1642,7 +1642,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryResidenceResponseDocument"
                 }
@@ -1664,7 +1664,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1674,7 +1674,7 @@
           "404": {
             "description": "The bedroom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1820,7 +1820,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceIdentifierResponseDocument"
                 }
@@ -1842,7 +1842,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1852,7 +1852,7 @@
           "404": {
             "description": "The bedroom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1965,7 +1965,7 @@
         "requestBody": {
           "description": "The identity of the residence to assign to the residence relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1984,7 +1984,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1994,7 +1994,7 @@
           "404": {
             "description": "The bedroom or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2004,7 +2004,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2014,7 +2014,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2067,7 +2067,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/buildingCollectionResponseDocument"
                 }
@@ -2089,7 +2089,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2190,7 +2190,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the building to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2216,7 +2216,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBuildingResponseDocument"
                 }
@@ -2229,7 +2229,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2239,7 +2239,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2249,7 +2249,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2259,7 +2259,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2269,7 +2269,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2333,7 +2333,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBuildingResponseDocument"
                 }
@@ -2355,7 +2355,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2365,7 +2365,7 @@
           "404": {
             "description": "The building does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2491,7 +2491,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the building to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2507,7 +2507,7 @@
           "200": {
             "description": "The building was successfully updated, which resulted in additional changes. The updated building is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBuildingResponseDocument"
                 }
@@ -2520,7 +2520,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2530,7 +2530,7 @@
           "404": {
             "description": "The building or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2540,7 +2540,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2550,7 +2550,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2585,7 +2585,7 @@
           "404": {
             "description": "The building does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2638,7 +2638,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/cyclePathCollectionResponseDocument"
                 }
@@ -2660,7 +2660,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2761,7 +2761,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the cyclePath to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2787,7 +2787,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryCyclePathResponseDocument"
                 }
@@ -2800,7 +2800,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2810,7 +2810,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2820,7 +2820,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2830,7 +2830,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2840,7 +2840,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2904,7 +2904,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryCyclePathResponseDocument"
                 }
@@ -2926,7 +2926,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2936,7 +2936,7 @@
           "404": {
             "description": "The cyclePath does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3062,7 +3062,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the cyclePath to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3078,7 +3078,7 @@
           "200": {
             "description": "The cyclePath was successfully updated, which resulted in additional changes. The updated cyclePath is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryCyclePathResponseDocument"
                 }
@@ -3091,7 +3091,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3101,7 +3101,7 @@
           "404": {
             "description": "The cyclePath or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3111,7 +3111,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3121,7 +3121,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3156,7 +3156,7 @@
           "404": {
             "description": "The cyclePath does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3209,7 +3209,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/districtCollectionResponseDocument"
                 }
@@ -3231,7 +3231,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3332,7 +3332,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the district to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3358,7 +3358,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryDistrictResponseDocument"
                 }
@@ -3371,7 +3371,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3381,7 +3381,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3391,7 +3391,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3401,7 +3401,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3411,7 +3411,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3475,7 +3475,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryDistrictResponseDocument"
                 }
@@ -3497,7 +3497,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3507,7 +3507,7 @@
           "404": {
             "description": "The district does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3633,7 +3633,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the district to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3649,7 +3649,7 @@
           "200": {
             "description": "The district was successfully updated, which resulted in additional changes. The updated district is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryDistrictResponseDocument"
                 }
@@ -3662,7 +3662,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3672,7 +3672,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3682,7 +3682,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3692,7 +3692,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3727,7 +3727,7 @@
           "404": {
             "description": "The district does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3791,7 +3791,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/buildingCollectionResponseDocument"
                 }
@@ -3813,7 +3813,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3823,7 +3823,7 @@
           "404": {
             "description": "The district does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3969,7 +3969,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/buildingIdentifierCollectionResponseDocument"
                 }
@@ -3991,7 +3991,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4001,7 +4001,7 @@
           "404": {
             "description": "The district does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4114,7 +4114,7 @@
         "requestBody": {
           "description": "The identities of the buildings to add to the buildings relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4133,7 +4133,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4143,7 +4143,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4153,7 +4153,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4163,7 +4163,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4194,7 +4194,7 @@
         "requestBody": {
           "description": "The identities of the buildings to assign to the buildings relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4213,7 +4213,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4223,7 +4223,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4233,7 +4233,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4243,7 +4243,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4274,7 +4274,7 @@
         "requestBody": {
           "description": "The identities of the buildings to remove from the buildings relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4293,7 +4293,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4303,7 +4303,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4313,7 +4313,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4323,7 +4323,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4387,7 +4387,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roadCollectionResponseDocument"
                 }
@@ -4409,7 +4409,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4419,7 +4419,7 @@
           "404": {
             "description": "The district does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4565,7 +4565,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roadIdentifierCollectionResponseDocument"
                 }
@@ -4587,7 +4587,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4597,7 +4597,7 @@
           "404": {
             "description": "The district does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4710,7 +4710,7 @@
         "requestBody": {
           "description": "The identities of the roads to add to the roads relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4729,7 +4729,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4739,7 +4739,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4749,7 +4749,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4759,7 +4759,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4790,7 +4790,7 @@
         "requestBody": {
           "description": "The identities of the roads to assign to the roads relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4809,7 +4809,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4819,7 +4819,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4829,7 +4829,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4839,7 +4839,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4870,7 +4870,7 @@
         "requestBody": {
           "description": "The identities of the roads to remove from the roads relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4889,7 +4889,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4899,7 +4899,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4909,7 +4909,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4919,7 +4919,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4972,7 +4972,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/familyHomeCollectionResponseDocument"
                 }
@@ -4994,7 +4994,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5095,7 +5095,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the familyHome to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5121,7 +5121,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryFamilyHomeResponseDocument"
                 }
@@ -5134,7 +5134,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5144,7 +5144,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5154,7 +5154,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5164,7 +5164,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5174,7 +5174,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5238,7 +5238,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryFamilyHomeResponseDocument"
                 }
@@ -5260,7 +5260,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5270,7 +5270,7 @@
           "404": {
             "description": "The familyHome does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5396,7 +5396,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the familyHome to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5412,7 +5412,7 @@
           "200": {
             "description": "The familyHome was successfully updated, which resulted in additional changes. The updated familyHome is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryFamilyHomeResponseDocument"
                 }
@@ -5425,7 +5425,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5435,7 +5435,7 @@
           "404": {
             "description": "The familyHome or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5445,7 +5445,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5455,7 +5455,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5490,7 +5490,7 @@
           "404": {
             "description": "The familyHome does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5554,7 +5554,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roomCollectionResponseDocument"
                 }
@@ -5576,7 +5576,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5586,7 +5586,7 @@
           "404": {
             "description": "The familyHome does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5732,7 +5732,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roomIdentifierCollectionResponseDocument"
                 }
@@ -5754,7 +5754,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5764,7 +5764,7 @@
           "404": {
             "description": "The familyHome does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5877,7 +5877,7 @@
         "requestBody": {
           "description": "The identities of the rooms to add to the rooms relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5896,7 +5896,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5906,7 +5906,7 @@
           "404": {
             "description": "The familyHome or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5916,7 +5916,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5926,7 +5926,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5957,7 +5957,7 @@
         "requestBody": {
           "description": "The identities of the rooms to assign to the rooms relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -5976,7 +5976,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5986,7 +5986,7 @@
           "404": {
             "description": "The familyHome or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -5996,7 +5996,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6006,7 +6006,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6037,7 +6037,7 @@
         "requestBody": {
           "description": "The identities of the rooms to remove from the rooms relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -6056,7 +6056,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6066,7 +6066,7 @@
           "404": {
             "description": "The familyHome or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6076,7 +6076,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6086,7 +6086,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6139,7 +6139,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/kitchenCollectionResponseDocument"
                 }
@@ -6161,7 +6161,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6262,7 +6262,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the kitchen to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -6288,7 +6288,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryKitchenResponseDocument"
                 }
@@ -6301,7 +6301,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6311,7 +6311,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6321,7 +6321,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6331,7 +6331,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6341,7 +6341,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6405,7 +6405,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryKitchenResponseDocument"
                 }
@@ -6427,7 +6427,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6437,7 +6437,7 @@
           "404": {
             "description": "The kitchen does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6563,7 +6563,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the kitchen to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -6579,7 +6579,7 @@
           "200": {
             "description": "The kitchen was successfully updated, which resulted in additional changes. The updated kitchen is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryKitchenResponseDocument"
                 }
@@ -6592,7 +6592,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6602,7 +6602,7 @@
           "404": {
             "description": "The kitchen or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6612,7 +6612,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6622,7 +6622,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6657,7 +6657,7 @@
           "404": {
             "description": "The kitchen does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6721,7 +6721,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryResidenceResponseDocument"
                 }
@@ -6743,7 +6743,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6753,7 +6753,7 @@
           "404": {
             "description": "The kitchen does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6899,7 +6899,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceIdentifierResponseDocument"
                 }
@@ -6921,7 +6921,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -6931,7 +6931,7 @@
           "404": {
             "description": "The kitchen does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7044,7 +7044,7 @@
         "requestBody": {
           "description": "The identity of the residence to assign to the residence relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -7063,7 +7063,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7073,7 +7073,7 @@
           "404": {
             "description": "The kitchen or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7083,7 +7083,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7093,7 +7093,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7146,7 +7146,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/livingRoomCollectionResponseDocument"
                 }
@@ -7168,7 +7168,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7269,7 +7269,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the livingRoom to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -7295,7 +7295,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryLivingRoomResponseDocument"
                 }
@@ -7308,7 +7308,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7318,7 +7318,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7328,7 +7328,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7338,7 +7338,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7348,7 +7348,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7412,7 +7412,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryLivingRoomResponseDocument"
                 }
@@ -7434,7 +7434,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7444,7 +7444,7 @@
           "404": {
             "description": "The livingRoom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7570,7 +7570,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the livingRoom to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -7586,7 +7586,7 @@
           "200": {
             "description": "The livingRoom was successfully updated, which resulted in additional changes. The updated livingRoom is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryLivingRoomResponseDocument"
                 }
@@ -7599,7 +7599,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7609,7 +7609,7 @@
           "404": {
             "description": "The livingRoom or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7619,7 +7619,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7629,7 +7629,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7664,7 +7664,7 @@
           "404": {
             "description": "The livingRoom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7728,7 +7728,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryResidenceResponseDocument"
                 }
@@ -7750,7 +7750,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7760,7 +7760,7 @@
           "404": {
             "description": "The livingRoom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7906,7 +7906,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceIdentifierResponseDocument"
                 }
@@ -7928,7 +7928,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -7938,7 +7938,7 @@
           "404": {
             "description": "The livingRoom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8051,7 +8051,7 @@
         "requestBody": {
           "description": "The identity of the residence to assign to the residence relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -8070,7 +8070,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8080,7 +8080,7 @@
           "404": {
             "description": "The livingRoom or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8090,7 +8090,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8100,7 +8100,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8153,7 +8153,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/mansionCollectionResponseDocument"
                 }
@@ -8175,7 +8175,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8276,7 +8276,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the mansion to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -8302,7 +8302,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryMansionResponseDocument"
                 }
@@ -8315,7 +8315,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8325,7 +8325,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8335,7 +8335,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8345,7 +8345,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8355,7 +8355,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8419,7 +8419,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryMansionResponseDocument"
                 }
@@ -8441,7 +8441,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8451,7 +8451,7 @@
           "404": {
             "description": "The mansion does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8577,7 +8577,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the mansion to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -8593,7 +8593,7 @@
           "200": {
             "description": "The mansion was successfully updated, which resulted in additional changes. The updated mansion is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryMansionResponseDocument"
                 }
@@ -8606,7 +8606,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8616,7 +8616,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8626,7 +8626,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8636,7 +8636,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8671,7 +8671,7 @@
           "404": {
             "description": "The mansion does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8735,7 +8735,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roomCollectionResponseDocument"
                 }
@@ -8757,7 +8757,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8767,7 +8767,7 @@
           "404": {
             "description": "The mansion does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8913,7 +8913,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roomIdentifierCollectionResponseDocument"
                 }
@@ -8935,7 +8935,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -8945,7 +8945,7 @@
           "404": {
             "description": "The mansion does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9058,7 +9058,7 @@
         "requestBody": {
           "description": "The identities of the rooms to add to the rooms relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -9077,7 +9077,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9087,7 +9087,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9097,7 +9097,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9107,7 +9107,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9138,7 +9138,7 @@
         "requestBody": {
           "description": "The identities of the rooms to assign to the rooms relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -9157,7 +9157,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9167,7 +9167,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9177,7 +9177,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9187,7 +9187,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9218,7 +9218,7 @@
         "requestBody": {
           "description": "The identities of the rooms to remove from the rooms relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -9237,7 +9237,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9247,7 +9247,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9257,7 +9257,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9267,7 +9267,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9331,7 +9331,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/staffMemberCollectionResponseDocument"
                 }
@@ -9353,7 +9353,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9363,7 +9363,7 @@
           "404": {
             "description": "The mansion does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9509,7 +9509,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/staffMemberIdentifierCollectionResponseDocument"
                 }
@@ -9531,7 +9531,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9541,7 +9541,7 @@
           "404": {
             "description": "The mansion does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9654,7 +9654,7 @@
         "requestBody": {
           "description": "The identities of the staffMembers to add to the staff relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -9673,7 +9673,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9683,7 +9683,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9693,7 +9693,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9703,7 +9703,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9734,7 +9734,7 @@
         "requestBody": {
           "description": "The identities of the staffMembers to assign to the staff relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -9753,7 +9753,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9763,7 +9763,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9773,7 +9773,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9783,7 +9783,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9814,7 +9814,7 @@
         "requestBody": {
           "description": "The identities of the staffMembers to remove from the staff relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -9833,7 +9833,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9843,7 +9843,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9853,7 +9853,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9863,7 +9863,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9883,7 +9883,7 @@
         "requestBody": {
           "description": "An array of mutation operations. For syntax, see the [Atomic Operations documentation](https://jsonapi.org/ext/atomic/).",
           "content": {
-            "application/vnd.api+json; ext=atomic; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -9899,7 +9899,7 @@
           "200": {
             "description": "All operations were successfully applied, which resulted in additional changes.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/operationsResponseDocument"
                 }
@@ -9912,7 +9912,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9922,7 +9922,7 @@
           "403": {
             "description": "An operation is not accessible or a client-generated ID is used.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9932,7 +9932,7 @@
           "404": {
             "description": "A resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9942,7 +9942,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -9952,7 +9952,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10005,7 +10005,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceCollectionResponseDocument"
                 }
@@ -10027,7 +10027,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10128,7 +10128,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the residence to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -10154,7 +10154,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResidenceResponseDocument"
                 }
@@ -10167,7 +10167,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10177,7 +10177,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10187,7 +10187,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10197,7 +10197,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10207,7 +10207,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10271,7 +10271,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResidenceResponseDocument"
                 }
@@ -10293,7 +10293,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10303,7 +10303,7 @@
           "404": {
             "description": "The residence does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10429,7 +10429,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the residence to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -10445,7 +10445,7 @@
           "200": {
             "description": "The residence was successfully updated, which resulted in additional changes. The updated residence is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryResidenceResponseDocument"
                 }
@@ -10458,7 +10458,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10468,7 +10468,7 @@
           "404": {
             "description": "The residence or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10478,7 +10478,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10488,7 +10488,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10523,7 +10523,7 @@
           "404": {
             "description": "The residence does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10587,7 +10587,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roomCollectionResponseDocument"
                 }
@@ -10609,7 +10609,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10619,7 +10619,7 @@
           "404": {
             "description": "The residence does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10765,7 +10765,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roomIdentifierCollectionResponseDocument"
                 }
@@ -10787,7 +10787,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10797,7 +10797,7 @@
           "404": {
             "description": "The residence does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10910,7 +10910,7 @@
         "requestBody": {
           "description": "The identities of the rooms to add to the rooms relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -10929,7 +10929,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10939,7 +10939,7 @@
           "404": {
             "description": "The residence or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10949,7 +10949,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10959,7 +10959,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -10990,7 +10990,7 @@
         "requestBody": {
           "description": "The identities of the rooms to assign to the rooms relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -11009,7 +11009,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11019,7 +11019,7 @@
           "404": {
             "description": "The residence or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11029,7 +11029,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11039,7 +11039,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11070,7 +11070,7 @@
         "requestBody": {
           "description": "The identities of the rooms to remove from the rooms relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -11089,7 +11089,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11099,7 +11099,7 @@
           "404": {
             "description": "The residence or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11109,7 +11109,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11119,7 +11119,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11172,7 +11172,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roadCollectionResponseDocument"
                 }
@@ -11194,7 +11194,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11295,7 +11295,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the road to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -11321,7 +11321,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryRoadResponseDocument"
                 }
@@ -11334,7 +11334,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11344,7 +11344,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11354,7 +11354,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11364,7 +11364,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11374,7 +11374,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11438,7 +11438,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryRoadResponseDocument"
                 }
@@ -11460,7 +11460,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11470,7 +11470,7 @@
           "404": {
             "description": "The road does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11596,7 +11596,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the road to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -11612,7 +11612,7 @@
           "200": {
             "description": "The road was successfully updated, which resulted in additional changes. The updated road is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryRoadResponseDocument"
                 }
@@ -11625,7 +11625,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11635,7 +11635,7 @@
           "404": {
             "description": "The road or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11645,7 +11645,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11655,7 +11655,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11690,7 +11690,7 @@
           "404": {
             "description": "The road does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11743,7 +11743,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roomCollectionResponseDocument"
                 }
@@ -11765,7 +11765,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11866,7 +11866,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the room to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -11892,7 +11892,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryRoomResponseDocument"
                 }
@@ -11905,7 +11905,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11915,7 +11915,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11925,7 +11925,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11935,7 +11935,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -11945,7 +11945,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12009,7 +12009,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryRoomResponseDocument"
                 }
@@ -12031,7 +12031,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12041,7 +12041,7 @@
           "404": {
             "description": "The room does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12167,7 +12167,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the room to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -12183,7 +12183,7 @@
           "200": {
             "description": "The room was successfully updated, which resulted in additional changes. The updated room is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryRoomResponseDocument"
                 }
@@ -12196,7 +12196,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12206,7 +12206,7 @@
           "404": {
             "description": "The room or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12216,7 +12216,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12226,7 +12226,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12261,7 +12261,7 @@
           "404": {
             "description": "The room does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12325,7 +12325,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryResidenceResponseDocument"
                 }
@@ -12347,7 +12347,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12357,7 +12357,7 @@
           "404": {
             "description": "The room does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12503,7 +12503,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceIdentifierResponseDocument"
                 }
@@ -12525,7 +12525,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12535,7 +12535,7 @@
           "404": {
             "description": "The room does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12648,7 +12648,7 @@
         "requestBody": {
           "description": "The identity of the residence to assign to the residence relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -12667,7 +12667,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12677,7 +12677,7 @@
           "404": {
             "description": "The room or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12687,7 +12687,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12697,7 +12697,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12750,7 +12750,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/staffMemberCollectionResponseDocument"
                 }
@@ -12772,7 +12772,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12873,7 +12873,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the staffMember to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -12899,7 +12899,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryStaffMemberResponseDocument"
                 }
@@ -12912,7 +12912,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12922,7 +12922,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12932,7 +12932,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12942,7 +12942,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -12952,7 +12952,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13016,7 +13016,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryStaffMemberResponseDocument"
                 }
@@ -13038,7 +13038,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13048,7 +13048,7 @@
           "404": {
             "description": "The staffMember does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13174,7 +13174,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the staffMember to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -13190,7 +13190,7 @@
           "200": {
             "description": "The staffMember was successfully updated, which resulted in additional changes. The updated staffMember is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryStaffMemberResponseDocument"
                 }
@@ -13203,7 +13203,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13213,7 +13213,7 @@
           "404": {
             "description": "The staffMember or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13223,7 +13223,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13233,7 +13233,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13268,7 +13268,7 @@
           "404": {
             "description": "The staffMember does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13321,7 +13321,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/toiletCollectionResponseDocument"
                 }
@@ -13343,7 +13343,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13444,7 +13444,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the toilet to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -13470,7 +13470,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryToiletResponseDocument"
                 }
@@ -13483,7 +13483,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13493,7 +13493,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13503,7 +13503,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13513,7 +13513,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13523,7 +13523,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13587,7 +13587,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryToiletResponseDocument"
                 }
@@ -13609,7 +13609,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13619,7 +13619,7 @@
           "404": {
             "description": "The toilet does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13745,7 +13745,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the toilet to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -13761,7 +13761,7 @@
           "200": {
             "description": "The toilet was successfully updated, which resulted in additional changes. The updated toilet is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryToiletResponseDocument"
                 }
@@ -13774,7 +13774,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13784,7 +13784,7 @@
           "404": {
             "description": "The toilet or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13794,7 +13794,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13804,7 +13804,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13839,7 +13839,7 @@
           "404": {
             "description": "The toilet does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13903,7 +13903,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryResidenceResponseDocument"
                 }
@@ -13925,7 +13925,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -13935,7 +13935,7 @@
           "404": {
             "description": "The toilet does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -14081,7 +14081,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceIdentifierResponseDocument"
                 }
@@ -14103,7 +14103,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -14113,7 +14113,7 @@
           "404": {
             "description": "The toilet does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -14226,7 +14226,7 @@
         "requestBody": {
           "description": "The identity of the residence to assign to the residence relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -14245,7 +14245,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -14255,7 +14255,7 @@
           "404": {
             "description": "The toilet or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -14265,7 +14265,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -14275,7 +14275,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/ResourceInheritance/OnlyRelationships/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ResourceInheritance/OnlyRelationships/GeneratedSwagger/swagger.g.json
@@ -64,7 +64,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceIdentifierResponseDocument"
                 }
@@ -86,7 +86,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -96,7 +96,7 @@
           "404": {
             "description": "The bathroom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -209,7 +209,7 @@
         "requestBody": {
           "description": "The identity of the residence to assign to the residence relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -228,7 +228,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -238,7 +238,7 @@
           "404": {
             "description": "The bathroom or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -248,7 +248,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -258,7 +258,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -322,7 +322,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceIdentifierResponseDocument"
                 }
@@ -344,7 +344,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -354,7 +354,7 @@
           "404": {
             "description": "The bedroom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -467,7 +467,7 @@
         "requestBody": {
           "description": "The identity of the residence to assign to the residence relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -486,7 +486,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -496,7 +496,7 @@
           "404": {
             "description": "The bedroom or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -506,7 +506,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -516,7 +516,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -580,7 +580,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/buildingIdentifierCollectionResponseDocument"
                 }
@@ -602,7 +602,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -612,7 +612,7 @@
           "404": {
             "description": "The district does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -725,7 +725,7 @@
         "requestBody": {
           "description": "The identities of the buildings to add to the buildings relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -744,7 +744,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -754,7 +754,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -764,7 +764,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -774,7 +774,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -805,7 +805,7 @@
         "requestBody": {
           "description": "The identities of the buildings to assign to the buildings relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -824,7 +824,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -834,7 +834,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -844,7 +844,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -854,7 +854,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -885,7 +885,7 @@
         "requestBody": {
           "description": "The identities of the buildings to remove from the buildings relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -904,7 +904,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -914,7 +914,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -924,7 +924,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -934,7 +934,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -998,7 +998,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roadIdentifierCollectionResponseDocument"
                 }
@@ -1020,7 +1020,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1030,7 +1030,7 @@
           "404": {
             "description": "The district does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1143,7 +1143,7 @@
         "requestBody": {
           "description": "The identities of the roads to add to the roads relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1162,7 +1162,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1172,7 +1172,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1182,7 +1182,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1192,7 +1192,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1223,7 +1223,7 @@
         "requestBody": {
           "description": "The identities of the roads to assign to the roads relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1242,7 +1242,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1252,7 +1252,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1262,7 +1262,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1272,7 +1272,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1303,7 +1303,7 @@
         "requestBody": {
           "description": "The identities of the roads to remove from the roads relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1322,7 +1322,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1332,7 +1332,7 @@
           "404": {
             "description": "The district or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1342,7 +1342,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1352,7 +1352,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1416,7 +1416,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roomIdentifierCollectionResponseDocument"
                 }
@@ -1438,7 +1438,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1448,7 +1448,7 @@
           "404": {
             "description": "The familyHome does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1561,7 +1561,7 @@
         "requestBody": {
           "description": "The identities of the rooms to add to the rooms relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1580,7 +1580,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1590,7 +1590,7 @@
           "404": {
             "description": "The familyHome or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1600,7 +1600,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1610,7 +1610,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1641,7 +1641,7 @@
         "requestBody": {
           "description": "The identities of the rooms to assign to the rooms relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1660,7 +1660,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1670,7 +1670,7 @@
           "404": {
             "description": "The familyHome or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1680,7 +1680,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1690,7 +1690,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1721,7 +1721,7 @@
         "requestBody": {
           "description": "The identities of the rooms to remove from the rooms relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1740,7 +1740,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1750,7 +1750,7 @@
           "404": {
             "description": "The familyHome or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1760,7 +1760,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1770,7 +1770,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1834,7 +1834,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceIdentifierResponseDocument"
                 }
@@ -1856,7 +1856,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1866,7 +1866,7 @@
           "404": {
             "description": "The kitchen does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1979,7 +1979,7 @@
         "requestBody": {
           "description": "The identity of the residence to assign to the residence relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -1998,7 +1998,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2008,7 +2008,7 @@
           "404": {
             "description": "The kitchen or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2018,7 +2018,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2028,7 +2028,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2092,7 +2092,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceIdentifierResponseDocument"
                 }
@@ -2114,7 +2114,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2124,7 +2124,7 @@
           "404": {
             "description": "The livingRoom does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2237,7 +2237,7 @@
         "requestBody": {
           "description": "The identity of the residence to assign to the residence relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2256,7 +2256,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2266,7 +2266,7 @@
           "404": {
             "description": "The livingRoom or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2276,7 +2276,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2286,7 +2286,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2350,7 +2350,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roomIdentifierCollectionResponseDocument"
                 }
@@ -2372,7 +2372,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2382,7 +2382,7 @@
           "404": {
             "description": "The mansion does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2495,7 +2495,7 @@
         "requestBody": {
           "description": "The identities of the rooms to add to the rooms relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2514,7 +2514,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2524,7 +2524,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2534,7 +2534,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2544,7 +2544,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2575,7 +2575,7 @@
         "requestBody": {
           "description": "The identities of the rooms to assign to the rooms relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2594,7 +2594,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2604,7 +2604,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2614,7 +2614,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2624,7 +2624,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2655,7 +2655,7 @@
         "requestBody": {
           "description": "The identities of the rooms to remove from the rooms relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2674,7 +2674,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2684,7 +2684,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2694,7 +2694,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2704,7 +2704,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2768,7 +2768,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/staffMemberIdentifierCollectionResponseDocument"
                 }
@@ -2790,7 +2790,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2800,7 +2800,7 @@
           "404": {
             "description": "The mansion does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2913,7 +2913,7 @@
         "requestBody": {
           "description": "The identities of the staffMembers to add to the staff relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2932,7 +2932,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2942,7 +2942,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2952,7 +2952,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2962,7 +2962,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2993,7 +2993,7 @@
         "requestBody": {
           "description": "The identities of the staffMembers to assign to the staff relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3012,7 +3012,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3022,7 +3022,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3032,7 +3032,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3042,7 +3042,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3073,7 +3073,7 @@
         "requestBody": {
           "description": "The identities of the staffMembers to remove from the staff relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3092,7 +3092,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3102,7 +3102,7 @@
           "404": {
             "description": "The mansion or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3112,7 +3112,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3122,7 +3122,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3142,7 +3142,7 @@
         "requestBody": {
           "description": "An array of mutation operations. For syntax, see the [Atomic Operations documentation](https://jsonapi.org/ext/atomic/).",
           "content": {
-            "application/vnd.api+json; ext=atomic; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3158,7 +3158,7 @@
           "200": {
             "description": "All operations were successfully applied, which resulted in additional changes.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/operationsResponseDocument"
                 }
@@ -3171,7 +3171,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3181,7 +3181,7 @@
           "403": {
             "description": "An operation is not accessible or a client-generated ID is used.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3191,7 +3191,7 @@
           "404": {
             "description": "A resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3201,7 +3201,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3211,7 +3211,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3275,7 +3275,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roomIdentifierCollectionResponseDocument"
                 }
@@ -3297,7 +3297,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3307,7 +3307,7 @@
           "404": {
             "description": "The residence does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3420,7 +3420,7 @@
         "requestBody": {
           "description": "The identities of the rooms to add to the rooms relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3439,7 +3439,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3449,7 +3449,7 @@
           "404": {
             "description": "The residence or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3459,7 +3459,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3469,7 +3469,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3500,7 +3500,7 @@
         "requestBody": {
           "description": "The identities of the rooms to assign to the rooms relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3519,7 +3519,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3529,7 +3529,7 @@
           "404": {
             "description": "The residence or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3539,7 +3539,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3549,7 +3549,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3580,7 +3580,7 @@
         "requestBody": {
           "description": "The identities of the rooms to remove from the rooms relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3599,7 +3599,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3609,7 +3609,7 @@
           "404": {
             "description": "The residence or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3619,7 +3619,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3629,7 +3629,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3693,7 +3693,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceIdentifierResponseDocument"
                 }
@@ -3715,7 +3715,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3725,7 +3725,7 @@
           "404": {
             "description": "The room does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3838,7 +3838,7 @@
         "requestBody": {
           "description": "The identity of the residence to assign to the residence relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3857,7 +3857,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3867,7 +3867,7 @@
           "404": {
             "description": "The room or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3877,7 +3877,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3887,7 +3887,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3951,7 +3951,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/residenceIdentifierResponseDocument"
                 }
@@ -3973,7 +3973,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3983,7 +3983,7 @@
           "404": {
             "description": "The toilet does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4096,7 +4096,7 @@
         "requestBody": {
           "description": "The identity of the residence to assign to the residence relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4115,7 +4115,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4125,7 +4125,7 @@
           "404": {
             "description": "The toilet or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4135,7 +4135,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4145,7 +4145,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/ResourceInheritance/SubsetOfOperations/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ResourceInheritance/SubsetOfOperations/GeneratedSwagger/swagger.g.json
@@ -20,7 +20,7 @@
         "requestBody": {
           "description": "An array of mutation operations. For syntax, see the [Atomic Operations documentation](https://jsonapi.org/ext/atomic/).",
           "content": {
-            "application/vnd.api+json; ext=atomic; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -36,7 +36,7 @@
           "200": {
             "description": "All operations were successfully applied, which resulted in additional changes.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/operationsResponseDocument"
                 }
@@ -49,7 +49,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -59,7 +59,7 @@
           "403": {
             "description": "An operation is not accessible or a client-generated ID is used.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -69,7 +69,7 @@
           "404": {
             "description": "A resource or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -79,7 +79,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -89,7 +89,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=atomic; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://jsonapi.org/ext/atomic https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/ResourceInheritance/SubsetOfVarious/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/ResourceInheritance/SubsetOfVarious/GeneratedSwagger/swagger.g.json
@@ -35,7 +35,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the building to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -61,7 +61,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBuildingResponseDocument"
                 }
@@ -74,7 +74,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -84,7 +84,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -94,7 +94,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -104,7 +104,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -114,7 +114,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -160,7 +160,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the building to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -176,7 +176,7 @@
           "200": {
             "description": "The building was successfully updated, which resulted in additional changes. The updated building is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryBuildingResponseDocument"
                 }
@@ -189,7 +189,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -199,7 +199,7 @@
           "404": {
             "description": "The building or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -209,7 +209,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -219,7 +219,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -283,7 +283,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryCyclePathResponseDocument"
                 }
@@ -305,7 +305,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -315,7 +315,7 @@
           "404": {
             "description": "The cyclePath does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -450,7 +450,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/districtCollectionResponseDocument"
                 }
@@ -472,7 +472,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -604,7 +604,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/roomIdentifierCollectionResponseDocument"
                 }
@@ -626,7 +626,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -636,7 +636,7 @@
           "404": {
             "description": "The familyHome does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }

--- a/test/OpenApiTests/RestrictedControllers/GeneratedSwagger/swagger.g.json
+++ b/test/OpenApiTests/RestrictedControllers/GeneratedSwagger/swagger.g.json
@@ -53,7 +53,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/dataStreamCollectionResponseDocument"
                 }
@@ -75,7 +75,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -207,7 +207,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryDataStreamResponseDocument"
                 }
@@ -229,7 +229,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -239,7 +239,7 @@
           "404": {
             "description": "The dataStream does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -374,7 +374,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/readOnlyChannelCollectionResponseDocument"
                 }
@@ -396,7 +396,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -528,7 +528,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryReadOnlyChannelResponseDocument"
                 }
@@ -550,7 +550,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -560,7 +560,7 @@
           "404": {
             "description": "The readOnlyChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -706,7 +706,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/dataStreamCollectionResponseDocument"
                 }
@@ -728,7 +728,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -738,7 +738,7 @@
           "404": {
             "description": "The readOnlyChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -884,7 +884,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/dataStreamIdentifierCollectionResponseDocument"
                 }
@@ -906,7 +906,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -916,7 +916,7 @@
           "404": {
             "description": "The readOnlyChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1062,7 +1062,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableSecondaryDataStreamResponseDocument"
                 }
@@ -1084,7 +1084,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1094,7 +1094,7 @@
           "404": {
             "description": "The readOnlyChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1240,7 +1240,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableDataStreamIdentifierResponseDocument"
                 }
@@ -1262,7 +1262,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1272,7 +1272,7 @@
           "404": {
             "description": "The readOnlyChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1418,7 +1418,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryDataStreamResponseDocument"
                 }
@@ -1440,7 +1440,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1450,7 +1450,7 @@
           "404": {
             "description": "The readOnlyChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1596,7 +1596,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/dataStreamIdentifierResponseDocument"
                 }
@@ -1618,7 +1618,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1628,7 +1628,7 @@
           "404": {
             "description": "The readOnlyChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1763,7 +1763,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/readOnlyResourceChannelCollectionResponseDocument"
                 }
@@ -1785,7 +1785,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1917,7 +1917,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryReadOnlyResourceChannelResponseDocument"
                 }
@@ -1939,7 +1939,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -1949,7 +1949,7 @@
           "404": {
             "description": "The readOnlyResourceChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2095,7 +2095,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/dataStreamCollectionResponseDocument"
                 }
@@ -2117,7 +2117,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2127,7 +2127,7 @@
           "404": {
             "description": "The readOnlyResourceChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2273,7 +2273,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableSecondaryDataStreamResponseDocument"
                 }
@@ -2295,7 +2295,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2305,7 +2305,7 @@
           "404": {
             "description": "The readOnlyResourceChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2451,7 +2451,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/secondaryDataStreamResponseDocument"
                 }
@@ -2473,7 +2473,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2483,7 +2483,7 @@
           "404": {
             "description": "The readOnlyResourceChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2629,7 +2629,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/dataStreamIdentifierCollectionResponseDocument"
                 }
@@ -2651,7 +2651,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2661,7 +2661,7 @@
           "404": {
             "description": "The relationshipChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2774,7 +2774,7 @@
         "requestBody": {
           "description": "The identities of the dataStreams to add to the audioStreams relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2793,7 +2793,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2803,7 +2803,7 @@
           "404": {
             "description": "The relationshipChannel or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2813,7 +2813,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2823,7 +2823,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2854,7 +2854,7 @@
         "requestBody": {
           "description": "The identities of the dataStreams to assign to the audioStreams relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2873,7 +2873,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2883,7 +2883,7 @@
           "404": {
             "description": "The relationshipChannel or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2893,7 +2893,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2903,7 +2903,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2934,7 +2934,7 @@
         "requestBody": {
           "description": "The identities of the dataStreams to remove from the audioStreams relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -2953,7 +2953,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2963,7 +2963,7 @@
           "404": {
             "description": "The relationshipChannel or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2973,7 +2973,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -2983,7 +2983,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3047,7 +3047,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/nullableDataStreamIdentifierResponseDocument"
                 }
@@ -3069,7 +3069,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3079,7 +3079,7 @@
           "404": {
             "description": "The relationshipChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3192,7 +3192,7 @@
         "requestBody": {
           "description": "The identity of the dataStream to assign to the ultraHighDefinitionVideoStream relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3211,7 +3211,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3221,7 +3221,7 @@
           "404": {
             "description": "The relationshipChannel or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3231,7 +3231,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3241,7 +3241,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3305,7 +3305,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/dataStreamIdentifierResponseDocument"
                 }
@@ -3327,7 +3327,7 @@
           "400": {
             "description": "The query string is invalid.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3337,7 +3337,7 @@
           "404": {
             "description": "The relationshipChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3450,7 +3450,7 @@
         "requestBody": {
           "description": "The identity of the dataStream to assign to the videoStream relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3469,7 +3469,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3479,7 +3479,7 @@
           "404": {
             "description": "The relationshipChannel or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3489,7 +3489,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3499,7 +3499,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3534,7 +3534,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the writeOnlyChannel to create.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3560,7 +3560,7 @@
               }
             },
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryWriteOnlyChannelResponseDocument"
                 }
@@ -3573,7 +3573,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3583,7 +3583,7 @@
           "403": {
             "description": "Client-generated IDs cannot be used at this endpoint.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3593,7 +3593,7 @@
           "404": {
             "description": "A related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3603,7 +3603,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3613,7 +3613,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3659,7 +3659,7 @@
         "requestBody": {
           "description": "The attributes and relationships of the writeOnlyChannel to update. Omitted fields are left unchanged.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3675,7 +3675,7 @@
           "200": {
             "description": "The writeOnlyChannel was successfully updated, which resulted in additional changes. The updated writeOnlyChannel is returned.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/primaryWriteOnlyChannelResponseDocument"
                 }
@@ -3688,7 +3688,7 @@
           "400": {
             "description": "The query string is invalid or the request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3698,7 +3698,7 @@
           "404": {
             "description": "The writeOnlyChannel or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3708,7 +3708,7 @@
           "409": {
             "description": "A resource type or identifier in the request body is incompatible.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3718,7 +3718,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3753,7 +3753,7 @@
           "404": {
             "description": "The writeOnlyChannel does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3786,7 +3786,7 @@
         "requestBody": {
           "description": "The identities of the dataStreams to add to the audioStreams relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3805,7 +3805,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3815,7 +3815,7 @@
           "404": {
             "description": "The writeOnlyChannel or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3825,7 +3825,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3835,7 +3835,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3866,7 +3866,7 @@
         "requestBody": {
           "description": "The identities of the dataStreams to assign to the audioStreams relationship, or an empty array to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3885,7 +3885,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3895,7 +3895,7 @@
           "404": {
             "description": "The writeOnlyChannel or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3905,7 +3905,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3915,7 +3915,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3946,7 +3946,7 @@
         "requestBody": {
           "description": "The identities of the dataStreams to remove from the audioStreams relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -3965,7 +3965,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3975,7 +3975,7 @@
           "404": {
             "description": "The writeOnlyChannel or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3985,7 +3985,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -3995,7 +3995,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4028,7 +4028,7 @@
         "requestBody": {
           "description": "The identity of the dataStream to assign to the ultraHighDefinitionVideoStream relationship, or `null` to clear the relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4047,7 +4047,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4057,7 +4057,7 @@
           "404": {
             "description": "The writeOnlyChannel or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4067,7 +4067,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4077,7 +4077,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4110,7 +4110,7 @@
         "requestBody": {
           "description": "The identity of the dataStream to assign to the videoStream relationship.",
           "content": {
-            "application/vnd.api+json; ext=openapi": {
+            "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
               "schema": {
                 "allOf": [
                   {
@@ -4129,7 +4129,7 @@
           "400": {
             "description": "The request body is missing or malformed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4139,7 +4139,7 @@
           "404": {
             "description": "The writeOnlyChannel or a related resource does not exist.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4149,7 +4149,7 @@
           "409": {
             "description": "The request body contains conflicting information or another resource with the same ID already exists.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }
@@ -4159,7 +4159,7 @@
           "422": {
             "description": "Validation of the request body failed.",
             "content": {
-              "application/vnd.api+json; ext=openapi": {
+              "application/vnd.api+json; ext=\"https://www.jsonapi.net/ext/openapi\"": {
                 "schema": {
                   "$ref": "#/components/schemas/errorResponseDocument"
                 }


### PR DESCRIPTION
Deprecate the relaxed variants of JSON:API media type extensions, now that both NSwag and Kiota can handle media types containing double quotes.

Closes #1936.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [x] Documentation updated
