### PR TITLE
Remove dev-dependency on CSharpGuidelinesAnalyzer

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Please follow these steps to have your contribution considered by the maintainer
 - Follow all instructions in the template. Don't forget to add tests and update documentation.
 - After you submit your pull request, verify that all status checks are passing. In release builds, all compiler warnings are treated as errors, so you should address them before push.
 
-We use [CSharpGuidelines](https://csharpcodingguidelines.com/) as our coding standard. Coding style is validated during PR build, where we inject an extra settings layer that promotes various IDE suggestions to warning level. This ensures a high-quality codebase without interfering too much while editing code.
+Coding style is validated during PR build, where we inject an extra settings layer that promotes various IDE suggestions to warning level. This ensures a high-quality codebase without interfering too much while editing code.
 You can run the following [PowerShell scripts](https://github.com/PowerShell/PowerShell/releases) locally:
 - `pwsh ./inspectcode.ps1`: Scans the code for style violations and opens the result in your web browser.
 - `pwsh ./cleanupcode.ps1 [branch-name-or-commit-hash]`: Reformats the codebase to match with our configured style, optionally only changed files since the specified branch (usually master).

--- a/CSharpGuidelinesAnalyzer.config
+++ b/CSharpGuidelinesAnalyzer.config
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<cSharpGuidelinesAnalyzerSettings>
-  <setting rule="AV1561" name="MaxParameterCount" value="6" />
-  <setting rule="AV1561" name="MaxConstructorParameterCount" value="15" />
-</cSharpGuidelinesAnalyzerSettings>

--- a/CodingGuidelines.ruleset
+++ b/CodingGuidelines.ruleset
@@ -1,29 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Coding Guidelines" Description=" " ToolsVersion="17.0">
-  <Rules AnalyzerId="CSharpGuidelinesAnalyzer" RuleNamespace="CSharpGuidelinesAnalyzer">
-    <Rule Id="AV1008" Action="Warning" />
-    <Rule Id="AV1135" Action="None" />
-    <Rule Id="AV1500" Action="None" />
-    <Rule Id="AV1505" Action="Warning" />
-    <Rule Id="AV1506" Action="Warning" />
-    <Rule Id="AV1507" Action="Warning" />
-    <Rule Id="AV1536" Action="None" />
-    <Rule Id="AV1537" Action="None" />
-    <Rule Id="AV1551" Action="None" />
-    <Rule Id="AV1564" Action="None" />
-    <Rule Id="AV1568" Action="Warning" />
-    <Rule Id="AV1580" Action="None" />
-    <Rule Id="AV1704" Action="None" />
-    <Rule Id="AV1710" Action="None" />
-    <Rule Id="AV1711" Action="None" />
-    <Rule Id="AV1738" Action="Warning" />
-    <Rule Id="AV1739" Action="Warning" />
-    <Rule Id="AV1745" Action="Warning" />
-    <Rule Id="AV2220" Action="Warning" />
-    <Rule Id="AV2230" Action="Info" />
-    <Rule Id="AV2305" Action="None" />
-    <Rule Id="AV2318" Action="Warning" />
-  </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.NetAnalyzers">
     <Rule Id="CA1027" Action="Warning" />
     <Rule Id="CA1033" Action="Warning" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -64,7 +64,5 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.*" PrivateAssets="All" />
-    <PackageReference Include="CSharpGuidelinesAnalyzer" Version="3.8.*" PrivateAssets="All" />
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)CSharpGuidelinesAnalyzer.config" Visible="False" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,7 +8,6 @@
   <!-- Workaround for compiler regression at https://github.com/dotnet/roslyn/issues/80756 -->
   <Target Name="DisableSlowAnalyzers" Condition="'$(Configuration)' == 'Debug'" BeforeTargets="CoreCompile">
     <ItemGroup>
-      <Analyzer Remove="@(Analyzer)" Condition="'%(Filename)' == 'CSharpGuidelinesAnalyzer'" />
       <Analyzer Remove="@(Analyzer)" Condition="'%(Filename)' == 'Microsoft.CodeAnalysis.CSharp.CodeStyle'" />
       <Analyzer Remove="@(Analyzer)" Condition="'%(Filename)' == 'Microsoft.CodeAnalysis.NetAnalyzers'" />
       <Analyzer Remove="@(Analyzer)" Condition="'%(Filename)' == 'Microsoft.CodeAnalysis.CSharp.NetAnalyzers'" />

--- a/JsonApiDotNetCore.slnx
+++ b/JsonApiDotNetCore.slnx
@@ -12,7 +12,6 @@
     <File Path=".github/workflows/build.yml" />
     <File Path=".gitignore" />
     <File Path="CodingGuidelines.ruleset" />
-    <File Path="CSharpGuidelinesAnalyzer.config" />
     <File Path="Directory.Build.props" />
     <File Path="package-versions.props" />
     <File Path="tests.runsettings" />

--- a/src/Examples/JsonApiDotNetCoreExample/AppLog.cs
+++ b/src/Examples/JsonApiDotNetCoreExample/AppLog.cs
@@ -1,5 +1,3 @@
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCoreExample;
 
 internal static partial class AppLog

--- a/src/JsonApiDotNetCore.Annotations/ArgumentGuard.cs
+++ b/src/JsonApiDotNetCore.Annotations/ArgumentGuard.cs
@@ -2,7 +2,6 @@ using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using SysNotNull = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 
-#pragma warning disable AV1008 // Class should not be static
 #pragma warning disable format
 
 namespace JsonApiDotNetCore;

--- a/src/JsonApiDotNetCore.Annotations/Resources/RuntimeTypeConverter.cs
+++ b/src/JsonApiDotNetCore.Annotations/Resources/RuntimeTypeConverter.cs
@@ -2,8 +2,6 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using JetBrains.Annotations;
 
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCore.Resources;
 
 /// <summary>

--- a/src/JsonApiDotNetCore.OpenApi.Client.NSwag/NotifyPropertySet.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Client.NSwag/NotifyPropertySet.cs
@@ -4,10 +4,6 @@ using JetBrains.Annotations;
 
 // Adapted from https://github.com/PrismLibrary/Prism/blob/9.0.537/src/Prism.Core/Mvvm/BindableBase.cs for JsonApiDotNetCore.
 
-#pragma warning disable AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
-#pragma warning disable AV1554 // Method contains optional parameter in type hierarchy
-#pragma warning disable AV1562 // Do not declare a parameter as ref or out
-
 namespace JsonApiDotNetCore.OpenApi.Client.NSwag;
 
 /// <summary>

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/ConsistencyGuard.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/ConsistencyGuard.cs
@@ -3,8 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace JsonApiDotNetCore.OpenApi.Swashbuckle;
 
-#pragma warning disable AV1008 // Class should not be static
-
 internal static class ConsistencyGuard
 {
     [ExcludeFromCodeCoverage]

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiPropertyName.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiPropertyName.cs
@@ -1,5 +1,3 @@
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCore.OpenApi.Swashbuckle;
 
 internal static class JsonApiPropertyName

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiSchemaFacts.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiSchemaFacts.cs
@@ -1,8 +1,6 @@
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiObjects.Documents;
 using JsonApiDotNetCore.OpenApi.Swashbuckle.JsonApiObjects.Relationships;
 
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCore.OpenApi.Swashbuckle;
 
 internal static class JsonApiSchemaFacts

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/MethodInfoWrapper.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/MethodInfoWrapper.cs
@@ -49,7 +49,6 @@ internal sealed class MethodInfoWrapper : MethodInfo
     {
         List<object> customAttributes = _innerMethod.GetCustomAttributes(inherit).ToList();
 
-#pragma warning disable AV1530 // Loop variable should not be written to in loop body
         for (int index = 0; index < customAttributes.Count; index++)
         {
             if (_attributeTypesToHide.Any(attribute => attribute.IsInstanceOfType(customAttributes[index])))
@@ -58,7 +57,6 @@ internal sealed class MethodInfoWrapper : MethodInfo
                 index--;
             }
         }
-#pragma warning restore AV1530 // Loop variable should not be written to in loop body
 
         return customAttributes.ToArray();
     }
@@ -67,7 +65,6 @@ internal sealed class MethodInfoWrapper : MethodInfo
     {
         List<object> customAttributes = _innerMethod.GetCustomAttributes(attributeType, inherit).ToList();
 
-#pragma warning disable AV1530 // Loop variable should not be written to in loop body
         for (int index = 0; index < customAttributes.Count; index++)
         {
             if (_attributeTypesToHide.Any(attribute => attribute.IsInstanceOfType(customAttributes[index])))
@@ -76,7 +73,6 @@ internal sealed class MethodInfoWrapper : MethodInfo
                 index--;
             }
         }
-#pragma warning restore AV1530 // Loop variable should not be written to in loop body
 
         object[] typedArray = (object[])Array.CreateInstance(attributeType, customAttributes.Count);
 
@@ -92,7 +88,6 @@ internal sealed class MethodInfoWrapper : MethodInfo
     {
         List<CustomAttributeData> customAttributes = _innerMethod.GetCustomAttributesData().ToList();
 
-#pragma warning disable AV1530 // Loop variable should not be written to in loop body
         for (int index = 0; index < customAttributes.Count; index++)
         {
             if (_attributeTypesToHide.Any(attribute => attribute.IsAssignableFrom(customAttributes[index].AttributeType)))
@@ -101,7 +96,6 @@ internal sealed class MethodInfoWrapper : MethodInfo
                 index--;
             }
         }
-#pragma warning restore AV1530 // Loop variable should not be written to in loop body
 
         return customAttributes.ToArray();
     }

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiMediaTypeExtension.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiMediaTypeExtension.cs
@@ -2,8 +2,6 @@ using JsonApiDotNetCore.Middleware;
 
 namespace JsonApiDotNetCore.OpenApi.Swashbuckle;
 
-#pragma warning disable AV1008 // Class should not be static
-
 internal static class OpenApiMediaTypeExtension
 {
     public const string ExtensionNamespace = "openapi";

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiMediaTypes.cs
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/OpenApiMediaTypes.cs
@@ -1,7 +1,5 @@
 using JsonApiDotNetCore.Middleware;
 
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCore.OpenApi.Swashbuckle;
 
 internal static class OpenApiMediaTypes

--- a/src/JsonApiDotNetCore.SourceGenerators/ControllerSourceGenerator.cs
+++ b/src/JsonApiDotNetCore.SourceGenerators/ControllerSourceGenerator.cs
@@ -235,10 +235,7 @@ public sealed class ControllerSourceGenerator : IIncrementalGenerator
         foreach ((TypeInfo controllerType, string hintFileName) in collection.OrderBy(static element => element.ControllerType.ToString(),
             StringComparer.Ordinal))
         {
-#pragma warning disable AV1532 // Loop statement contains nested loop
-            // Justification: optimized for performance.
             for (int index = -1;; index++)
-#pragma warning restore AV1532 // Loop statement contains nested loop
             {
                 if (index == -1)
                 {
@@ -284,9 +281,7 @@ public sealed class ControllerSourceGenerator : IIncrementalGenerator
 
             fileContent = writer.Write(in fullController);
         }
-#pragma warning disable AV1210 // Catch a specific exception instead of Exception, SystemException or ApplicationException
         catch (Exception exception)
-#pragma warning restore AV1210 // Catch a specific exception instead of Exception, SystemException or ApplicationException
         {
             fileContent = GetErrorText(exception, in fullController);
         }

--- a/src/JsonApiDotNetCore.SourceGenerators/SourceCodeWriter.cs
+++ b/src/JsonApiDotNetCore.SourceGenerators/SourceCodeWriter.cs
@@ -254,7 +254,6 @@ internal sealed class SourceCodeWriter
         _sourceBuilder.Append(indent);
     }
 
-#pragma warning disable AV1008 // Class should not be static
     private static class Tokens
     {
         public const string OpenCurly = "{";
@@ -262,5 +261,4 @@ internal sealed class SourceCodeWriter
         public const string CloseParen = ")";
         public const string Comma = ",";
     }
-#pragma warning restore AV1008 // Class should not be static
 }

--- a/src/JsonApiDotNetCore/AtomicOperations/OperationsProcessor.cs
+++ b/src/JsonApiDotNetCore/AtomicOperations/OperationsProcessor.cs
@@ -89,9 +89,7 @@ public class OperationsProcessor : IOperationsProcessor
 
             throw;
         }
-#pragma warning disable AV1210 // Catch a specific exception instead of Exception, SystemException or ApplicationException
         catch (Exception exception)
-#pragma warning restore AV1210 // Catch a specific exception instead of Exception, SystemException or ApplicationException
         {
             throw new FailedOperationException(results.Count, exception);
         }

--- a/src/JsonApiDotNetCore/CollectionExtensions.cs
+++ b/src/JsonApiDotNetCore/CollectionExtensions.cs
@@ -102,8 +102,6 @@ internal static class CollectionExtensions
 
     public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source)
     {
-#pragma warning disable AV1250 // Evaluate LINQ query before returning it
         return source.Where(element => element is not null)!;
-#pragma warning restore AV1250 // Evaluate LINQ query before returning it
     }
 }

--- a/src/JsonApiDotNetCore/Configuration/ResourceGraphBuilder.cs
+++ b/src/JsonApiDotNetCore/Configuration/ResourceGraphBuilder.cs
@@ -206,10 +206,8 @@ public partial class ResourceGraphBuilder
     /// The name under which the resource is publicly exposed by the API. If nothing is specified, the naming convention is applied on the pluralized CLR
     /// type name.
     /// </param>
-#pragma warning disable AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
     public ResourceGraphBuilder Add<TResource, TId>(string? publicName = null)
         where TResource : class, IIdentifiable<TId>
-#pragma warning restore AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
     {
         return Add(typeof(TResource), typeof(TId), publicName);
     }
@@ -227,9 +225,7 @@ public partial class ResourceGraphBuilder
     /// The name under which the resource is publicly exposed by the API. If nothing is specified, the naming convention is applied on the pluralized CLR
     /// type name.
     /// </param>
-#pragma warning disable AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
     public ResourceGraphBuilder Add(Type resourceClrType, Type? idClrType = null, string? publicName = null)
-#pragma warning restore AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
     {
         ArgumentNullException.ThrowIfNull(resourceClrType);
 

--- a/src/JsonApiDotNetCore/Configuration/ServiceCollectionExtensions.cs
+++ b/src/JsonApiDotNetCore/Configuration/ServiceCollectionExtensions.cs
@@ -27,11 +27,9 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Configures JsonApiDotNetCore by registering resources manually.
     /// </summary>
-#pragma warning disable AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
     public static IServiceCollection AddJsonApi(this IServiceCollection services, Action<JsonApiOptions>? options = null,
         Action<ServiceDiscoveryFacade>? discovery = null, Action<ResourceGraphBuilder>? resources = null, IMvcCoreBuilder? mvcBuilder = null,
         ICollection<Type>? dbContextTypes = null)
-#pragma warning restore AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
     {
         ArgumentNullException.ThrowIfNull(services);
         AssertCompatibleOpenApiVersion();

--- a/src/JsonApiDotNetCore/Diagnostics/CodeTimingSessionManager.cs
+++ b/src/JsonApiDotNetCore/Diagnostics/CodeTimingSessionManager.cs
@@ -1,7 +1,5 @@
 using System.Reflection;
 
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCore.Diagnostics;
 
 /// <summary>

--- a/src/JsonApiDotNetCore/Diagnostics/MeasurementSettings.cs
+++ b/src/JsonApiDotNetCore/Diagnostics/MeasurementSettings.cs
@@ -1,5 +1,3 @@
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCore.Diagnostics;
 
 internal static class MeasurementSettings

--- a/src/JsonApiDotNetCore/Middleware/HeaderConstants.cs
+++ b/src/JsonApiDotNetCore/Middleware/HeaderConstants.cs
@@ -1,7 +1,5 @@
 using JetBrains.Annotations;
 
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCore.Middleware;
 
 [PublicAPI]

--- a/src/JsonApiDotNetCore/Queries/FieldSelection.cs
+++ b/src/JsonApiDotNetCore/Queries/FieldSelection.cs
@@ -19,9 +19,7 @@ public sealed class FieldSelection : Dictionary<ResourceType, FieldSelectors>
         return Keys.ToHashSet().AsReadOnly();
     }
 
-#pragma warning disable AV1130 // Return type in method signature should be an interface to an unchangeable collection
     public FieldSelectors GetOrCreateSelectors(ResourceType resourceType)
-#pragma warning restore AV1130 // Return type in method signature should be an interface to an unchangeable collection
     {
         ArgumentNullException.ThrowIfNull(resourceType);
 

--- a/src/JsonApiDotNetCore/Queries/Parsing/Keywords.cs
+++ b/src/JsonApiDotNetCore/Queries/Parsing/Keywords.cs
@@ -1,8 +1,5 @@
 using JetBrains.Annotations;
 
-#pragma warning disable AV1008 // Class should not be static
-#pragma warning disable AV1010 // Member hides inherited member
-
 namespace JsonApiDotNetCore.Queries.Parsing;
 
 [PublicAPI]

--- a/src/JsonApiDotNetCore/Queries/QueryLayerComposer.cs
+++ b/src/JsonApiDotNetCore/Queries/QueryLayerComposer.cs
@@ -587,9 +587,7 @@ public class QueryLayerComposer : IQueryLayerComposer
         return pagination;
     }
 
-#pragma warning disable AV1130 // Return type in method signature should be an interface to an unchangeable collection
     protected virtual FieldSelection? GetSelectionForSparseAttributeSet(ResourceType resourceType)
-#pragma warning restore AV1130 // Return type in method signature should be an interface to an unchangeable collection
     {
         ArgumentNullException.ThrowIfNull(resourceType);
 

--- a/src/JsonApiDotNetCore/Queries/SystemExpressionBuilder.cs
+++ b/src/JsonApiDotNetCore/Queries/SystemExpressionBuilder.cs
@@ -1,8 +1,6 @@
 using System.Linq.Expressions;
 using System.Reflection;
 
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCore.Queries;
 
 internal static class SystemExpressionBuilder

--- a/src/JsonApiDotNetCore/QueryStrings/FieldChains/BuiltInPatterns.cs
+++ b/src/JsonApiDotNetCore/QueryStrings/FieldChains/BuiltInPatterns.cs
@@ -1,7 +1,5 @@
 using JetBrains.Annotations;
 
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCore.QueryStrings.FieldChains;
 
 [PublicAPI]

--- a/src/JsonApiDotNetCore/Resources/IResourceDefinition.cs
+++ b/src/JsonApiDotNetCore/Resources/IResourceDefinition.cs
@@ -108,16 +108,12 @@ public interface IResourceDefinition<TResource, in TId>
     /// }
     /// ]]></code>
     /// </example>
-#pragma warning disable AV1130 // Return type in method signature should be an interface to an unchangeable collection
     QueryStringParameterHandlers<TResource>? OnRegisterQueryableHandlersForQueryStringParameters();
-#pragma warning restore AV1130 // Return type in method signature should be an interface to an unchangeable collection
 
     /// <summary>
     /// Enables adding JSON:API meta information, specific to this resource.
     /// </summary>
-#pragma warning disable AV1130 // Return type in method signature should be an interface to an unchangeable collection
     IDictionary<string, object?>? GetMeta(TResource resource);
-#pragma warning restore AV1130 // Return type in method signature should be an interface to an unchangeable collection
 
     /// <summary>
     /// Executes after the original version of the resource has been retrieved from the underlying data store, as part of a write request.

--- a/src/JsonApiDotNetCore/Resources/IResourceDefinitionAccessor.cs
+++ b/src/JsonApiDotNetCore/Resources/IResourceDefinitionAccessor.cs
@@ -64,9 +64,7 @@ public interface IResourceDefinitionAccessor
     /// <summary>
     /// Invokes <see cref="IResourceDefinition{TResource,TId}.GetMeta" /> for the specified resource.
     /// </summary>
-#pragma warning disable AV1130 // Return type in method signature should be an interface to an unchangeable collection
     IDictionary<string, object?>? GetMeta(ResourceType resourceType, IIdentifiable resourceInstance);
-#pragma warning restore AV1130 // Return type in method signature should be an interface to an unchangeable collection
 
     /// <summary>
     /// Invokes <see cref="IResourceDefinition{TResource,TId}.OnPrepareWriteAsync" /> for the specified resource.

--- a/src/JsonApiDotNetCore/Resources/OperationContainer.cs
+++ b/src/JsonApiDotNetCore/Resources/OperationContainer.cs
@@ -37,9 +37,7 @@ public sealed class OperationContainer
         return new OperationContainer(resource, TargetedFields, Request);
     }
 
-#pragma warning disable AV1130 // Return type in method signature should be an interface to an unchangeable collection
     public ISet<IIdentifiable> GetSecondaryResources()
-#pragma warning restore AV1130 // Return type in method signature should be an interface to an unchangeable collection
     {
         var secondaryResources = new HashSet<IIdentifiable>(IdentifiableComparer.Instance);
 

--- a/src/JsonApiDotNetCore/Resources/ResourceFactory.cs
+++ b/src/JsonApiDotNetCore/Resources/ResourceFactory.cs
@@ -71,9 +71,7 @@ internal sealed class ResourceFactory : IResourceFactory
                 ? (IIdentifiable)Activator.CreateInstance(type)!
                 : (IIdentifiable)ActivatorUtilities.CreateInstance(serviceProvider, type);
         }
-#pragma warning disable AV1210 // Catch a specific exception instead of Exception, SystemException or ApplicationException
         catch (Exception exception)
-#pragma warning restore AV1210 // Catch a specific exception instead of Exception, SystemException or ApplicationException
         {
             throw new InvalidOperationException(
                 hasSingleConstructorWithoutParameters
@@ -105,9 +103,7 @@ internal sealed class ResourceFactory : IResourceFactory
                 Expression argumentExpression = SystemExpressionBuilder.CloseOver(constructorArgument);
                 constructorArguments.Add(argumentExpression);
             }
-#pragma warning disable AV1210 // Catch a specific exception instead of Exception, SystemException or ApplicationException
             catch (Exception exception)
-#pragma warning restore AV1210 // Catch a specific exception instead of Exception, SystemException or ApplicationException
             {
                 throw new InvalidOperationException(
                     $"Failed to create an instance of '{resourceClrType.FullName}': Parameter '{constructorParameter.Name}' could not be resolved.", exception);

--- a/src/JsonApiDotNetCore/Serialization/Request/Adapters/IDocumentInOperationsRequestAdapter.cs
+++ b/src/JsonApiDotNetCore/Serialization/Request/Adapters/IDocumentInOperationsRequestAdapter.cs
@@ -11,7 +11,5 @@ public interface IDocumentInOperationsRequestAdapter
     /// <summary>
     /// Validates and converts the specified <paramref name="document" />.
     /// </summary>
-#pragma warning disable AV1130 // Return type in method signature should be an interface to an unchangeable collection
     IList<OperationContainer> Convert(Document document, RequestAdapterState state);
-#pragma warning restore AV1130 // Return type in method signature should be an interface to an unchangeable collection
 }

--- a/src/JsonApiDotNetCore/Serialization/Response/IMetaBuilder.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/IMetaBuilder.cs
@@ -17,7 +17,5 @@ public interface IMetaBuilder
     /// <summary>
     /// Builds the top-level meta data object.
     /// </summary>
-#pragma warning disable AV1130 // Return type in method signature should be an interface to an unchangeable collection
     IDictionary<string, object?>? Build();
-#pragma warning restore AV1130 // Return type in method signature should be an interface to an unchangeable collection
 }

--- a/src/JsonApiDotNetCore/Serialization/Response/IResponseMeta.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/IResponseMeta.cs
@@ -12,7 +12,5 @@ public interface IResponseMeta
     /// <summary>
     /// Gets the global top-level JSON:API meta information to add to the response.
     /// </summary>
-#pragma warning disable AV1130 // Return type in method signature should be an interface to an unchangeable collection
     IDictionary<string, object?>? GetMeta();
-#pragma warning restore AV1130 // Return type in method signature should be an interface to an unchangeable collection
 }

--- a/src/JsonApiDotNetCore/Serialization/Response/JsonApiWriter.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/JsonApiWriter.cs
@@ -105,9 +105,7 @@ public sealed partial class JsonApiWriter : IJsonApiWriter
 
             return responseBody;
         }
-#pragma warning disable AV1210 // Catch a specific exception instead of Exception, SystemException or ApplicationException
         catch (Exception exception)
-#pragma warning restore AV1210 // Catch a specific exception instead of Exception, SystemException or ApplicationException
         {
             IReadOnlyList<ErrorObject> errors = _exceptionHandler.HandleException(exception);
             httpContext.Response.StatusCode = (int)ErrorObject.GetResponseStatusCode(errors);

--- a/src/JsonApiDotNetCore/Serialization/Response/ResourceObjectTreeNode.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/ResourceObjectTreeNode.cs
@@ -168,9 +168,7 @@ internal sealed class ResourceObjectTreeNode : IEquatable<ResourceObjectTreeNode
     /// <summary>
     /// Provides the value for 'included' in the response body. Uses relationship declaration order.
     /// </summary>
-#pragma warning disable AV1130 // Return type in method signature should be an interface to an unchangeable collection
     public IList<ResourceObject> GetResponseIncluded()
-#pragma warning restore AV1130 // Return type in method signature should be an interface to an unchangeable collection
     {
         AssertIsTreeRoot();
 

--- a/src/JsonApiDotNetCore/Serialization/Response/ResponseModelAdapter.cs
+++ b/src/JsonApiDotNetCore/Serialization/Response/ResponseModelAdapter.cs
@@ -234,9 +234,7 @@ public class ResponseModelAdapter : IResponseModelAdapter
         return resourceObject;
     }
 
-#pragma warning disable AV1130 // Return type in method signature should be an interface to an unchangeable collection
     protected virtual IDictionary<string, object?>? ConvertAttributes(IIdentifiable resource, ResourceType resourceType,
-#pragma warning restore AV1130 // Return type in method signature should be an interface to an unchangeable collection
         IImmutableSet<ResourceFieldAttribute> fieldSet)
     {
         ArgumentNullException.ThrowIfNull(resource);

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeMediaTypeExtension.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeMediaTypeExtension.cs
@@ -1,7 +1,5 @@
 using JsonApiDotNetCore.Middleware;
 
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCoreTests.IntegrationTests.ContentNegotiation.CustomExtensions;
 
 internal static class ServerTimeMediaTypeExtension

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeMediaTypes.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ContentNegotiation/CustomExtensions/ServerTimeMediaTypes.cs
@@ -1,7 +1,5 @@
 using JsonApiDotNetCore.Middleware;
 
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCoreTests.IntegrationTests.ContentNegotiation.CustomExtensions;
 
 internal static class ServerTimeMediaTypes

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/Decrypt/DatabaseFunctionStub.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/Decrypt/DatabaseFunctionStub.cs
@@ -1,7 +1,5 @@
 using System.Reflection;
 
-#pragma warning disable AV1008 // Class should not be static
-
 namespace JsonApiDotNetCoreTests.IntegrationTests.QueryStrings.CustomFunctions.Decrypt;
 
 internal static class DatabaseFunctionStub

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/RequiredRelationships/Shipment.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/RequiredRelationships/Shipment.cs
@@ -2,8 +2,6 @@ using JetBrains.Annotations;
 using JsonApiDotNetCore.Resources;
 using JsonApiDotNetCore.Resources.Annotations;
 
-#pragma warning disable AV1115 // Member or local function contains the word 'and', which suggests doing multiple things
-
 namespace JsonApiDotNetCoreTests.IntegrationTests.RequiredRelationships;
 
 [UsedImplicitly(ImplicitUseTargetFlags.Members)]

--- a/test/JsonApiDotNetCoreTests/UnitTests/FieldChains/FieldChainPatternInheritanceMatchTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/FieldChains/FieldChainPatternInheritanceMatchTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 using Xunit.Abstractions;
 
 // ReSharper disable InconsistentNaming
-#pragma warning disable AV1706 // Identifier contains an abbreviation or is too short
 
 namespace JsonApiDotNetCoreTests.UnitTests.FieldChains;
 

--- a/test/JsonApiDotNetCoreTests/UnitTests/FieldChains/FieldChainPatternMatchTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/FieldChains/FieldChainPatternMatchTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 using Xunit.Abstractions;
 
 // ReSharper disable InconsistentNaming
-#pragma warning disable AV1706 // Identifier contains an abbreviation or is too short
 
 namespace JsonApiDotNetCoreTests.UnitTests.FieldChains;
 

--- a/test/JsonApiDotNetCoreTests/UnitTests/Middleware/JsonApiMiddlewareTests.cs
+++ b/test/JsonApiDotNetCoreTests/UnitTests/Middleware/JsonApiMiddlewareTests.cs
@@ -11,8 +11,6 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-#pragma warning disable AV1561 // Signature contains too many parameters
-
 namespace JsonApiDotNetCoreTests.UnitTests.Middleware;
 
 public sealed class JsonApiMiddlewareTests

--- a/test/OpenApiTests/JsonPathBuilder.cs
+++ b/test/OpenApiTests/JsonPathBuilder.cs
@@ -3,8 +3,6 @@ using JsonApiDotNetCore.Configuration;
 using JsonApiDotNetCore.Controllers;
 using JsonApiDotNetCore.Resources.Annotations;
 
-#pragma warning disable AV1008 // Class should not be static
-
 namespace OpenApiTests;
 
 internal static class JsonPathBuilder

--- a/test/OpenApiTests/ResourceInheritance/ResourceInheritanceTests.cs
+++ b/test/OpenApiTests/ResourceInheritance/ResourceInheritanceTests.cs
@@ -8,8 +8,6 @@ using TestBuildingBlocks;
 using Xunit;
 using Xunit.Abstractions;
 
-#pragma warning disable AV1755 // Name of async method should end with Async or TaskAsync
-
 namespace OpenApiTests.ResourceInheritance;
 
 public abstract class ResourceInheritanceTests : IClassFixture<OpenApiTestContext<OpenApiStartup<ResourceInheritanceDbContext>, ResourceInheritanceDbContext>>

--- a/test/TestBuildingBlocks/FakerExtensions.cs
+++ b/test/TestBuildingBlocks/FakerExtensions.cs
@@ -20,9 +20,7 @@ public static class FakerExtensions
         return faker;
     }
 
-#pragma warning disable AV1008 // Class should not be static
     public static int GetFakerSeed()
-#pragma warning restore AV1008 // Class should not be static
     {
         // The goal here is to have stable data over multiple test runs, but at the same time different data per test case.
 
@@ -91,7 +89,6 @@ public static class FakerExtensions
         return faker.Generate();
     }
 
-#pragma warning disable AV1130 // Return type in method signature should be an interface to an unchangeable collection
     public static List<T> GenerateList<T>(this Faker<T> faker, int count)
         where T : class
     {
@@ -110,5 +107,4 @@ public static class FakerExtensions
     {
         return faker.Generate(count).Cast<TOut>().ToHashSet();
     }
-#pragma warning restore AV1130 // Return type in method signature should be an interface to an unchangeable collection
 }

--- a/test/TestBuildingBlocks/FluentMetaExtensions.cs
+++ b/test/TestBuildingBlocks/FluentMetaExtensions.cs
@@ -19,10 +19,8 @@ public static class FluentMetaExtensions
     /// Asserts that a "meta" dictionary contains a single element named "total" with the specified value.
     /// </summary>
     [CustomAssertion]
-#pragma warning disable AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
     public static void ContainTotal(this GenericDictionaryAssertions<IDictionary<string, object?>, string, object?> source, int expected,
         string? keyName = null)
-#pragma warning restore AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
     {
         JsonElement element = GetMetaJsonElement(source, keyName ?? "total");
         element.GetInt32().Should().Be(expected);
@@ -32,9 +30,7 @@ public static class FluentMetaExtensions
     /// Asserts that a "meta" dictionary does not contain a single element named "total" when not null.
     /// </summary>
     [CustomAssertion]
-#pragma warning disable AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
     public static void NotContainTotal(this GenericDictionaryAssertions<IDictionary<string, object?>, string, object?> source, string? keyName = null)
-#pragma warning restore AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
     {
         source.Subject?.Should().NotContainKey(keyName ?? "total");
     }

--- a/test/TestBuildingBlocks/IntegrationTest.cs
+++ b/test/TestBuildingBlocks/IntegrationTest.cs
@@ -42,10 +42,8 @@ public abstract class IntegrationTest : IAsyncLifetime
         return await ExecuteRequestAsync<TResponseDocument>(HttpMethod.Get, requestUrl, null, null, setRequestHeaders);
     }
 
-#pragma warning disable AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
     public async Task<(HttpResponseMessage httpResponse, TResponseDocument responseDocument)> ExecutePostAsync<TResponseDocument>(string requestUrl,
         object requestBody, string? contentType = null, Action<HttpRequestHeaders>? setRequestHeaders = null)
-#pragma warning restore AV1553 // Do not use optional parameters with default value null for strings, collections or tasks
     {
         MediaTypeHeaderValue mediaType = contentType == null ? DefaultMediaType : MediaTypeHeaderValue.Parse(contentType);
 

--- a/test/TestBuildingBlocks/JsonApiStringConverter.cs
+++ b/test/TestBuildingBlocks/JsonApiStringConverter.cs
@@ -1,8 +1,5 @@
 using System.Text.Json;
 
-#pragma warning disable AV1008 // Class should not be static
-#pragma warning disable AV1210 // Catch a specific exception instead of Exception, SystemException or ApplicationException
-
 namespace TestBuildingBlocks;
 
 public static class JsonApiStringConverter

--- a/test/TestBuildingBlocks/Unknown.cs
+++ b/test/TestBuildingBlocks/Unknown.cs
@@ -2,7 +2,6 @@ using JsonApiDotNetCore.Resources;
 
 // ReSharper disable MemberCanBeInternal
 // ReSharper disable MemberCanBePrivate.Global
-#pragma warning disable AV1008 // Class should not be static
 
 namespace TestBuildingBlocks;
 


### PR DESCRIPTION
Remove dependency on CSharpGuidelinesAnalyzer, which is no longer being maintained.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
