### PR TITLE
Turn off slow analyzers again to measure roslyn perf regression impact

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,7 +6,7 @@
   </Target>
 
   <!-- Workaround for compiler regression at https://github.com/dotnet/roslyn/issues/80756 -->
-  <Target Name="DisableSlowAnalyzers" Condition="'$(Configuration)' == 'Debug'" BeforeTargets="CoreCompile">
+  <Target Name="DisableSlowAnalyzers" BeforeTargets="CoreCompile">
     <ItemGroup>
       <Analyzer Remove="@(Analyzer)" Condition="'%(Filename)' == 'Microsoft.CodeAnalysis.CSharp.CodeStyle'" />
       <Analyzer Remove="@(Analyzer)" Condition="'%(Filename)' == 'Microsoft.CodeAnalysis.NetAnalyzers'" />


### PR DESCRIPTION
Turn off slow analyzers in Release builds to measure impact (using .NET SDK v10.0.300).

Follow-up of #1973.