### PR TITLE
Refactor: use HttpMethods

### DIFF
--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiMetadata/JsonApiEndpointMetadataProvider.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiMetadata/JsonApiEndpointMetadataProvider.cs
@@ -8,6 +8,7 @@ using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiMetadata.ActionMethods;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiMetadata.Documents;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiObjects.Documents;
 using JsonApiDotNetCore.Resources.Annotations;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -280,7 +281,7 @@ internal sealed class JsonApiEndpointMetadataProvider
         ConsistencyGuard.ThrowIf(actionMethod == null);
 
         HashSet<string> httpMethods = actionMethod.GetCustomAttributes<HttpMethodAttribute>(true).SelectMany(httpMethod => httpMethod.HttpMethods).ToHashSet();
-        bool skipHasOneAtRelationshipEndpoint = httpMethods.Contains("POST") || httpMethods.Contains("DELETE");
+        bool skipHasOneAtRelationshipEndpoint = httpMethods.Any(httpMethod => HttpMethods.IsPost(httpMethod) || HttpMethods.IsDelete(httpMethod));
 
         IJsonApiRequestMetadata? requestMetadata = GetCustomRequestMetadata(descriptor, controllerResourceType, hasParameterForId,
             hasParameterForRelationshipName, skipHasOneAtRelationshipEndpoint);

--- a/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiMiddleware.cs
@@ -134,7 +134,7 @@ public sealed partial class JsonApiMiddleware
     {
         AssertNoAtomicOperationsExtension(extensions);
 
-        request.IsReadOnly = httpRequest.Method == HttpMethod.Get.Method || httpRequest.Method == HttpMethod.Head.Method;
+        request.IsReadOnly = HttpMethods.IsGet(httpRequest.Method) || HttpMethods.IsHead(httpRequest.Method);
         request.PrimaryResourceType = primaryResourceType;
         request.PrimaryId = GetPrimaryRequestId(routeValues);
 
@@ -148,9 +148,9 @@ public sealed partial class JsonApiMiddleware
             // @formatter:keep_existing_linebreaks true
 
             request.WriteOperation =
-                httpRequest.Method == HttpMethod.Post.Method ? WriteOperationKind.AddToRelationship :
-                httpRequest.Method == HttpMethod.Patch.Method ? WriteOperationKind.SetRelationship :
-                httpRequest.Method == HttpMethod.Delete.Method ? WriteOperationKind.RemoveFromRelationship : null;
+                HttpMethods.IsPost(httpRequest.Method) ? WriteOperationKind.AddToRelationship :
+                HttpMethods.IsPatch(httpRequest.Method) ? WriteOperationKind.SetRelationship :
+                HttpMethods.IsDelete(httpRequest.Method) ? WriteOperationKind.RemoveFromRelationship : null;
 
             // @formatter:keep_existing_linebreaks restore
             // @formatter:wrap_chained_method_calls restore
@@ -171,9 +171,9 @@ public sealed partial class JsonApiMiddleware
             // @formatter:keep_existing_linebreaks true
 
             request.WriteOperation =
-                httpRequest.Method == HttpMethod.Post.Method ? WriteOperationKind.CreateResource :
-                httpRequest.Method == HttpMethod.Patch.Method ? WriteOperationKind.UpdateResource :
-                httpRequest.Method == HttpMethod.Delete.Method ? WriteOperationKind.DeleteResource : null;
+                HttpMethods.IsPost(httpRequest.Method) ? WriteOperationKind.CreateResource :
+                HttpMethods.IsPatch(httpRequest.Method) ? WriteOperationKind.UpdateResource :
+                HttpMethods.IsDelete(httpRequest.Method) ? WriteOperationKind.DeleteResource : null;
 
             // @formatter:keep_existing_linebreaks restore
             // @formatter:wrap_chained_method_calls restore

--- a/src/JsonApiDotNetCore/Serialization/Response/JsonApiWriter.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/JsonApiWriter.cs
@@ -57,7 +57,7 @@ public sealed partial class JsonApiWriter : IJsonApiWriter
 
         string? responseBody = GetResponseBody(model, httpContext);
 
-        if (httpContext.Request.Method == HttpMethod.Head.Method)
+        if (HttpMethods.IsHead(httpContext.Request.Method))
         {
             httpContext.Response.GetTypedHeaders().ContentLength = responseBody == null ? 0 : Encoding.UTF8.GetByteCount(responseBody);
             return;
@@ -136,7 +136,7 @@ public sealed partial class JsonApiWriter : IJsonApiWriter
 
     private bool SetETagResponseHeader(HttpRequest request, HttpResponse response, string responseContent)
     {
-        bool isReadOnly = request.Method == HttpMethod.Get.Method || request.Method == HttpMethod.Head.Method;
+        bool isReadOnly = HttpMethods.IsGet(request.Method) || HttpMethods.IsHead(request.Method);
 
         if (isReadOnly && response.StatusCode == (int)HttpStatusCode.OK)
         {

--- a/test/OpenApiNSwagEndToEndTests/MixedControllers/GeneratedCode/MixedControllersClient.cs
+++ b/test/OpenApiNSwagEndToEndTests/MixedControllers/GeneratedCode/MixedControllersClient.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Microsoft.AspNetCore.Http;
 
 // Justification: The CA1852 analyzer doesn't take auto-generated code into account, presumably for improved performance.
 #pragma warning disable CA1852 // Type can be sealed because it has no subtypes in its containing assembly and is not externally visible
@@ -10,7 +11,7 @@ internal partial class MixedControllersClient
     // ReSharper disable once UnusedParameterInPartialMethod
     partial void PrepareRequest(HttpClient client, HttpRequestMessage request, StringBuilder urlBuilder)
     {
-        if (request.Method == HttpMethod.Patch && urlBuilder.ToString().EndsWith("/cupOfCoffees/batch", StringComparison.Ordinal))
+        if (HttpMethods.IsPatch(request.Method.Method) && urlBuilder.ToString().EndsWith("/cupOfCoffees/batch", StringComparison.Ordinal))
         {
             // Workaround: NSwag assumes a PATCH request must always send a request body, despite our OpenAPI document not specifying one.
             request.Content = null;


### PR DESCRIPTION
Refactor to use the built-in `HttpMethods` extension methods, which are case-insensitive.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
