### PR TITLE
Use Docker Compose to start containers

### DIFF
--- a/JsonApiDotNetCore.slnx
+++ b/JsonApiDotNetCore.slnx
@@ -13,7 +13,12 @@
     <File Path=".gitignore" />
     <File Path="CodingGuidelines.ruleset" />
     <File Path="Directory.Build.props" />
+    <File Path="Directory.Build.targets" />
+    <File Path="docker-compose.yml" />
+    <File Path="nuget.config" />
     <File Path="package-versions.props" />
+    <File Path="PackageReadme.md" />
+    <File Path="README.md" />
     <File Path="tests.runsettings" />
   </Folder>
   <Folder Name="/src/">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,81 @@
+name: jsonapi
+
+# This file starts a PostgreSQL database in a docker container, which is required for running tests locally.
+# It also starts pgAdmin (a web-based PostgreSQL management tool) in a second container, which lets you query the database.
+#
+# Usage:
+#   docker compose up --detach --wait
+#
+# To connect to pgAdmin, open http://localhost:5050. It will automatically log in and connect to the database.
+#
+# To stop:
+#   docker compose down
+#
+# To stop and remove persistent data (reset):
+#   docker compose down --volumes
+
+services:
+  postgres-db:
+    image: postgres:latest
+    pull_policy: always
+    container_name: jsonapi-postgres-db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    command: -N 500
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 1s
+      timeout: 3s
+      retries: 5
+      start_period: 2s
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    pull_policy: always
+    container_name: jsonapi-pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: postgres
+      PGADMIN_CONFIG_SERVER_MODE: 'False'
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: 'False'
+      PGADMIN_DISABLE_POSTFIX: 'true'
+      PGADMIN_REPLACE_SERVERS_ON_STARTUP: 'True'
+    ports:
+      - "5050:80"
+    depends_on:
+      - postgres-db
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+    healthcheck:
+      test: ["CMD", "wget", "-O", "-", "http://localhost:80/misc/ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 25
+      start_period: 20s
+    configs:
+      - source: pgadmin-servers
+        target: /pgadmin4/servers.json
+
+volumes:
+  pgadmin-data:
+
+configs:
+  pgadmin-servers:
+    content: |
+      {
+        "Servers": {
+          "1": {
+            "Name": "jsonapi-postgres-database",
+            "Group": "Servers",
+            "Host": "postgres-db",
+            "Port": 5432,
+            "MaintenanceDB": "postgres",
+            "Username": "postgres",
+            "SSLMode": "prefer",
+            "PasswordExecCommand": "echo 'postgres'"
+          }
+        }
+      }

--- a/run-docker-postgres.ps1
+++ b/run-docker-postgres.ps1
@@ -1,18 +1,12 @@
 #Requires -Version 7.0
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $true
 
-# This script starts a PostgreSQL database in a docker container, which is required for running tests locally.
-# When the -UI switch is passed, pgAdmin (a web-based PostgreSQL management tool) is started in a second container, which lets you query the database.
-# To connect to pgAdmin, open http://localhost:5050 and login with user "admin@admin.com", password "postgres". Use hostname "db" when registering the server.
-
-param(
-    [switch] $UI=$false
-)
-
-docker container stop jsonapi-postgresql-db
-docker container stop jsonapi-postgresql-management
-
-docker run --pull always --rm --detach --name jsonapi-postgresql-db -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:latest -N 500
-
-if ($UI) {
-    docker run --pull always --rm --detach --name jsonapi-postgresql-management --link jsonapi-postgresql-db:db -e PGADMIN_DEFAULT_EMAIL=admin@admin.com -e PGADMIN_DEFAULT_PASSWORD=postgres -p 5050:80 dpage/pgadmin4:latest
+Push-Location $PSScriptRoot
+try {
+    docker compose down
+    docker compose up --detach --wait
+}
+finally {
+    Pop-Location
 }

--- a/src/Examples/DapperExample/Program.cs
+++ b/src/Examples/DapperExample/Program.cs
@@ -16,7 +16,7 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
-builder.Services.AddSingleton<TimeProvider>();
+builder.Services.AddSingleton(TimeProvider.System);
 
 DatabaseProvider databaseProvider = GetDatabaseProvider(builder.Configuration);
 string? connectionString = builder.Configuration.GetConnectionString($"DapperExample{databaseProvider}");

--- a/src/Examples/DapperExample/appsettings.json
+++ b/src/Examples/DapperExample/appsettings.json
@@ -1,13 +1,11 @@
 {
   "DatabaseProvider": "PostgreSql",
   "ConnectionStrings": {
-    // docker run --pull always --rm --detach --name dapper-example-postgresql-db -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:latest
-    // docker run --pull always --rm --detach --name dapper-example-postgresql-management --link dapper-example-postgresql-db:db -e PGADMIN_DEFAULT_EMAIL=admin@admin.com -e PGADMIN_DEFAULT_PASSWORD=postgres -p 5050:80 dpage/pgadmin4:latest
+    // docker compose up postgres-db pgadmin --detach --wait
     "DapperExamplePostgreSql": "Host=localhost;Database=DapperExample;User ID=postgres;Password=postgres;Include Error Detail=true",
-    // docker run --pull always --rm --detach --name dapper-example-mysql-db -e MYSQL_ROOT_PASSWORD=mysql -e MYSQL_DATABASE=DapperExample -e MYSQL_USER=mysql -e MYSQL_PASSWORD=mysql -p 3306:3306 mysql:latest
-    // docker run --pull always --rm --detach --name dapper-example-mysql-management --link dapper-example-mysql-db:db -p 8081:80 phpmyadmin/phpmyadmin
+    // docker compose up mysql-db phpmyadmin --detach --wait
     "DapperExampleMySql": "Host=localhost;Database=DapperExample;User ID=mysql;Password=mysql;SSL Mode=None;AllowPublicKeyRetrieval=True",
-    // docker run --pull always --rm --detach --name dapper-example-sqlserver -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Passw0rd!" -p 1433:1433 mcr.microsoft.com/mssql/server:2022-latest
+    // docker compose up sqlserver-db dbgate --detach --wait
     "DapperExampleSqlServer": "Server=localhost;Database=DapperExample;User ID=sa;Password=Passw0rd!;TrustServerCertificate=true"
   },
   "Logging": {

--- a/src/Examples/DapperExample/docker-compose.yml
+++ b/src/Examples/DapperExample/docker-compose.yml
@@ -1,0 +1,165 @@
+name: dapper-example
+
+# This file starts PostgreSQL, MySQL, and SQL Server databases in docker containers, along with admin tools.
+#
+# Usage:
+#   docker compose up --detach --wait
+#
+# Admin tools:
+#   - pgAdmin (PostgreSQL): http://localhost:5050 (auto-logs in and connects to postgres-db)
+#   - phpMyAdmin (MySQL):   http://localhost:8081 (auto-logs in and connects to mysql-db)
+#   - DbGate (SQL Server):  http://localhost:3000 (auto-logs in and connects to sqlserver-db)
+#
+# To stop:
+#   docker compose down
+#
+# To stop and remove persistent data (reset):
+#   docker compose down --volumes
+
+services:
+  postgres-db:
+    image: postgres:latest
+    pull_policy: always
+    container_name: dapper-example-postgres-db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    command: -N 500
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 1s
+      timeout: 3s
+      retries: 5
+      start_period: 2s
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    pull_policy: always
+    container_name: dapper-example-pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: postgres
+      PGADMIN_CONFIG_SERVER_MODE: 'False'
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: 'False'
+      PGADMIN_DISABLE_POSTFIX: 'true'
+      PGADMIN_REPLACE_SERVERS_ON_STARTUP: 'True'
+    ports:
+      - "5050:80"
+    depends_on:
+      - postgres-db
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+    healthcheck:
+      test: ["CMD", "wget", "-O", "-", "http://localhost:80/misc/ping"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
+      start_period: 20s
+    configs:
+      - source: pgadmin-servers
+        target: /pgadmin4/servers.json
+
+  mysql-db:
+    image: mysql:latest
+    pull_policy: always
+    container_name: dapper-example-mysql-db
+    environment:
+      MYSQL_ROOT_PASSWORD: mysql
+      MYSQL_DATABASE: DapperExample
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: mysql
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u mysql -pmysql || exit 1"]
+      interval: 1s
+      timeout: 3s
+      retries: 25
+      start_period: 10s
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:latest
+    pull_policy: always
+    container_name: dapper-example-phpmyadmin
+    environment:
+      PMA_HOST: mysql-db
+      PMA_USER: mysql
+      PMA_PASSWORD: mysql
+    ports:
+      - "8081:80"
+    depends_on:
+      - mysql-db
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-s", "http://localhost:80/"]
+      interval: 1s
+      timeout: 3s
+      retries: 10
+      start_period: 2s
+
+  sqlserver-db:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    pull_policy: always
+    container_name: dapper-example-sqlserver-db
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Passw0rd!"
+    ports:
+      - "1433:1433"
+    volumes:
+      - sqlserver-data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P \"$$MSSQL_SA_PASSWORD\" -Q \"SELECT 1\" -b -o /dev/null"]
+      interval: 1s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
+
+  dbgate:
+    image: dbgate/dbgate:latest
+    pull_policy: always
+    container_name: dapper-example-dbgate
+    environment:
+      CONNECTIONS: sqlserver
+      LABEL_sqlserver: dapper-example-sqlserver-db
+      SERVER_sqlserver: sqlserver-db
+      PORT_sqlserver: 1433
+      USER_sqlserver: sa
+      PASSWORD_sqlserver: "Passw0rd!"
+      ENGINE_sqlserver: mssql@dbgate-plugin-mssql
+    ports:
+      - "3000:3000"
+    depends_on:
+      - sqlserver-db
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"]
+      interval: 1s
+      timeout: 3s
+      retries: 10
+      start_period: 2s
+
+volumes:
+  pgadmin-data:
+  mysql-data:
+  sqlserver-data:
+
+configs:
+  pgadmin-servers:
+    content: |
+      {
+        "Servers": {
+          "1": {
+            "Name": "dapper-example-postgres-db",
+            "Group": "Servers",
+            "Host": "postgres-db",
+            "Port": 5432,
+            "MaintenanceDB": "postgres",
+            "Username": "postgres",
+            "SSLMode": "prefer",
+            "PasswordExecCommand": "echo 'postgres'"
+          }
+        }
+      }

--- a/src/Examples/DapperExample/docker-compose.yml
+++ b/src/Examples/DapperExample/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       start_period: 2s
 
   sqlserver-db:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: mcr.microsoft.com/mssql/server:2025-latest
     pull_policy: always
     container_name: dapper-example-sqlserver-db
     environment:


### PR DESCRIPTION
Convert Docker commands into `docker-compose.yml` files that auto-login to web-based database management tools. Use persistent volumes to speed up warm restarts, while waiting until containers are healthy. Fix a startup crash in DapperExample.

#### QUALITY CHECKLIST
- [x] Changes implemented in code
- [x] Complies with our [contributing guidelines](https://github.com/json-api-dotnet/JsonApiDotNetCore/blob/master/.github/CONTRIBUTING.md)
- [ ] N/A: Adapted tests
- [x] Documentation updated
