### PR TITLE
Remove dependency on SimonCropp/Polyfill

### DIFF
--- a/package-versions.props
+++ b/package-versions.props
@@ -16,7 +16,6 @@
     <GitHubActionsTestLoggerVersion>3.0.*</GitHubActionsTestLoggerVersion>
     <InheritDocVersion>2.0.*</InheritDocVersion>
     <MiniValidationVersion>0.10.*</MiniValidationVersion>
-    <PolyfillVersion>10.10.*</PolyfillVersion>
     <ReadableExpressionsVersion>4.1.*</ReadableExpressionsVersion>
     <SystemTextJsonVersion>10.0.*</SystemTextJsonVersion>
     <TestSdkVersion>18.8.*</TestSdkVersion>

--- a/src/JsonApiDotNetCore.SourceGenerators/ControllerSourceGenerator.cs
+++ b/src/JsonApiDotNetCore.SourceGenerators/ControllerSourceGenerator.cs
@@ -299,7 +299,7 @@ public sealed class ControllerSourceGenerator : IIncrementalGenerator
         builder.AppendLine($"// Input: {fullController}");
         builder.AppendLine();
 
-        foreach (string errorLine in exception.ToString().Split(LineBreak))
+        foreach (string errorLine in exception.ToString().Split([LineBreak], StringSplitOptions.None))
         {
             builder.AppendLine($"// {errorLine}");
         }

--- a/src/JsonApiDotNetCore.SourceGenerators/JsonApiDotNetCore.SourceGenerators.csproj
+++ b/src/JsonApiDotNetCore.SourceGenerators/JsonApiDotNetCore.SourceGenerators.csproj
@@ -48,6 +48,5 @@
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" Version="$(HumanizerFrozenVersion)" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisFrozenVersion)" PrivateAssets="all" />
-    <PackageReference Include="Polyfill" Version="$(PolyfillVersion)" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/JsonApiDotNetCore.SourceGenerators/Polyfills/IsExternalInit.cs
+++ b/src/JsonApiDotNetCore.SourceGenerators/Polyfills/IsExternalInit.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+// ReSharper disable CheckNamespace
+// ReSharper disable UnusedType.Global
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Reserved to be used by the compiler for tracking metadata. This class should not be used by developers in source code.
+/// </summary>
+[ExcludeFromCodeCoverage]
+[DebuggerNonUserCode]
+internal static class IsExternalInit;

--- a/src/JsonApiDotNetCore.SourceGenerators/Polyfills/KeyValuePairExtensions.cs
+++ b/src/JsonApiDotNetCore.SourceGenerators/Polyfills/KeyValuePairExtensions.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+// ReSharper disable CheckNamespace
+
+namespace System.Collections.Generic;
+
+[ExcludeFromCodeCoverage]
+internal static class KeyValuePairExtensions
+{
+    /// <summary>
+    /// Deconstructs the current KeyValuePair into its key and value.
+    /// </summary>
+    public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> target, out TKey key, out TValue value)
+    {
+        key = target.Key;
+        value = target.Value;
+    }
+}


### PR DESCRIPTION
Replace the dependency on [SimonCropp/Polyfill](https://github.com/SimonCropp/Polyfill) (used by source generators) by inlining only the bits we need.

This prevents Dependabot notifications (usually multiple per week) each time a new version of the dependency is published.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [ ] N/A: Documentation updated
