### PR TITLE
Remove Microsoft.Extensions.Caching.Memory reference since it is platform provided

### DIFF
--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiDotNetCore.OpenApi.Swashbuckle.csproj
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiDotNetCore.OpenApi.Swashbuckle.csproj
@@ -33,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Workaround: Microsoft.EntityFrameworkCore 8.0.0 depends on Microsoft.Extensions.Caching.Memory 8.0.0, which is vulnerable. -->
     <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
   

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiDotNetCore.OpenApi.Swashbuckle.csproj
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiDotNetCore.OpenApi.Swashbuckle.csproj
@@ -33,6 +33,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="SauceControl.InheritDoc" Version="$(InheritDocVersion)" PrivateAssets="All" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="$(SwashbuckleFrozenVersion)" />
   </ItemGroup>

--- a/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiDotNetCore.OpenApi.Swashbuckle.csproj
+++ b/src/JsonApiDotNetCore.OpenApi.Swashbuckle/JsonApiDotNetCore.OpenApi.Swashbuckle.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
+++ b/src/JsonApiDotNetCore/JsonApiDotNetCore.csproj
@@ -40,12 +40,6 @@
     <PackageReference Include="Humanizer.Core" Version="$(HumanizerFrozenVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EntityFrameworkCoreFrozenVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EntityFrameworkCoreFrozenVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" NoWarn="$(NoWarn);NU1510">
-      <!--
-        Microsoft.EntityFrameworkCore 8.0.0 depends on Microsoft.Extensions.Caching.Memory 8.0.0, which is vulnerable.
-        This package reference silences the vulnerability warning and suppresses the NU1510 warning that the dependency will not appear in our NuGet package.
-      -->
-    </PackageReference>
     <PackageReference Include="SauceControl.InheritDoc" Version="$(InheritDocVersion)" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Follow up to https://devblogs.microsoft.com/dotnet/nuget-package-pruning-in-dotnet-10/?commentid=22975#comment-22975.

#### QUALITY CHECKLIST
- [ ] ~Changes implemented in code~
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] ~Adapted tests~ Existing tests should pass just fine. Not audit issues reported.
- [ ] ~Documentation updated~
