### PR TITLE
Add Dapper support for Microting.EntityFrameworkCore.MySql

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,16 +14,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NoWarn>
-      <!--
-        Temporary workaround: Stable EF Core 10 package for Pomelo.EntityFrameworkCore.MySql is not available yet.
-        NU1608: Detected package version outside of dependency constraint
-      -->
-      $(NoWarn);NU1608
-    </NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!--
       Disabled IDE analyzers for "Use collection expression" because they are dangerous in a subtle way.
       For example, a suggestion for the following code is raised:

--- a/JsonApiDotNetCore.slnx.DotSettings
+++ b/JsonApiDotNetCore.slnx.DotSettings
@@ -671,6 +671,7 @@ $left$ = $right$;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=jsonapi/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=linebreaks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Microservices/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Microting/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=navigations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Npgsql/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=parallelize/@EntryIndexedValue">True</s:Boolean>

--- a/package-versions.props
+++ b/package-versions.props
@@ -30,10 +30,6 @@
     <!-- Non-published dependencies (these are safe to update, won't cause a breaking change) -->
     <AspNetCoreVersion>10.0.*</AspNetCoreVersion>
     <EntityFrameworkCoreVersion>10.0.*-*</EntityFrameworkCoreVersion>
-    <PomeloEntityFrameworkCoreVersion>
-      <!-- Temporary workaround: Unstable EF Core 10 package for Pomelo.EntityFrameworkCore.MySql is not available yet. -->
-      9.0.*
-    </PomeloEntityFrameworkCoreVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0'">
@@ -43,7 +39,6 @@
     <!-- Non-published dependencies (these are safe to update, won't cause a breaking change) -->
     <AspNetCoreVersion>9.0.*</AspNetCoreVersion>
     <EntityFrameworkCoreVersion>9.0.*</EntityFrameworkCoreVersion>
-    <PomeloEntityFrameworkCoreVersion>$(EntityFrameworkCoreVersion)</PomeloEntityFrameworkCoreVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -53,6 +48,5 @@
     <!-- Non-published dependencies (these are safe to update, won't cause a breaking change) -->
     <AspNetCoreVersion>8.0.*</AspNetCoreVersion>
     <EntityFrameworkCoreVersion>8.0.*</EntityFrameworkCoreVersion>
-    <PomeloEntityFrameworkCoreVersion>$(EntityFrameworkCoreVersion)</PomeloEntityFrameworkCoreVersion>
   </PropertyGroup>
 </Project>

--- a/src/Examples/DapperExample/DapperExample.csproj
+++ b/src/Examples/DapperExample/DapperExample.csproj
@@ -15,7 +15,8 @@
     <PackageReference Include="Dapper" Version="$(DapperVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EntityFrameworkCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageReference Include="Microting.EntityFrameworkCore.MySql" Condition="'$(TargetFramework)' != 'net9.0' And '$(TargetFramework)' != 'net8.0'" Version="$(EntityFrameworkCoreVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(EntityFrameworkCoreVersion)" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreVersion)" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Condition="'$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net8.0'" Version="$(EntityFrameworkCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Examples/DapperExample/TranslationToSql/DataModel/FromEntitiesDataModelService.cs
+++ b/src/Examples/DapperExample/TranslationToSql/DataModel/FromEntitiesDataModelService.cs
@@ -29,7 +29,7 @@ public sealed class FromEntitiesDataModelService(IResourceGraph resourceGraph)
         _databaseProvider = dbContext.Database.ProviderName switch
         {
             "Npgsql.EntityFrameworkCore.PostgreSQL" => DatabaseProvider.PostgreSql,
-            "Pomelo.EntityFrameworkCore.MySql" => DatabaseProvider.MySql,
+            "Pomelo.EntityFrameworkCore.MySql" or "Microting.EntityFrameworkCore.MySql" => DatabaseProvider.MySql,
             "Microsoft.EntityFrameworkCore.SqlServer" => DatabaseProvider.SqlServer,
             _ => throw new NotSupportedException($"Unknown database provider '{dbContext.Database.ProviderName}'.")
         };

--- a/src/Examples/DapperExample/appsettings.json
+++ b/src/Examples/DapperExample/appsettings.json
@@ -1,13 +1,13 @@
 {
   "DatabaseProvider": "PostgreSql",
   "ConnectionStrings": {
-    // docker run --rm --detach --name dapper-example-postgresql-db -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:latest
-    // docker run --rm --detach --name dapper-example-postgresql-management --link dapper-example-postgresql-db:db -e PGADMIN_DEFAULT_EMAIL=admin@admin.com -e PGADMIN_DEFAULT_PASSWORD=postgres -p 5050:80 dpage/pgadmin4:latest
+    // docker run --pull always --rm --detach --name dapper-example-postgresql-db -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:latest
+    // docker run --pull always --rm --detach --name dapper-example-postgresql-management --link dapper-example-postgresql-db:db -e PGADMIN_DEFAULT_EMAIL=admin@admin.com -e PGADMIN_DEFAULT_PASSWORD=postgres -p 5050:80 dpage/pgadmin4:latest
     "DapperExamplePostgreSql": "Host=localhost;Database=DapperExample;User ID=postgres;Password=postgres;Include Error Detail=true",
-    // docker run --rm --detach --name dapper-example-mysql-db -e MYSQL_ROOT_PASSWORD=mysql -e MYSQL_DATABASE=DapperExample -e MYSQL_USER=mysql -e MYSQL_PASSWORD=mysql -p 3306:3306 mysql:latest
-    // docker run --rm --detach --name dapper-example-mysql-management --link dapper-example-mysql-db:db -p 8081:80 phpmyadmin/phpmyadmin
+    // docker run --pull always --rm --detach --name dapper-example-mysql-db -e MYSQL_ROOT_PASSWORD=mysql -e MYSQL_DATABASE=DapperExample -e MYSQL_USER=mysql -e MYSQL_PASSWORD=mysql -p 3306:3306 mysql:latest
+    // docker run --pull always --rm --detach --name dapper-example-mysql-management --link dapper-example-mysql-db:db -p 8081:80 phpmyadmin/phpmyadmin
     "DapperExampleMySql": "Host=localhost;Database=DapperExample;User ID=mysql;Password=mysql;SSL Mode=None;AllowPublicKeyRetrieval=True",
-    // docker run --rm --detach --name dapper-example-sqlserver -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Passw0rd!" -p 1433:1433 mcr.microsoft.com/mssql/server:2022-latest
+    // docker run --pull always --rm --detach --name dapper-example-sqlserver -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Passw0rd!" -p 1433:1433 mcr.microsoft.com/mssql/server:2022-latest
     "DapperExampleSqlServer": "Server=localhost;Database=DapperExample;User ID=sa;Password=Passw0rd!;TrustServerCertificate=true"
   },
   "Logging": {

--- a/test/DapperTests/IntegrationTests/AtomicOperations/AtomicOperationsTests.cs
+++ b/test/DapperTests/IntegrationTests/AtomicOperations/AtomicOperationsTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using TestBuildingBlocks;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace DapperTests.IntegrationTests.AtomicOperations;
 
@@ -33,6 +34,16 @@ public sealed class AtomicOperationsTests : IClassFixture<DapperTestContext>
         Person newAssignee = _fakers.Person.GenerateOne();
         Tag newTag = _fakers.Tag.GenerateOne();
         TodoItem newTodoItem = _fakers.TodoItem.GenerateOne();
+
+        await _testContext.RunOnDatabaseAsync(async dbContext =>
+        {
+            await Task.Yield();
+
+            if (dbContext.Database.ProviderName == "Microsoft.EntityFrameworkCore.SqlServer")
+            {
+                throw SkipException.ForSkip("Cascading deletes are not supported in SQL Server.");
+            }
+        });
 
         const string ownerLocalId = "new-owner";
         const string assigneeLocalId = "new-assignee";

--- a/test/DapperTests/IntegrationTests/QueryStrings/IncludeTests.cs
+++ b/test/DapperTests/IntegrationTests/QueryStrings/IncludeTests.cs
@@ -116,31 +116,42 @@ public sealed class IncludeTests : IClassFixture<DapperTestContext>
 
         responseDocument.Included.Should().HaveCount(6);
 
-        responseDocument.Included[0].Type.Should().Be("people");
-        responseDocument.Included[0].Id.Should().Be(owner.StringId);
-        responseDocument.Included[0].Attributes.Should().ContainKey("firstName").WhoseValue.Should().Be(owner.FirstName);
-        responseDocument.Included[0].Attributes.Should().ContainKey("lastName").WhoseValue.Should().Be(owner.LastName);
+        responseDocument.Included.Should().ContainSingle(resource => resource.Type == "people" && resource.Id == owner.StringId).Subject.With(resource =>
+        {
+            resource.Attributes.Should().ContainKey("firstName").WhoseValue.Should().Be(owner.FirstName);
+            resource.Attributes.Should().ContainKey("lastName").WhoseValue.Should().Be(owner.LastName);
+        });
 
-        responseDocument.Included[1].Type.Should().Be("tags");
-        responseDocument.Included[1].Id.Should().Be(todoItems[0].Tags.ElementAt(0).StringId);
-        responseDocument.Included[1].Attributes.Should().ContainKey("name").WhoseValue.Should().Be(todoItems[0].Tags.ElementAt(0).Name);
+        responseDocument.Included.Should().ContainSingle(resource => resource.Type == "tags" && resource.Id == todoItems[0].Tags.ElementAt(0).StringId).Subject
+            .With(resource =>
+            {
+                resource.Attributes.Should().ContainKey("name").WhoseValue.Should().Be(todoItems[0].Tags.ElementAt(0).Name);
+            });
 
-        responseDocument.Included[2].Type.Should().Be("tags");
-        responseDocument.Included[2].Id.Should().Be(todoItems[0].Tags.ElementAt(1).StringId);
-        responseDocument.Included[2].Attributes.Should().ContainKey("name").WhoseValue.Should().Be(todoItems[0].Tags.ElementAt(1).Name);
+        responseDocument.Included.Should().ContainSingle(resource => resource.Type == "tags" && resource.Id == todoItems[0].Tags.ElementAt(1).StringId).Subject
+            .With(resource =>
+            {
+                resource.Attributes.Should().ContainKey("name").WhoseValue.Should().Be(todoItems[0].Tags.ElementAt(1).Name);
+            });
 
-        responseDocument.Included[3].Type.Should().Be("people");
-        responseDocument.Included[3].Id.Should().Be(todoItems[1].Assignee!.StringId);
-        responseDocument.Included[3].Attributes.Should().ContainKey("firstName").WhoseValue.Should().Be(todoItems[1].Assignee!.FirstName);
-        responseDocument.Included[3].Attributes.Should().ContainKey("lastName").WhoseValue.Should().Be(todoItems[1].Assignee!.LastName);
+        responseDocument.Included.Should().ContainSingle(resource => resource.Type == "people" && resource.Id == todoItems[1].Assignee!.StringId).Subject
+            .With(resource =>
+            {
+                resource.Attributes.Should().ContainKey("firstName").WhoseValue.Should().Be(todoItems[1].Assignee!.FirstName);
+                resource.Attributes.Should().ContainKey("lastName").WhoseValue.Should().Be(todoItems[1].Assignee!.LastName);
+            });
 
-        responseDocument.Included[4].Type.Should().Be("tags");
-        responseDocument.Included[4].Id.Should().Be(todoItems[1].Tags.ElementAt(0).StringId);
-        responseDocument.Included[4].Attributes.Should().ContainKey("name").WhoseValue.Should().Be(todoItems[1].Tags.ElementAt(0).Name);
+        responseDocument.Included.Should().ContainSingle(resource => resource.Type == "tags" && resource.Id == todoItems[1].Tags.ElementAt(0).StringId).Subject
+            .With(resource =>
+            {
+                resource.Attributes.Should().ContainKey("name").WhoseValue.Should().Be(todoItems[1].Tags.ElementAt(0).Name);
+            });
 
-        responseDocument.Included[5].Type.Should().Be("tags");
-        responseDocument.Included[5].Id.Should().Be(todoItems[1].Tags.ElementAt(1).StringId);
-        responseDocument.Included[5].Attributes.Should().ContainKey("name").WhoseValue.Should().Be(todoItems[1].Tags.ElementAt(1).Name);
+        responseDocument.Included.Should().ContainSingle(resource => resource.Type == "tags" && resource.Id == todoItems[1].Tags.ElementAt(1).StringId).Subject
+            .With(resource =>
+            {
+                resource.Attributes.Should().ContainKey("name").WhoseValue.Should().Be(todoItems[1].Tags.ElementAt(1).Name);
+            });
 
         responseDocument.Meta.Should().ContainTotal(2);
 

--- a/test/DapperTests/IntegrationTests/ReadWrite/Resources/DeleteResourceTests.cs
+++ b/test/DapperTests/IntegrationTests/ReadWrite/Resources/DeleteResourceTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using TestBuildingBlocks;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace DapperTests.IntegrationTests.ReadWrite.Resources;
 
@@ -36,6 +37,11 @@ public sealed class DeleteResourceTests : IClassFixture<DapperTestContext>
 
         await _testContext.RunOnDatabaseAsync(async dbContext =>
         {
+            if (dbContext.Database.ProviderName == "Microsoft.EntityFrameworkCore.SqlServer")
+            {
+                throw SkipException.ForSkip("Cascading deletes are not supported in SQL Server.");
+            }
+
             await _testContext.ClearAllTablesAsync(dbContext);
             dbContext.TodoItems.Add(existingTodoItem);
             await dbContext.SaveChangesAsync();


### PR DESCRIPTION
Because `Pomelo.EntityFrameworkCore.MySql` seems to have been abandoned, we're now using `Microting.EntityFrameworkCore.MySql` for EF Core 10 and higher in the Dapper example.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [x] Adapted tests
- [ ] N/A: Documentation updated
