### PR TITLE
Block GET request on secondary/relationship endpoint when `AllowView` is off

### DIFF
--- a/docs/usage/resources/relationships.md
+++ b/docs/usage/resources/relationships.md
@@ -289,7 +289,7 @@ Indicates whether the relationship can be returned in responses. When not allowe
 Otherwise, the relationship (and its related resources, when included) are silently omitted.
 
 > [!WARNING]
-> This setting does not affect retrieving the related resources directly.
+> This setting affects the secondary and relationship endpoints, but it does not affect retrieving the related resources directly.
 
 ```c#
 #nullable enable

--- a/src/JsonApiDotNetCore.Annotations/Resources/Annotations/HasManyCapabilities.shared.cs
+++ b/src/JsonApiDotNetCore.Annotations/Resources/Annotations/HasManyCapabilities.shared.cs
@@ -16,7 +16,7 @@ public enum HasManyCapabilities
     /// disabled will return an HTTP 400 response. Otherwise, the relationship (and its related resources, when included) are silently omitted.
     /// </summary>
     /// <remarks>
-    /// Note this setting does not affect retrieving the related resources directly.
+    /// Note this setting affects the secondary and relationship endpoints, but it does not affect retrieving the related resources directly.
     /// </remarks>
     AllowView = 1,
 

--- a/src/JsonApiDotNetCore.Annotations/Resources/Annotations/HasOneCapabilities.shared.cs
+++ b/src/JsonApiDotNetCore.Annotations/Resources/Annotations/HasOneCapabilities.shared.cs
@@ -16,7 +16,7 @@ public enum HasOneCapabilities
     /// disabled will return an HTTP 400 response. Otherwise, the relationship (and its related resources, when included) are silently omitted.
     /// </summary>
     /// <remarks>
-    /// Note this setting does not affect retrieving the related resources directly.
+    /// Note this setting affects the secondary and relationship endpoints, but it does not affect retrieving the related resources directly.
     /// </remarks>
     AllowView = 1,
 

--- a/src/JsonApiDotNetCore/Errors/BlockedGetRelationshipException.cs
+++ b/src/JsonApiDotNetCore/Errors/BlockedGetRelationshipException.cs
@@ -1,0 +1,14 @@
+using System.Net;
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources.Annotations;
+using JsonApiDotNetCore.Serialization.Objects;
+
+namespace JsonApiDotNetCore.Errors;
+
+[PublicAPI]
+public sealed class BlockedGetRelationshipException(RelationshipAttribute relationship)
+    : JsonApiException(new ErrorObject(HttpStatusCode.Forbidden)
+    {
+        Title = "The requested endpoint is not accessible.",
+        Detail = $"Retrieving the relationship '{relationship.PublicName}' of type '{relationship.LeftType}' is not allowed."
+    });

--- a/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
+++ b/src/JsonApiDotNetCore/Services/JsonApiResourceService.cs
@@ -115,6 +115,7 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
         AssertHasRelationship(_request.Relationship, relationshipName);
         AssertPrimaryResourceTypeInJsonApiRequestIsNotNull(_request.PrimaryResourceType);
         AssertSecondaryResourceTypeInJsonApiRequestIsNotNull(_request.SecondaryResourceType);
+        AssertCanViewRelationship(_request.Relationship);
 
         using IDisposable _ = CodeTimingSessionManager.Current.Measure("Service - Get secondary resource(s)");
 
@@ -167,6 +168,7 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
         AssertHasRelationship(_request.Relationship, relationshipName);
         AssertPrimaryResourceTypeInJsonApiRequestIsNotNull(_request.PrimaryResourceType);
         AssertSecondaryResourceTypeInJsonApiRequestIsNotNull(_request.SecondaryResourceType);
+        AssertCanViewRelationship(_request.Relationship);
 
         using IDisposable _ = CodeTimingSessionManager.Current.Measure("Service - Get relationship");
 
@@ -693,6 +695,22 @@ public class JsonApiResourceService<TResource, TId> : IResourceService<TResource
         if (relationship == null)
         {
             throw new RelationshipNotFoundException(name, _request.PrimaryResourceType!.PublicName);
+        }
+    }
+
+    [AssertionMethod]
+    private void AssertCanViewRelationship(RelationshipAttribute relationship)
+    {
+        bool allowView = relationship switch
+        {
+            HasOneAttribute hasOneRelationship when !hasOneRelationship.Capabilities.HasFlag(HasOneCapabilities.AllowView) => false,
+            HasManyAttribute hasManyRelationship when !hasManyRelationship.Capabilities.HasFlag(HasManyCapabilities.AllowView) => false,
+            _ => true
+        };
+
+        if (!allowView)
+        {
+            throw new BlockedGetRelationshipException(relationship);
         }
     }
 

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/TimeOffset/TimeOffsetTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/CustomFunctions/TimeOffset/TimeOffsetTests.cs
@@ -21,6 +21,7 @@ public sealed class TimeOffsetTests : IClassFixture<IntegrationTestContext<Testa
         _testContext = testContext;
 
         testContext.UseController<CalendarsController>();
+        testContext.UseController<AppointmentsController>();
         testContext.UseController<RemindersController>();
 
         testContext.ConfigureServices(services =>
@@ -202,22 +203,22 @@ public sealed class TimeOffsetTests : IClassFixture<IntegrationTestContext<Testa
         var timeProvider = _testContext.Factory.Services.GetRequiredService<TimeProvider>();
         DateTimeOffset utcNow = timeProvider.GetUtcNow();
 
-        Calendar calendar = _fakers.Calendar.GenerateOne();
-        calendar.Appointments = _fakers.Appointment.GenerateSet(2);
+        List<Appointment> appointments = _fakers.Appointment.GenerateList(2);
 
-        calendar.Appointments.ElementAt(0).Reminders = _fakers.Reminder.GenerateList(1);
-        calendar.Appointments.ElementAt(0).Reminders[0].RemindsAt = utcNow.UtcDateTime;
+        appointments[0].Reminders = _fakers.Reminder.GenerateList(1);
+        appointments[0].Reminders[0].RemindsAt = utcNow.UtcDateTime;
 
-        calendar.Appointments.ElementAt(1).Reminders = _fakers.Reminder.GenerateList(1);
-        calendar.Appointments.ElementAt(1).Reminders[0].RemindsAt = utcNow.Add(TimeSpan.FromMinutes(30)).UtcDateTime;
+        appointments[1].Reminders = _fakers.Reminder.GenerateList(1);
+        appointments[1].Reminders[0].RemindsAt = utcNow.Add(TimeSpan.FromMinutes(30)).UtcDateTime;
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            dbContext.Calendars.Add(calendar);
+            await dbContext.ClearTableAsync<Appointment>();
+            dbContext.Appointments.AddRange(appointments);
             await dbContext.SaveChangesAsync();
         });
 
-        string route = $"/calendars/{calendar.StringId}/appointments?filter=has(reminders,equals(remindsAt,timeOffset('%2B0:30:00')))";
+        const string route = "/appointments?filter=has(reminders,equals(remindsAt,timeOffset('%2B0:30:00')))";
 
         // Act
         (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
@@ -227,6 +228,6 @@ public sealed class TimeOffsetTests : IClassFixture<IntegrationTestContext<Testa
 
         responseDocument.Data.ManyValue.Should().HaveCount(1);
 
-        responseDocument.Data.ManyValue[0].Id.Should().Be(calendar.Appointments.ElementAt(1).StringId);
+        responseDocument.Data.ManyValue[0].Id.Should().Be(appointments[1].StringId);
     }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Includes/DisablePaginationOnRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/QueryStrings/Includes/DisablePaginationOnRelationshipTests.cs
@@ -149,17 +149,17 @@ public sealed class DisablePaginationOnRelationshipTests : IClassFixture<Integra
     public async Task Ignores_pagination_from_query_string()
     {
         // Arrange
-        Calendar calendar = _fakers.Calendar.GenerateOne();
-        calendar.Appointments = _fakers.Appointment.GenerateSet(3);
-        calendar.Appointments.ElementAt(0).Reminders = _fakers.Reminder.GenerateList(7);
+        List<Appointment> appointments = _fakers.Appointment.GenerateList(3);
+        appointments[0].Reminders = _fakers.Reminder.GenerateList(7);
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
-            dbContext.Calendars.Add(calendar);
+            await dbContext.ClearTableAsync<Appointment>();
+            dbContext.Appointments.AddRange(appointments);
             await dbContext.SaveChangesAsync();
         });
 
-        string route = $"calendars/{calendar.StringId}/appointments?include=reminders&page[size]=2,reminders:4";
+        const string route = "appointments?include=reminders&page[size]=2,reminders:4";
 
         // Act
         (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
@@ -170,7 +170,7 @@ public sealed class DisablePaginationOnRelationshipTests : IClassFixture<Integra
         responseDocument.Data.ManyValue.Should().HaveCount(2);
         responseDocument.Data.ManyValue.Should().AllSatisfy(resource => resource.Type.Should().Be("appointments"));
 
-        ResourceObject firstAppointment = responseDocument.Data.ManyValue.Single(resource => resource.Id == calendar.Appointments.ElementAt(0).StringId);
+        ResourceObject firstAppointment = responseDocument.Data.ManyValue.Single(resource => resource.Id == appointments[0].StringId);
 
         firstAppointment.Relationships.Should().ContainKey("reminders").WhoseValue.With(value =>
         {

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Fetching/FetchRelationshipTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Fetching/FetchRelationshipTests.cs
@@ -16,6 +16,7 @@ public sealed class FetchRelationshipTests : IClassFixture<IntegrationTestContex
         _testContext = testContext;
 
         testContext.UseController<WorkItemsController>();
+        testContext.UseController<WorkItemGroupsController>();
         testContext.UseController<UserAccountsController>();
     }
 
@@ -66,6 +67,33 @@ public sealed class FetchRelationshipTests : IClassFixture<IntegrationTestContex
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
         responseDocument.Data.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Cannot_get_ManyToOne_relationship_with_blocked_capability()
+    {
+        WorkItem workItem = _fakers.WorkItem.GenerateOne();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            dbContext.WorkItems.Add(workItem);
+            await dbContext.SaveChangesAsync();
+        });
+
+        string route = $"/workItems/{workItem.StringId}/relationships/group";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Forbidden);
+
+        responseDocument.Errors.Should().HaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        error.Title.Should().Be("The requested endpoint is not accessible.");
+        error.Detail.Should().Be("Retrieving the relationship 'group' of type 'workItems' is not allowed.");
     }
 
     [Fact]
@@ -123,6 +151,33 @@ public sealed class FetchRelationshipTests : IClassFixture<IntegrationTestContex
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
         responseDocument.Data.ManyValue.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Cannot_get_OneToMany_relationship_with_blocked_capability()
+    {
+        WorkItemGroup group = _fakers.WorkItemGroup.GenerateOne();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            dbContext.Groups.Add(group);
+            await dbContext.SaveChangesAsync();
+        });
+
+        string route = $"/workItemGroups/{group.StringId}/relationships/items";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Forbidden);
+
+        responseDocument.Errors.Should().HaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        error.Title.Should().Be("The requested endpoint is not accessible.");
+        error.Detail.Should().Be("Retrieving the relationship 'items' of type 'workItemGroups' is not allowed.");
     }
 
     [Fact]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Fetching/FetchResourceTests.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/Fetching/FetchResourceTests.cs
@@ -16,6 +16,7 @@ public sealed class FetchResourceTests : IClassFixture<IntegrationTestContext<Te
         _testContext = testContext;
 
         testContext.UseController<WorkItemsController>();
+        testContext.UseController<WorkItemGroupsController>();
         testContext.UseController<UserAccountsController>();
         testContext.UseController<WorkTagsController>();
     }
@@ -192,6 +193,34 @@ public sealed class FetchResourceTests : IClassFixture<IntegrationTestContext<Te
     }
 
     [Fact]
+    public async Task Cannot_get_secondary_ManyToOne_resource_with_blocked_capability()
+    {
+        // Arrange
+        WorkItem workItem = _fakers.WorkItem.GenerateOne();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            dbContext.WorkItems.Add(workItem);
+            await dbContext.SaveChangesAsync();
+        });
+
+        string route = $"/workItems/{workItem.StringId}/group";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Forbidden);
+
+        responseDocument.Errors.Should().HaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        error.Title.Should().Be("The requested endpoint is not accessible.");
+        error.Detail.Should().Be("Retrieving the relationship 'group' of type 'workItems' is not allowed.");
+    }
+
+    [Fact]
     public async Task Can_get_secondary_OneToMany_resources()
     {
         // Arrange
@@ -250,6 +279,34 @@ public sealed class FetchResourceTests : IClassFixture<IntegrationTestContext<Te
         httpResponse.ShouldHaveStatusCode(HttpStatusCode.OK);
 
         responseDocument.Data.ManyValue.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Cannot_get_secondary_OneToMany_resources_with_blocked_capability()
+    {
+        // Arrange
+        WorkItemGroup group = _fakers.WorkItemGroup.GenerateOne();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            dbContext.Groups.Add(group);
+            await dbContext.SaveChangesAsync();
+        });
+
+        string route = $"/workItemGroups/{group.StringId}/items";
+
+        // Act
+        (HttpResponseMessage httpResponse, Document responseDocument) = await _testContext.ExecuteGetAsync<Document>(route);
+
+        // Assert
+        httpResponse.ShouldHaveStatusCode(HttpStatusCode.Forbidden);
+
+        responseDocument.Errors.Should().HaveCount(1);
+
+        ErrorObject error = responseDocument.Errors[0];
+        error.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        error.Title.Should().Be("The requested endpoint is not accessible.");
+        error.Detail.Should().Be("Retrieving the relationship 'items' of type 'workItemGroups' is not allowed.");
     }
 
     [Fact]

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/WorkItem.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/WorkItem.cs
@@ -47,6 +47,6 @@ public sealed class WorkItem : Identifiable<int>
     [HasMany]
     public IList<WorkItem> RelatedTo { get; set; } = new List<WorkItem>();
 
-    [HasOne(Capabilities = HasOneCapabilities.All & ~HasOneCapabilities.AllowSet)]
+    [HasOne(Capabilities = HasOneCapabilities.All & ~(HasOneCapabilities.AllowView | HasOneCapabilities.AllowSet))]
     public WorkItemGroup? Group { get; set; }
 }

--- a/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/WorkItemGroup.cs
+++ b/test/JsonApiDotNetCoreTests/IntegrationTests/ReadWrite/WorkItemGroup.cs
@@ -22,6 +22,8 @@ public sealed class WorkItemGroup : Identifiable<Guid>
     [HasOne]
     public RgbColor? Color { get; set; }
 
-    [HasMany(Capabilities = HasManyCapabilities.All & ~(HasManyCapabilities.AllowSet | HasManyCapabilities.AllowAdd | HasManyCapabilities.AllowRemove))]
+    [HasMany(Capabilities =
+        HasManyCapabilities.All &
+        ~(HasManyCapabilities.AllowView | HasManyCapabilities.AllowSet | HasManyCapabilities.AllowAdd | HasManyCapabilities.AllowRemove))]
     public IList<WorkItem> Items { get; set; } = new List<WorkItem>();
 }


### PR DESCRIPTION
Block GET request on secondary/relationship endpoint when the relationship doesn't contain the `AllowView` capability

Fixes #1991.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [x] Documentation updated
