### PR TITLE
Add OpenAPI tests for the presence of meta

### DIFF
--- a/test/OpenApiTests/AttributeTypes/TypeContainer.cs
+++ b/test/OpenApiTests/AttributeTypes/TypeContainer.cs
@@ -128,7 +128,7 @@ public sealed class TypeContainer : Identifiable<long>
     public char? TestNullableChar { get; set; }
 
     [Attr]
-    public required string TestString { get; set; }
+    public string TestString { get; set; } = null!;
 
     [Attr]
     public string? TestNullableString { get; set; }
@@ -186,13 +186,13 @@ public sealed class TypeContainer : Identifiable<long>
     public Guid? TestNullableGuid { get; set; }
 
     [Attr]
-    public required Uri TestUri { get; set; }
+    public Uri TestUri { get; set; } = null!;
 
     [Attr]
     public Uri? TestNullableUri { get; set; }
 
     [Attr]
-    public required IPAddress TestIPAddress { get; set; }
+    public IPAddress TestIPAddress { get; set; } = null!;
 
     [Attr]
     public IPAddress? TestNullableIPAddress { get; set; }
@@ -204,7 +204,7 @@ public sealed class TypeContainer : Identifiable<long>
     public IPNetwork? TestNullableIPNetwork { get; set; }
 
     [Attr]
-    public required Version TestVersion { get; set; }
+    public Version TestVersion { get; set; } = null!;
 
     [Attr]
     public Version? TestNullableVersion { get; set; }

--- a/test/OpenApiTests/Meta/JigsawPuzzle.cs
+++ b/test/OpenApiTests/Meta/JigsawPuzzle.cs
@@ -1,0 +1,22 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace OpenApiTests.Meta;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "OpenApiTests.Meta")]
+public sealed class JigsawPuzzle : Identifiable<long>
+{
+    [Attr]
+    public string Title { get; set; } = null!;
+
+    [HasOne]
+    public JigsawPuzzlePicture FrontPicture { get; set; } = null!;
+
+    [HasOne]
+    public JigsawPuzzlePicture? BackPicture { get; set; }
+
+    [HasMany]
+    public ISet<JigsawPuzzlePiece> Pieces { get; set; } = new HashSet<JigsawPuzzlePiece>();
+}

--- a/test/OpenApiTests/Meta/JigsawPuzzlePicture.cs
+++ b/test/OpenApiTests/Meta/JigsawPuzzlePicture.cs
@@ -1,0 +1,13 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace OpenApiTests.Meta;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "OpenApiTests.Meta")]
+public sealed class JigsawPuzzlePicture : Identifiable<long>
+{
+    [Attr]
+    public string ImageUrl { get; set; } = null!;
+}

--- a/test/OpenApiTests/Meta/JigsawPuzzlePiece.cs
+++ b/test/OpenApiTests/Meta/JigsawPuzzlePiece.cs
@@ -1,0 +1,16 @@
+using JetBrains.Annotations;
+using JsonApiDotNetCore.Resources;
+using JsonApiDotNetCore.Resources.Annotations;
+
+namespace OpenApiTests.Meta;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+[Resource(ControllerNamespace = "OpenApiTests.Meta")]
+public sealed class JigsawPuzzlePiece : Identifiable<long>
+{
+    [Attr]
+    public string ImageUrl { get; set; } = null!;
+
+    [HasOne]
+    public JigsawPuzzle Puzzle { get; set; } = null!;
+}

--- a/test/OpenApiTests/Meta/MetaDbContext.cs
+++ b/test/OpenApiTests/Meta/MetaDbContext.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using TestBuildingBlocks;
+
+namespace OpenApiTests.Meta;
+
+[UsedImplicitly(ImplicitUseTargetFlags.Members)]
+public sealed class MetaDbContext(DbContextOptions<MetaDbContext> options)
+    : TestableDbContext(options)
+{
+    public DbSet<JigsawPuzzle> Puzzles => Set<JigsawPuzzle>();
+}

--- a/test/OpenApiTests/Meta/MetaTests.cs
+++ b/test/OpenApiTests/Meta/MetaTests.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using JsonApiDotNetCore.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TestBuildingBlocks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OpenApiTests.Meta;
+
+public sealed class MetaTests : IClassFixture<OpenApiTestContext<OpenApiStartup<MetaDbContext>, MetaDbContext>>
+{
+    private readonly OpenApiTestContext<OpenApiStartup<MetaDbContext>, MetaDbContext> _testContext;
+
+    public MetaTests(OpenApiTestContext<OpenApiStartup<MetaDbContext>, MetaDbContext> testContext, ITestOutputHelper testOutputHelper)
+    {
+        _testContext = testContext;
+
+        testContext.UseController<JigsawPuzzlesController>();
+        testContext.UseController<JigsawPuzzlePicturesController>();
+        testContext.UseController<JigsawPuzzlePiecesController>();
+        testContext.UseController<OperationsController>();
+
+        testContext.SetTestOutputHelper(testOutputHelper);
+
+        var options = (JsonApiOptions)testContext.Factory.Services.GetRequiredService<IJsonApiOptions>();
+        options.IncludeJsonApiVersion = true;
+    }
+
+    [Fact]
+    public async Task Includes_meta_definition()
+    {
+        // Act
+        JsonElement document = await _testContext.GetSwaggerDocumentAsync();
+
+        // Assert
+        document.Should().ContainPath("components.schemas.meta").With(metaElement =>
+        {
+            metaElement.Should().BeJson("""
+                {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+                """);
+        });
+    }
+
+    [Theory]
+    [InlineData("atomicOperation")]
+    [InlineData("atomicResult")]
+    [InlineData("createJigsawPuzzlePictureRequestDocument")]
+    [InlineData("createJigsawPuzzlePieceRequestDocument")]
+    [InlineData("createJigsawPuzzleRequestDocument")]
+    [InlineData("errorObject")]
+    [InlineData("errorResponseDocument")]
+    [InlineData("identifierInRequest")]
+    [InlineData("jigsawPuzzleCollectionResponseDocument")]
+    [InlineData("jigsawPuzzleIdentifierInResponse")]
+    [InlineData("jigsawPuzzleIdentifierResponseDocument")]
+    [InlineData("jigsawPuzzlePictureCollectionResponseDocument")]
+    [InlineData("jigsawPuzzlePictureIdentifierInResponse")]
+    [InlineData("jigsawPuzzlePictureIdentifierResponseDocument")]
+    [InlineData("jigsawPuzzlePieceCollectionResponseDocument")]
+    [InlineData("jigsawPuzzlePieceIdentifierCollectionResponseDocument")]
+    [InlineData("jigsawPuzzlePieceIdentifierInResponse")]
+    [InlineData("jsonapi")]
+    [InlineData("nullableJigsawPuzzlePictureIdentifierResponseDocument")]
+    [InlineData("nullableSecondaryJigsawPuzzlePictureResponseDocument")]
+    [InlineData("nullableToOneJigsawPuzzlePictureInRequest")]
+    [InlineData("nullableToOneJigsawPuzzlePictureInResponse")]
+    [InlineData("operationsRequestDocument")]
+    [InlineData("operationsResponseDocument")]
+    [InlineData("primaryJigsawPuzzlePictureResponseDocument")]
+    [InlineData("primaryJigsawPuzzlePieceResponseDocument")]
+    [InlineData("primaryJigsawPuzzleResponseDocument")]
+    [InlineData("resourceInCreateRequest")]
+    [InlineData("resourceInResponse")]
+    [InlineData("resourceInUpdateRequest")]
+    [InlineData("secondaryJigsawPuzzlePictureResponseDocument")]
+    [InlineData("secondaryJigsawPuzzleResponseDocument")]
+    [InlineData("toManyJigsawPuzzlePieceInRequest")]
+    [InlineData("toManyJigsawPuzzlePieceInResponse")]
+    [InlineData("toOneJigsawPuzzleInRequest")]
+    [InlineData("toOneJigsawPuzzleInResponse")]
+    [InlineData("toOneJigsawPuzzlePictureInRequest")]
+    [InlineData("toOneJigsawPuzzlePictureInResponse")]
+    [InlineData("updateJigsawPuzzlePictureRequestDocument")]
+    [InlineData("updateJigsawPuzzlePieceRequestDocument")]
+    [InlineData("updateJigsawPuzzleRequestDocument")]
+    public async Task Includes_meta_property(string schemaId)
+    {
+        // Act
+        JsonElement document = await _testContext.GetSwaggerDocumentAsync();
+
+        // Assert
+        document.Should().ContainPath($"components.schemas.{schemaId}.properties").With(propertiesElement =>
+        {
+            JsonElement metaElement = propertiesElement.Should().ContainPath("meta.allOf[0]");
+            metaElement.Should().HaveProperty("$ref", "#/components/schemas/meta");
+        });
+    }
+}

--- a/test/OpenApiTests/Meta/OperationsController.cs
+++ b/test/OpenApiTests/Meta/OperationsController.cs
@@ -1,0 +1,13 @@
+using JsonApiDotNetCore.AtomicOperations;
+using JsonApiDotNetCore.Configuration;
+using JsonApiDotNetCore.Controllers;
+using JsonApiDotNetCore.Middleware;
+using JsonApiDotNetCore.Resources;
+using Microsoft.Extensions.Logging;
+
+namespace OpenApiTests.Meta;
+
+public sealed class OperationsController(
+    IJsonApiOptions options, IResourceGraph resourceGraph, ILoggerFactory loggerFactory, IOperationsProcessor processor, IJsonApiRequest request,
+    ITargetedFields targetedFields, IAtomicOperationFilter operationFilter)
+    : JsonApiOperationsController(options, resourceGraph, loggerFactory, processor, request, targetedFields, operationFilter);

--- a/test/OpenApiTests/OpenApiTests.csproj
+++ b/test/OpenApiTests/OpenApiTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>


### PR DESCRIPTION
Adds test coverage for `meta` in OpenAPI schemas. Because it is a free-format dictionary, we can't generate statically typed properties for built-in keys such as `total`, `requestBody`, and `stackTrace`.

Closes #1063.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
